### PR TITLE
Add CodeCov integration for coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: coverage-results/cobertura.xml
+          flags: unit-tests
           disable_search: true
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,22 +63,41 @@ jobs:
       - name: Export Coverage Report
         if: always()
         run: |
-          RESULT_BUNDLE="./DerivedData/Logs/Test/*.xcresult"
+          set -e
           COVERAGE_DIR="$GITHUB_WORKSPACE/coverage"
           COVERAGE_REPORT="$COVERAGE_DIR/cobertura.xml"
           
-          if [ ! -d "$RESULT_BUNDLE" ]; then
-            echo "No xcresult bundle found"
+          echo "Finding xcresult bundles..."
+          RESULT_BUNDLES=(./DerivedData/Logs/Test/*.xcresult)
+          
+          if [ ! -e "${RESULT_BUNDLES[0]}" ]; then
+            echo "No xcresult bundle found at ./DerivedData/Logs/Test/"
+            mkdir -p "$COVERAGE_DIR"
+            echo "No coverage available" > "$COVERAGE_REPORT"
             exit 0
           fi
           
+          RESULT_BUNDLE="${RESULT_BUNDLES[0]}"
+          echo "Found xcresult bundle: $RESULT_BUNDLE"
+          
           if ! xcrun xccov view --report "$RESULT_BUNDLE" >/dev/null 2>&1; then
-            echo "No coverage report available"
+            echo "No coverage report available in $RESULT_BUNDLE"
+            mkdir -p "$COVERAGE_DIR"
+            echo "No coverage available" > "$COVERAGE_REPORT"
             exit 0
           fi
           
           mkdir -p "$COVERAGE_DIR"
-          xcresultparser --output-format cobertura --project-root "$GITHUB_WORKSPACE" "$RESULT_BUNDLE" > "$COVERAGE_REPORT"
+          echo "Exporting coverage to Cobertura format..."
+          xcresultparser --output-format cobertura --project-root "$GITHUB_WORKSPACE" "$RESULT_BUNDLE" > "$COVERAGE_REPORT" || true
+          
+          if [ ! -s "$COVERAGE_REPORT" ]; then
+            echo "Coverage export failed or produced empty file"
+            echo "No coverage available" > "$COVERAGE_REPORT"
+          fi
+          
+          echo "Coverage report created at $COVERAGE_REPORT"
+          ls -la "$COVERAGE_DIR"
 
       - name: Upload Coverage Results
         if: always()
@@ -86,7 +105,7 @@ jobs:
         with:
           name: coverage-results
           path: coverage
-          if-no-files-found: warn
+          if-no-files-found: error
             
 
   build-archive:
@@ -131,6 +150,15 @@ jobs:
           name: coverage-results
           path: coverage-results
 
+      - name: Check coverage file
+        run: |
+          if [ ! -f "coverage-results/cobertura.xml" ]; then
+            echo "Coverage file not found"
+            exit 1
+          fi
+          echo "Coverage file contents:"
+          head -20 coverage-results/cobertura.xml
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -138,3 +166,4 @@ jobs:
           disable_search: true
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,38 @@ jobs:
           name: test-results
           path: ./DerivedData/Logs/Test/*.xcresult
           retention-days: 30
+
+      - name: Install xcresultparser
+        if: always()
+        run: brew install xcresultparser
+
+      - name: Export Coverage Report
+        if: always()
+        run: |
+          RESULT_BUNDLE="./DerivedData/Logs/Test/*.xcresult"
+          COVERAGE_DIR="$GITHUB_WORKSPACE/coverage"
+          COVERAGE_REPORT="$COVERAGE_DIR/cobertura.xml"
+          
+          if [ ! -d "$RESULT_BUNDLE" ]; then
+            echo "No xcresult bundle found"
+            exit 0
+          fi
+          
+          if ! xcrun xccov view --report "$RESULT_BUNDLE" >/dev/null 2>&1; then
+            echo "No coverage report available"
+            exit 0
+          fi
+          
+          mkdir -p "$COVERAGE_DIR"
+          xcresultparser --output-format cobertura --project-root "$GITHUB_WORKSPACE" "$RESULT_BUNDLE" > "$COVERAGE_REPORT"
+
+      - name: Upload Coverage Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-results
+          path: coverage
+          if-no-files-found: warn
             
 
   build-archive:
@@ -83,3 +115,26 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
             -allowProvisioningUpdates
+
+  codecov:
+    name: Upload Coverage to Codecov
+    runs-on: macos-latest
+    needs: test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download coverage results
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-results
+          path: coverage-results
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage-results/cobertura.xml
+          disable_search: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -157,3 +157,79 @@ jobs:
             ./ui-test-results
             ./ui-test-output.log
           retention-days: 7
+
+      - name: Install xcresultparser
+        if: always()
+        run: brew install xcresultparser
+
+      - name: Export UI Test Coverage Report
+        if: always()
+        run: |
+          set -e
+          COVERAGE_DIR="$GITHUB_WORKSPACE/ui-test-coverage"
+          COVERAGE_REPORT="$COVERAGE_DIR/cobertura.xml"
+
+          echo "Finding xcresult bundles..."
+          RESULT_BUNDLES=(./ui-test-results/*.xcresult)
+
+          if [ ! -e "${RESULT_BUNDLES[0]}" ]; then
+            echo "No xcresult bundle found at ./ui-test-results/"
+            mkdir -p "$COVERAGE_DIR"
+            echo "No coverage available" > "$COVERAGE_REPORT"
+            exit 0
+          fi
+
+          RESULT_BUNDLE="${RESULT_BUNDLES[0]}"
+          echo "Found xcresult bundle: $RESULT_BUNDLE"
+
+          if ! xcrun xccov view --report "$RESULT_BUNDLE" >/dev/null 2>&1; then
+            echo "No coverage report available in $RESULT_BUNDLE"
+            mkdir -p "$COVERAGE_DIR"
+            echo "No coverage available" > "$COVERAGE_REPORT"
+            exit 0
+          fi
+
+          mkdir -p "$COVERAGE_DIR"
+          echo "Exporting coverage to Cobertura format..."
+          xcresultparser --output-format cobertura --project-root "$GITHUB_WORKSPACE" "$RESULT_BUNDLE" > "$COVERAGE_REPORT" || true
+
+          if [ ! -s "$COVERAGE_REPORT" ]; then
+            echo "Coverage export failed or produced empty file"
+            echo "No coverage available" > "$COVERAGE_REPORT"
+          fi
+
+          echo "Coverage report created at $COVERAGE_REPORT"
+          ls -la "$COVERAGE_DIR"
+
+      - name: Upload UI Test Coverage Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-test-coverage-results
+          path: ui-test-coverage
+          if-no-files-found: warn
+
+  upload-coverage:
+    name: Upload UI Test Coverage to Codecov
+    runs-on: macos-latest
+    needs: ui-tests
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download coverage results
+        uses: actions/download-artifact@v4
+        with:
+          name: ui-test-coverage-results
+          path: coverage-results
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage-results/cobertura.xml
+          flags: ui-tests
+          disable_search: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,35 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+
+ignore:
+  - "**/*.generated.swift"
+  - "**/DerivedData/**"
+  - "**/build/**"
+  - "**/*.xctest/**"
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+  require_base: yes
+  require_head: yes
+
+flags:
+  unit-tests:
+    carryforward: false
+  ui-tests:
+    carryforward: false


### PR DESCRIPTION
## Summary

- Added CodeCov integration to the CI/CD pipeline for automated coverage reporting
- Updated `.github/workflows/ci.yml` to upload coverage reports to CodeCov
- Added `codecov.yml` configuration file for CodeCov settings

This enables continuous monitoring of test coverage with detailed reporting and trend tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to always install coverage tooling, export UI test coverage (Cobertura XML), and upload coverage artifacts.
  * Added a separate workflow/job to download artifacts and send coverage to Codecov (with verbose logging and tolerant error handling).
  * Added Codecov configuration with coverage rules, thresholds, ignore patterns, and reporting flags for project health.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->