### PR TITLE
Add comprehensive tests for server song management and input systems

### DIFF
--- a/VirgoTests/DrumTypeExtensionsAndConstantsTests.swift
+++ b/VirgoTests/DrumTypeExtensionsAndConstantsTests.swift
@@ -1,0 +1,155 @@
+import Testing
+import SwiftUI
+@testable import Virgo
+
+@Suite("DrumType Extensions and Drum Constants Tests")
+@MainActor
+struct DrumTypeExtensionsAndConstantsTests {
+    private struct DrumTypeTestData {
+        let type: DrumType
+        let displayName: String
+        let sortOrder: Int
+    }
+
+    @Test("DrumType display names and sort order cover all cases")
+    func testDrumTypeDisplayNameAndSortOrder() {
+        let expected: [DrumTypeTestData] = [
+            DrumTypeTestData(type: .kick, displayName: "Kick Drum", sortOrder: 0),
+            DrumTypeTestData(type: .snare, displayName: "Snare", sortOrder: 1),
+            DrumTypeTestData(type: .hiHat, displayName: "Hi-Hat", sortOrder: 2),
+            DrumTypeTestData(type: .hiHatPedal, displayName: "Hi-Hat Pedal", sortOrder: 3),
+            DrumTypeTestData(type: .tom1, displayName: "High Tom", sortOrder: 4),
+            DrumTypeTestData(type: .tom2, displayName: "Mid Tom", sortOrder: 5),
+            DrumTypeTestData(type: .tom3, displayName: "Low Tom", sortOrder: 6),
+            DrumTypeTestData(type: .crash, displayName: "Crash", sortOrder: 7),
+            DrumTypeTestData(type: .ride, displayName: "Ride", sortOrder: 8),
+            DrumTypeTestData(type: .cowbell, displayName: "Cowbell", sortOrder: 9)
+        ]
+
+        #expect(DrumType.allCases.count == expected.count)
+
+        for data in expected {
+            #expect(data.type.displayName == data.displayName)
+            #expect(data.type.sortOrder == data.sortOrder)
+        }
+    }
+
+    @Test("DrumType storageKey round-trips for all drum types")
+    func testDrumTypeStorageKeyRoundTrip() {
+        for drumType in DrumType.allCases {
+            let key = drumType.storageKey
+            #expect(DrumType(storageKey: key) == drumType)
+        }
+
+        #expect(DrumType(storageKey: "invalid_key") == nil)
+    }
+
+    @Test("DrumType.from(noteType:) maps all supported note types")
+    func testDrumTypeFromNoteTypeMappings() {
+        let expectedMappings: [(NoteType, DrumType?)] = [
+            (.bass, .kick),
+            (.snare, .snare),
+            (.hiHat, .hiHat),
+            (.openHiHat, .hiHat),
+            (.hiHatPedal, .hiHatPedal),
+            (.crash, .crash),
+            (.china, .crash),
+            (.splash, .crash),
+            (.ride, .ride),
+            (.highTom, .tom1),
+            (.midTom, .tom2),
+            (.lowTom, .tom3),
+            (.cowbell, .cowbell)
+        ]
+
+        for (noteType, expectedDrumType) in expectedMappings {
+            #expect(DrumType.from(noteType: noteType) == expectedDrumType)
+        }
+    }
+
+    @Test("NoteInterval stem, flag, and flag count logic is consistent")
+    func testNoteIntervalProperties() {
+        let noStemIntervals: [NoteInterval] = [.full, .half]
+        let stemIntervals: [NoteInterval] = [.quarter, .eighth, .sixteenth, .thirtysecond, .sixtyfourth]
+
+        for interval in noStemIntervals {
+            #expect(interval.needsStem == false)
+        }
+        for interval in stemIntervals {
+            #expect(interval.needsStem == true)
+        }
+
+        #expect(NoteInterval.full.needsFlag == false)
+        #expect(NoteInterval.half.needsFlag == false)
+        #expect(NoteInterval.quarter.needsFlag == false)
+
+        #expect(NoteInterval.eighth.needsFlag == true)
+        #expect(NoteInterval.sixteenth.needsFlag == true)
+        #expect(NoteInterval.thirtysecond.needsFlag == true)
+        #expect(NoteInterval.sixtyfourth.needsFlag == true)
+
+        #expect(NoteInterval.full.flagCount == 0)
+        #expect(NoteInterval.half.flagCount == 0)
+        #expect(NoteInterval.quarter.flagCount == 0)
+        #expect(NoteInterval.eighth.flagCount == 1)
+        #expect(NoteInterval.sixteenth.flagCount == 2)
+        #expect(NoteInterval.thirtysecond.flagCount == 3)
+        #expect(NoteInterval.sixtyfourth.flagCount == 4)
+    }
+
+    private struct TimeSignatureTestData {
+        let signature: TimeSignature
+        let beatsPerMeasure: Int
+        let noteValue: Int
+        let displayName: String
+    }
+
+    private struct DifficultyTestData {
+        let difficulty: Difficulty
+        let defaultLevel: Int
+        let sortOrder: Int
+        let color: Color
+    }
+
+    @Test("TimeSignature and Difficulty metadata covers all enum cases")
+    func testTimeSignatureAndDifficultyMetadata() {
+        let signatureExpectations: [TimeSignatureTestData] = [
+            TimeSignatureTestData(signature: .twoFour, beatsPerMeasure: 2, noteValue: 4, displayName: "2/4"),
+            TimeSignatureTestData(signature: .threeFour, beatsPerMeasure: 3, noteValue: 4, displayName: "3/4"),
+            TimeSignatureTestData(signature: .fourFour, beatsPerMeasure: 4, noteValue: 4, displayName: "4/4"),
+            TimeSignatureTestData(signature: .fiveFour, beatsPerMeasure: 5, noteValue: 4, displayName: "5/4"),
+            TimeSignatureTestData(signature: .sixEight, beatsPerMeasure: 6, noteValue: 8, displayName: "6/8"),
+            TimeSignatureTestData(signature: .sevenEight, beatsPerMeasure: 7, noteValue: 8, displayName: "7/8"),
+            TimeSignatureTestData(signature: .nineEight, beatsPerMeasure: 9, noteValue: 8, displayName: "9/8"),
+            TimeSignatureTestData(signature: .twelveEight, beatsPerMeasure: 12, noteValue: 8, displayName: "12/8")
+        ]
+
+        #expect(TimeSignature.allCases.count == signatureExpectations.count)
+
+        for data in signatureExpectations {
+            #expect(data.signature.beatsPerMeasure == data.beatsPerMeasure)
+            #expect(data.signature.noteValue == data.noteValue)
+            #expect(data.signature.displayName == data.displayName)
+        }
+
+        let difficultyExpectations: [DifficultyTestData] = [
+            DifficultyTestData(difficulty: .easy, defaultLevel: 30, sortOrder: 0, color: .green),
+            DifficultyTestData(difficulty: .medium, defaultLevel: 50, sortOrder: 1, color: .orange),
+            DifficultyTestData(difficulty: .hard, defaultLevel: 70, sortOrder: 2, color: .red),
+            DifficultyTestData(difficulty: .expert, defaultLevel: 90, sortOrder: 3, color: .purple)
+        ]
+
+        #expect(Difficulty.allCases.count == difficultyExpectations.count)
+
+        for data in difficultyExpectations {
+            #expect(data.difficulty.defaultLevel == data.defaultLevel)
+            #expect(data.difficulty.sortOrder == data.sortOrder)
+            #expect(data.difficulty.color == data.color)
+        }
+    }
+
+    @Test("BeamGroupingConstants expose expected threshold")
+    func testBeamGroupingConstant() {
+        #expect(BeamGroupingConstants.maxConsecutiveInterval == 0.3)
+    }
+}

--- a/VirgoTests/InputSettingsManagerTests.swift
+++ b/VirgoTests/InputSettingsManagerTests.swift
@@ -1,0 +1,200 @@
+import Testing
+import Foundation
+@testable import Virgo
+
+@Suite("InputSettingsManager Tests", .serialized)
+@MainActor
+struct InputSettingsManagerTests {
+    private let keyboardMappingsKey = "InputSettingsKeyboardMappings"
+    private let midiMappingsKey = "InputSettingsMidiMappings"
+
+    private func clearPersistedMappings() {
+        UserDefaults.standard.removeObject(forKey: keyboardMappingsKey)
+        UserDefaults.standard.removeObject(forKey: midiMappingsKey)
+    }
+
+    @Test("Initialization seeds defaults when persisted values are missing")
+    func testInitializationSeedsDefaults() {
+        clearPersistedMappings()
+        defer { clearPersistedMappings() }
+
+        let manager = InputSettingsManager()
+
+        let keyboard = manager.getKeyboardMappings()
+        #expect(keyboard.count == 9)
+        #expect(keyboard["space"] == .kick)
+        #expect(keyboard["f"] == .snare)
+        #expect(keyboard["semicolon"] == .ride)
+
+        let midi = manager.getMidiMappings()
+        #expect(midi.count == 10)
+        #expect(midi[36] == .kick)
+        #expect(midi[44] == .hiHatPedal)
+        #expect(midi[56] == .cowbell)
+
+        #expect(UserDefaults.standard.data(forKey: keyboardMappingsKey) != nil)
+        #expect(UserDefaults.standard.data(forKey: midiMappingsKey) != nil)
+    }
+
+    @Test("Initialization loads persisted keyboard and MIDI mappings")
+    func testInitializationLoadsPersistedMappings() throws {
+        clearPersistedMappings()
+        defer { clearPersistedMappings() }
+
+        let encodedKeyboard = try JSONEncoder().encode([
+            "q": "snare",
+            "w": "kick",
+            "e": "invalid-drum"
+        ])
+        let persistedMidi: [UInt8: String] = [
+            UInt8(10): "ride",
+            UInt8(11): "tom1",
+            UInt8(12): "unknown"
+        ]
+        let encodedMidi = try JSONEncoder().encode(persistedMidi)
+
+        UserDefaults.standard.set(encodedKeyboard, forKey: keyboardMappingsKey)
+        UserDefaults.standard.set(encodedMidi, forKey: midiMappingsKey)
+
+        let manager = InputSettingsManager()
+
+        let keyboard = manager.getKeyboardMappings()
+        #expect(keyboard.count == 2)
+        #expect(keyboard["q"] == .snare)
+        #expect(keyboard["w"] == .kick)
+        #expect(keyboard["e"] == nil)
+
+        let midi = manager.getMidiMappings()
+        #expect(midi.count == 2)
+        #expect(midi[10] == .ride)
+        #expect(midi[11] == .tom1)
+        #expect(midi[12] == nil)
+    }
+
+    @Test("Invalid persisted payload falls back to defaults")
+    func testInvalidPersistedDataFallsBackToDefaults() {
+        clearPersistedMappings()
+        defer { clearPersistedMappings() }
+
+        UserDefaults.standard.set(Data("not-json".utf8), forKey: keyboardMappingsKey)
+        UserDefaults.standard.set(Data("still-not-json".utf8), forKey: midiMappingsKey)
+
+        let manager = InputSettingsManager()
+
+        #expect(manager.getKeyboardMappings()["space"] == .kick)
+        #expect(manager.getMidiMappings()[36] == .kick)
+    }
+
+    @Test("setKeyBinding enforces unique key and unique drum mapping")
+    func testSetKeyBindingConflictResolution() {
+        clearPersistedMappings()
+        defer { clearPersistedMappings() }
+
+        let manager = InputSettingsManager()
+
+        manager.setKeyBinding("x", for: .kick)
+        #expect(manager.getKeyBinding(for: .kick) == "x")
+        #expect(manager.getKeyboardMappings()["space"] == nil)
+
+        manager.setKeyBinding("x", for: .snare)
+        #expect(manager.getKeyBinding(for: .snare) == "x")
+        #expect(manager.getKeyBinding(for: .kick) == nil)
+    }
+
+    @Test("removeKeyBinding persists removal across manager instances")
+    func testRemoveKeyBindingPersistence() {
+        clearPersistedMappings()
+        defer { clearPersistedMappings() }
+
+        let manager = InputSettingsManager()
+        manager.setKeyBinding("z", for: .ride)
+        #expect(manager.getKeyBinding(for: .ride) == "z")
+
+        manager.removeKeyBinding(for: .ride)
+        #expect(manager.getKeyBinding(for: .ride) == nil)
+
+        let reloadedManager = InputSettingsManager()
+        #expect(reloadedManager.getKeyBinding(for: .ride) == nil)
+    }
+
+    @Test("setMidiMapping and removeMidiMapping enforce uniqueness and persist")
+    func testMidiMappingLifecycle() {
+        clearPersistedMappings()
+        defer { clearPersistedMappings() }
+
+        let manager = InputSettingsManager()
+
+        manager.setMidiMapping(60, for: .snare)
+        #expect(manager.getMidiMapping(for: .snare) == 60)
+        #expect(manager.getMidiMappings()[38] == nil)
+
+        manager.setMidiMapping(60, for: .kick)
+        #expect(manager.getMidiMapping(for: .kick) == 60)
+        #expect(manager.getMidiMapping(for: .snare) == nil)
+
+        manager.removeMidiMapping(for: .kick)
+        #expect(manager.getMidiMapping(for: .kick) == nil)
+
+        let reloadedManager = InputSettingsManager()
+        #expect(reloadedManager.getMidiMapping(for: .kick) == nil)
+    }
+
+    @Test("resetToDefaults restores default keyboard and MIDI values")
+    func testResetToDefaults() {
+        clearPersistedMappings()
+        defer { clearPersistedMappings() }
+
+        let manager = InputSettingsManager()
+        manager.setKeyBinding("x", for: .kick)
+        manager.setMidiMapping(10, for: .snare)
+
+        manager.resetToDefaults()
+
+        #expect(manager.getKeyBinding(for: .kick) == "space")
+        #expect(manager.getKeyBinding(for: .snare) == "f")
+        #expect(manager.getMidiMapping(for: .kick) == 36)
+        #expect(manager.getMidiMapping(for: .snare) == 38)
+    }
+
+    @Test("saveSettings writes current state to UserDefaults")
+    func testSaveSettingsWritesPersistedData() throws {
+        clearPersistedMappings()
+        defer { clearPersistedMappings() }
+
+        let manager = InputSettingsManager()
+        manager.setKeyBinding("x", for: .kick)
+        manager.setMidiMapping(99, for: .ride)
+        manager.saveSettings()
+
+        let keyboardData = UserDefaults.standard.data(forKey: keyboardMappingsKey)
+        let midiData = UserDefaults.standard.data(forKey: midiMappingsKey)
+
+        #expect(keyboardData != nil)
+        #expect(midiData != nil)
+
+        guard let keyboardData, let midiData else {
+            return
+        }
+
+        let keyboardPayload = try JSONDecoder().decode([String: String].self, from: keyboardData)
+        let midiPayload = try JSONDecoder().decode([UInt8: String].self, from: midiData)
+
+        #expect(keyboardPayload["x"] == "kick")
+        #expect(midiPayload[99] == "ride")
+    }
+
+    @Test("DrumType.fromString converts known values and rejects unknown values")
+    func testDrumTypeFromStringMapping() {
+        #expect(DrumType.fromString("kick") == .kick)
+        #expect(DrumType.fromString("snare") == .snare)
+        #expect(DrumType.fromString("hiHat") == .hiHat)
+        #expect(DrumType.fromString("hiHatPedal") == .hiHatPedal)
+        #expect(DrumType.fromString("crash") == .crash)
+        #expect(DrumType.fromString("ride") == .ride)
+        #expect(DrumType.fromString("tom1") == .tom1)
+        #expect(DrumType.fromString("tom2") == .tom2)
+        #expect(DrumType.fromString("tom3") == .tom3)
+        #expect(DrumType.fromString("cowbell") == .cowbell)
+        #expect(DrumType.fromString("unknown") == nil)
+    }
+}

--- a/VirgoTests/ServerSongCacheTests.swift
+++ b/VirgoTests/ServerSongCacheTests.swift
@@ -1,0 +1,80 @@
+import Testing
+import SwiftData
+import Foundation
+@testable import Virgo
+
+@Suite("ServerSongCache Tests", .serialized)
+@MainActor
+struct ServerSongCacheTests {
+    @Test("loadServerSongs returns non-stale cache and updates download statuses")
+    func testLoadServerSongsUsesCacheAndUpdatesStatus() async throws {
+        try await TestSetup.withTestSetup {
+            let context = TestContainer.shared.context
+            let cache = ServerSongCache()
+
+            let localMatch = Song(
+                title: "Matched Song",
+                artist: "Matched Artist",
+                bpm: 120.0,
+                duration: "3:00",
+                genre: "DTX Import"
+            )
+            context.insert(localMatch)
+
+            let matchedServerSong = ServerSong(
+                songId: "matched-song",
+                title: "Matched Song",
+                artist: "Matched Artist",
+                bpm: 120.0,
+                isDownloaded: false
+            )
+            matchedServerSong.lastUpdated = Date()
+
+            let unmatchedServerSong = ServerSong(
+                songId: "unmatched-song",
+                title: "Unmatched Song",
+                artist: "Unmatched Artist",
+                bpm: 100.0,
+                isDownloaded: true
+            )
+            unmatchedServerSong.lastUpdated = Date().addingTimeInterval(-60)
+
+            context.insert(matchedServerSong)
+            context.insert(unmatchedServerSong)
+            try context.save()
+
+            let loadedSongs = try await cache.loadServerSongs(modelContext: context)
+
+            #expect(loadedSongs.count == 2)
+            #expect(loadedSongs.first?.songId == "matched-song") // Most recently updated first
+            #expect(matchedServerSong.isDownloaded == true)
+            #expect(unmatchedServerSong.isDownloaded == false)
+        }
+    }
+
+    @Test("loadServerSongs keeps existing statuses when no local songs exist")
+    func testLoadServerSongsRetainsUndownloadedStatusWithoutMatches() async throws {
+        try await TestSetup.withTestSetup {
+            let context = TestContainer.shared.context
+            let cache = ServerSongCache()
+
+            let serverSong = ServerSong(
+                songId: "cache-only",
+                title: "Cache Only",
+                artist: "No Local Match",
+                bpm: 128.0,
+                isDownloaded: false
+            )
+            serverSong.lastUpdated = Date()
+
+            context.insert(serverSong)
+            try context.save()
+
+            let loadedSongs = try await cache.loadServerSongs(modelContext: context)
+
+            #expect(loadedSongs.count == 1)
+            #expect(loadedSongs.first?.songId == "cache-only")
+            #expect(serverSong.isDownloaded == false)
+        }
+    }
+}

--- a/VirgoTests/ServerSongFileManagerTests.swift
+++ b/VirgoTests/ServerSongFileManagerTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import Foundation
+@testable import Virgo
+
+@Suite("ServerSongFileManager Tests", .serialized)
+@MainActor
+struct ServerSongFileManagerTests {
+    @Test("saveBGMFile writes file and deleteBGMFile removes it")
+    func testSaveAndDeleteBGMFile() throws {
+        let fileManager = ServerSongFileManager()
+        let songId = "bgm-test-\(UUID().uuidString)"
+        let payload = Data("bgm-payload".utf8)
+
+        let savedPath = try fileManager.saveBGMFile(payload, for: songId)
+
+        #expect(savedPath.hasSuffix("/BGM/\(songId).ogg"))
+        #expect(FileManager.default.fileExists(atPath: savedPath))
+
+        let loadedData = try Data(contentsOf: URL(fileURLWithPath: savedPath))
+        #expect(loadedData == payload)
+
+        fileManager.deleteBGMFile(at: savedPath)
+        #expect(!FileManager.default.fileExists(atPath: savedPath))
+    }
+
+    @Test("savePreviewFile writes file and deletePreviewFile removes it")
+    func testSaveAndDeletePreviewFile() throws {
+        let fileManager = ServerSongFileManager()
+        let songId = "preview-test-\(UUID().uuidString)"
+        let payload = Data("preview-payload".utf8)
+
+        let savedPath = try fileManager.savePreviewFile(payload, for: songId)
+
+        #expect(savedPath.hasSuffix("/Preview/\(songId).mp3"))
+        #expect(FileManager.default.fileExists(atPath: savedPath))
+
+        let loadedData = try Data(contentsOf: URL(fileURLWithPath: savedPath))
+        #expect(loadedData == payload)
+
+        fileManager.deletePreviewFile(at: savedPath)
+        #expect(!FileManager.default.fileExists(atPath: savedPath))
+    }
+
+    @Test("delete methods tolerate non-existent paths")
+    func testDeleteOnNonExistentPaths() {
+        let fileManager = ServerSongFileManager()
+        let missingBase = FileManager.default.temporaryDirectory
+            .appendingPathComponent("virgo-missing-\(UUID().uuidString)")
+
+        fileManager.deleteBGMFile(at: missingBase.appendingPathComponent("bgm.ogg").path)
+        fileManager.deletePreviewFile(at: missingBase.appendingPathComponent("preview.mp3").path)
+
+        #expect(true)
+    }
+}

--- a/VirgoTests/ServerSongServiceTests.swift
+++ b/VirgoTests/ServerSongServiceTests.swift
@@ -1,0 +1,151 @@
+import Testing
+import SwiftData
+@testable import Virgo
+
+@Suite("ServerSongService Tests", .serialized)
+@MainActor
+struct ServerSongServiceTests {
+    @Test("loadServerSongs returns empty list when modelContext is not set")
+    func testLoadServerSongsWithoutModelContext() async {
+        let service = ServerSongService()
+
+        let songs = await service.loadServerSongs()
+
+        #expect(songs.isEmpty)
+    }
+
+    @Test("refresh methods are no-op when modelContext is not set")
+    func testRefreshWithoutModelContext() async {
+        let service = ServerSongService()
+
+        await service.refreshServerSongs()
+        #expect(service.isRefreshing == false)
+        #expect(service.errorMessage == nil)
+
+        await service.forceRefreshServerSongs()
+        #expect(service.isRefreshing == false)
+        #expect(service.errorMessage == nil)
+    }
+
+    @Test("deleteDownloadedSong returns false when modelContext is not set")
+    func testDeleteDownloadedSongWithoutModelContext() async {
+        let service = ServerSongService()
+        let serverSong = ServerSong(songId: "song-1", title: "Song", artist: "Artist", bpm: 120.0)
+
+        let success = await service.deleteDownloadedSong(serverSong)
+
+        #expect(success == false)
+    }
+
+    @Test("deleteLocalSong returns false and sets error when modelContext is missing")
+    func testDeleteLocalSongWithoutModelContext() async {
+        let service = ServerSongService()
+        let song = Song(title: "Missing", artist: "Context", bpm: 100.0, duration: "1:00", genre: "DTX Import")
+
+        let success = await service.deleteLocalSong(song)
+
+        #expect(success == false)
+        #expect(service.errorMessage == "No model context available")
+        #expect(service.deletingSongs.isEmpty)
+    }
+
+    @Test("deleteLocalSong returns false immediately when song is already deleting")
+    func testDeleteLocalSongWhenAlreadyDeleting() async {
+        let service = ServerSongService()
+        let song = Song(title: "A", artist: "B", bpm: 100.0, duration: "1:00", genre: "DTX Import")
+        let key = "a|b"
+        service.deletingSongs = [key]
+
+        let success = await service.deleteLocalSong(song)
+
+        #expect(success == false)
+        #expect(service.deletingSongs == [key])
+    }
+
+    @Test("downloadAndImportSong returns false when song is already downloaded")
+    func testDownloadAndImportSongAlreadyDownloaded() async {
+        let service = ServerSongService()
+        let serverSong = ServerSong(
+            songId: "already-downloaded",
+            title: "Downloaded",
+            artist: "Artist",
+            bpm: 120.0,
+            isDownloaded: true
+        )
+
+        let success = await service.downloadAndImportSong(serverSong)
+
+        #expect(success == false)
+        #expect(service.downloadingSongs.isEmpty)
+    }
+
+    @Test("downloadAndImportSong returns false when song is already being downloaded")
+    func testDownloadAndImportSongAlreadyDownloading() async {
+        let service = ServerSongService()
+        let serverSong = ServerSong(songId: "in-flight", title: "In Flight", artist: "Artist", bpm: 120.0)
+        service.downloadingSongs = ["in-flight"]
+
+        let success = await service.downloadAndImportSong(serverSong)
+
+        #expect(success == false)
+        #expect(service.downloadingSongs == ["in-flight"])
+    }
+
+    @Test("downloadAndImportSong returns false and reports missing context when modelContext is nil")
+    func testDownloadAndImportSongWithoutModelContext() async {
+        let service = ServerSongService()
+        let serverSong = ServerSong(songId: "no-context", title: "No Context", artist: "Artist", bpm: 120.0)
+
+        let success = await service.downloadAndImportSong(serverSong)
+
+        #expect(success == false)
+        #expect(service.errorMessage == "No model context available")
+        #expect(service.downloadingSongs.isEmpty)
+    }
+
+    @Test("isDownloading and isDeleting helpers reflect tracking sets")
+    func testHelperMethodsTrackState() async {
+        let service = ServerSongService()
+        let serverSong = ServerSong(songId: "song-x", title: "Song X", artist: "Artist X", bpm: 120.0)
+        let localSong = Song(title: "Mixed Case", artist: "Artist", bpm: 100.0, duration: "1:00", genre: "Rock")
+
+        service.downloadingSongs = ["song-x"]
+        service.deletingSongs = ["mixed case|artist"]
+
+        #expect(service.isDownloading(serverSong))
+        #expect(service.isDeleting(localSong))
+    }
+
+    @Test("setModelContext enables deleteDownloadedSong delegation")
+    func testDeleteDownloadedSongWithContext() async throws {
+        try await TestSetup.withTestSetup {
+            let context = TestContainer.shared.context
+            let service = ServerSongService()
+            service.setModelContext(context)
+
+            let serverSong = ServerSong(
+                songId: "service-delete",
+                title: "Delete Me",
+                artist: "Artist",
+                bpm: 120.0,
+                isDownloaded: true
+            )
+            let importedSong = Song(
+                title: "Delete Me",
+                artist: "Artist",
+                bpm: 120.0,
+                duration: "3:00",
+                genre: "DTX Import"
+            )
+            context.insert(serverSong)
+            context.insert(importedSong)
+            try context.save()
+
+            let success = await service.deleteDownloadedSong(serverSong)
+
+            #expect(success)
+            #expect(serverSong.isDownloaded == false)
+            TestAssertions.assertDeleted(importedSong, in: context)
+        }
+    }
+}

--- a/VirgoTests/ServerSongStatusManagerTests.swift
+++ b/VirgoTests/ServerSongStatusManagerTests.swift
@@ -1,0 +1,235 @@
+import Testing
+import SwiftData
+@testable import Virgo
+
+@Suite("ServerSongStatusManager Tests", .serialized)
+@MainActor
+struct ServerSongStatusManagerTests {
+    private func fetchSong(
+        songId: PersistentIdentifier,
+        context: ModelContext
+    ) throws -> Song? {
+        let descriptor = FetchDescriptor<Song>(predicate: #Predicate<Song> { songModel in
+            songModel.persistentModelID == songId
+        })
+        return try context.fetch(descriptor).first
+    }
+
+    private func fetchServerSong(
+        songId: String,
+        context: ModelContext
+    ) throws -> ServerSong? {
+        let descriptor = FetchDescriptor<ServerSong>(predicate: #Predicate<ServerSong> { serverSong in
+            serverSong.songId == songId
+        })
+        return try context.fetch(descriptor).first
+    }
+
+    @Test("deleteDownloadedSong deletes only matching DTX Import songs")
+    func testDeleteDownloadedSongSelectiveDeletion() async throws {
+        try await TestSetup.withTestSetup {
+            let context = TestContainer.shared.context
+            let manager = ServerSongStatusManager()
+
+            let serverSong = ServerSong(
+                songId: "server-song-a",
+                title: "Song A",
+                artist: "Artist A",
+                bpm: 120.0,
+                isDownloaded: true
+            )
+            context.insert(serverSong)
+
+            let importedMatch = Song(
+                title: "Song A",
+                artist: "Artist A",
+                bpm: 120.0,
+                duration: "3:00",
+                genre: "DTX Import"
+            )
+            let nonImportedMatch = Song(
+                title: "Song A",
+                artist: "Artist A",
+                bpm: 120.0,
+                duration: "3:00",
+                genre: "Rock"
+            )
+            let differentSong = Song(
+                title: "Song B",
+                artist: "Artist A",
+                bpm: 120.0,
+                duration: "3:00",
+                genre: "DTX Import"
+            )
+            context.insert(importedMatch)
+            context.insert(nonImportedMatch)
+            context.insert(differentSong)
+            try context.save()
+
+            let success = await manager.deleteDownloadedSong(serverSong, modelContext: context)
+
+            #expect(success)
+            #expect(serverSong.isDownloaded == false)
+            TestAssertions.assertDeleted(importedMatch, in: context)
+            TestAssertions.assertNotDeleted(nonImportedMatch, in: context)
+            TestAssertions.assertNotDeleted(differentSong, in: context)
+        }
+    }
+
+    @Test("refreshDownloadStatus updates downloaded and media flags from local songs")
+    func testRefreshDownloadStatusUpdatesFlags() async throws {
+        try await TestSetup.withTestSetup {
+            let context = TestContainer.shared.context
+            let manager = ServerSongStatusManager()
+
+            let localSong = Song(
+                title: "Match Song",
+                artist: "Match Artist",
+                bpm: 140.0,
+                duration: "4:00",
+                genre: "DTX Import",
+                bgmFilePath: "/tmp/test-match.ogg",
+                previewFilePath: "/tmp/test-match.mp3"
+            )
+            context.insert(localSong)
+
+            let matchingServerSong = ServerSong(
+                songId: "match-song",
+                title: "Match Song",
+                artist: "Match Artist",
+                bpm: 140.0,
+                isDownloaded: false,
+                bgmDownloaded: false,
+                previewDownloaded: false
+            )
+            let unmatchedServerSong = ServerSong(
+                songId: "no-match-song",
+                title: "No Match",
+                artist: "No Match Artist",
+                bpm: 100.0,
+                isDownloaded: true,
+                bgmDownloaded: true,
+                previewDownloaded: true
+            )
+            context.insert(matchingServerSong)
+            context.insert(unmatchedServerSong)
+            try context.save()
+
+            await manager.refreshDownloadStatus(modelContext: context)
+
+            #expect(matchingServerSong.isDownloaded == true)
+            #expect(matchingServerSong.bgmDownloaded == true)
+            #expect(matchingServerSong.previewDownloaded == true)
+
+            #expect(unmatchedServerSong.isDownloaded == false)
+            #expect(unmatchedServerSong.bgmDownloaded == false)
+            #expect(unmatchedServerSong.previewDownloaded == false)
+        }
+    }
+
+    private struct GroupedSongsData {
+        let serverSong: ServerSong
+        let firstImported: Song
+        let secondImported: Song
+        let nonImported: Song
+    }
+
+    private func setupGroupedSongs(
+        context: ModelContext
+    ) throws -> GroupedSongsData {
+        let serverSong = ServerSong(
+            songId: "song-group",
+            title: "Grouped Song",
+            artist: "Grouped Artist",
+            bpm: 128.0,
+            isDownloaded: true
+        )
+        context.insert(serverSong)
+
+        let firstImported = Song(
+            title: "Grouped Song",
+            artist: "Grouped Artist",
+            bpm: 128.0,
+            duration: "2:50",
+            genre: "DTX Import"
+        )
+        let secondImported = Song(
+            title: "Grouped Song",
+            artist: "Grouped Artist",
+            bpm: 128.0,
+            duration: "2:50",
+            genre: "DTX Import"
+        )
+        let nonImported = Song(
+            title: "Grouped Song",
+            artist: "Grouped Artist",
+            bpm: 128.0,
+            duration: "2:50",
+            genre: "Rock"
+        )
+        context.insert(firstImported)
+        context.insert(secondImported)
+        context.insert(nonImported)
+        try context.save()
+
+        return GroupedSongsData(
+            serverSong: serverSong,
+            firstImported: firstImported,
+            secondImported: secondImported,
+            nonImported: nonImported
+        )
+    }
+
+    @Test("deleteLocalSong updates server download status only after last DTX Import match is removed")
+    func testDeleteLocalSongUpdatesStatusAfterLastMatch() async throws {
+        try await TestSetup.withTestSetup {
+            let context = TestContainer.shared.context
+            let container = TestContainer.shared.container
+            let manager = ServerSongStatusManager()
+
+            let groupedData = try setupGroupedSongs(context: context)
+            let firstImported = groupedData.firstImported
+            let secondImported = groupedData.secondImported
+
+            let firstImportedId = firstImported.persistentModelID
+            let secondImportedId = secondImported.persistentModelID
+
+            let firstDeleteSuccess = await manager.deleteLocalSong(firstImported, container: container)
+            #expect(firstDeleteSuccess)
+
+            let verificationContext1 = ModelContext(container)
+            let firstDeletedSong = try fetchSong(songId: firstImportedId, context: verificationContext1)
+            let serverAfterFirstDelete = try fetchServerSong(songId: "song-group", context: verificationContext1)
+            #expect(firstDeletedSong == nil)
+            #expect(serverAfterFirstDelete?.isDownloaded == true)
+
+            let secondDeleteSuccess = await manager.deleteLocalSong(secondImported, container: container)
+            #expect(secondDeleteSuccess)
+
+            let verificationContext2 = ModelContext(container)
+            let secondDeletedSong = try fetchSong(songId: secondImportedId, context: verificationContext2)
+            let serverAfterSecondDelete = try fetchServerSong(songId: "song-group", context: verificationContext2)
+            #expect(secondDeletedSong == nil)
+            #expect(serverAfterSecondDelete?.isDownloaded == false)
+        }
+    }
+
+    @Test("deleteLocalSong returns true when song is already absent")
+    func testDeleteLocalSongAbsentSongIsNoOpSuccess() async throws {
+        try await TestSetup.withTestSetup {
+            let container = TestContainer.shared.container
+            let manager = ServerSongStatusManager()
+
+            let orphanSong = Song(
+                title: "Orphan",
+                artist: "Nobody",
+                bpm: 100.0,
+                duration: "1:00",
+                genre: "DTX Import"
+            )
+
+            let success = await manager.deleteLocalSong(orphanSong, container: container)
+            #expect(success)
+        }
+    }
+}

--- a/VirgoTests/SwiftDataRelationshipLoaderTests.swift
+++ b/VirgoTests/SwiftDataRelationshipLoaderTests.swift
@@ -8,6 +8,7 @@
 import Testing
 import SwiftData
 import SwiftUI
+import Foundation
 @testable import Virgo
 
 @Suite("SwiftData Relationship Loader Tests")
@@ -71,6 +72,179 @@ struct SwiftDataRelationshipLoaderTests {
             #expect(loadingCompleted, "Loading should complete")
             #expect(loader.relationshipData.chartCount == 0)
             #expect(loader.isLoading == false)
+        }
+    }
+
+    @Test("SongRelationshipLoader computes chart count, measure count, and sorted difficulties")
+    func testSongRelationshipLoaderComputedData() async throws {
+        try await TestSetup.withTestSetup {
+            let context = TestContainer.shared.context
+
+            let song = TestModelFactory.createSong(in: context, title: "Loader Song", artist: "Loader Artist")
+            let hardChart = TestModelFactory.createChart(in: context, difficulty: .hard, song: song)
+            let easyChart = TestModelFactory.createChart(in: context, difficulty: .easy, song: song)
+            let duplicateEasyChart = TestModelFactory.createChart(in: context, difficulty: .easy, song: song)
+
+            let noteA = TestModelFactory.createNote(
+                in: context,
+                interval: .quarter,
+                noteType: .snare,
+                measureNumber: 2,
+                measureOffset: 0.0,
+                chart: hardChart
+            )
+            let noteB = TestModelFactory.createNote(
+                in: context,
+                interval: .eighth,
+                noteType: .bass,
+                measureNumber: 5,
+                measureOffset: 0.5,
+                chart: easyChart
+            )
+
+            hardChart.notes = [noteA]
+            easyChart.notes = [noteB]
+            duplicateEasyChart.notes = []
+            song.charts = [hardChart, easyChart, duplicateEasyChart]
+            try context.save()
+
+            let loader = SongRelationshipLoader(song: song)
+            let loaded = await TestHelpers.waitFor(
+                condition: {
+                    loader.relationshipData.chartCount == 3 &&
+                    loader.relationshipData.measureCount == 5 &&
+                    loader.relationshipData.availableDifficulties == [.easy, .hard] &&
+                    loader.isLoading == false
+                },
+                timeout: 2.0,
+                checkInterval: 0.01
+            )
+
+            #expect(loaded)
+            #expect(loader.relationshipData.chartCount == 3)
+            #expect(loader.relationshipData.measureCount == 5)
+            #expect(loader.relationshipData.charts.count == 3)
+            #expect(loader.relationshipData.availableDifficulties == [.easy, .hard])
+            #expect(loader.isLoading == false)
+            loader.stopObserving()
+        }
+    }
+
+    @Test("ChartRelationshipLoader computes notes count and measure count")
+    func testChartRelationshipLoaderComputedData() async throws {
+        try await TestSetup.withTestSetup {
+            let context = TestContainer.shared.context
+
+            let song = TestModelFactory.createSong(in: context)
+            let chart = TestModelFactory.createChart(in: context, difficulty: .medium, song: song)
+
+            let note1 = TestModelFactory.createNote(
+                in: context,
+                interval: .quarter,
+                noteType: .bass,
+                measureNumber: 1,
+                measureOffset: 0.0,
+                chart: chart
+            )
+            let note2 = TestModelFactory.createNote(
+                in: context,
+                interval: .eighth,
+                noteType: .snare,
+                measureNumber: 4,
+                measureOffset: 0.5,
+                chart: chart
+            )
+
+            chart.notes = [note1, note2]
+            song.charts = [chart]
+            try context.save()
+
+            let loader = ChartRelationshipLoader(chart: chart)
+            let loaded = await TestHelpers.waitFor(
+                condition: {
+                    loader.relationshipData.notesCount == 2 &&
+                    loader.relationshipData.measureCount == 4 &&
+                    loader.relationshipData.notes.count == 2 &&
+                    loader.isLoading == false
+                },
+                timeout: 2.0,
+                checkInterval: 0.01
+            )
+
+            #expect(loaded)
+            #expect(loader.relationshipData.notesCount == 2)
+            #expect(loader.relationshipData.measureCount == 4)
+            #expect(loader.relationshipData.notes.count == 2)
+            #expect(loader.isLoading == false)
+            loader.stopObserving()
+        }
+    }
+
+    @Test("BaseSwiftDataRelationshipLoader refresh reloads and replaces previous data")
+    func testBaseLoaderRefreshReplacesData() async throws {
+        try await TestSetup.withTestSetup {
+            let context = TestContainer.shared.context
+            let mockSong = TestModelFactory.createSong(in: context)
+
+            var loadCount = 0
+            let loader = BaseSwiftDataRelationshipLoader(
+                model: mockSong,
+                defaultData: 0
+            ) { _ in
+                try? await Task.sleep(nanoseconds: 20_000_000)
+                loadCount += 1
+                return loadCount
+            }
+
+            let initialLoaded = await TestHelpers.waitFor(
+                condition: { loader.relationshipData >= 1 && loader.isLoading == false },
+                timeout: 1.5,
+                checkInterval: 0.01
+            )
+
+            #expect(initialLoaded)
+            let firstValue = loader.relationshipData
+            #expect(firstValue >= 1)
+
+            loader.refresh()
+            let refreshed = await TestHelpers.waitFor(
+                condition: { loader.relationshipData > firstValue && loader.isLoading == false },
+                timeout: 1.5,
+                checkInterval: 0.01
+            )
+
+            #expect(refreshed)
+            #expect(loader.relationshipData > firstValue)
+            loader.stopObserving()
+        }
+    }
+
+    @Test("BaseSwiftDataRelationshipLoader stopObserving cancels in-flight load")
+    func testBaseLoaderStopObservingCancelsLoad() async throws {
+        try await TestSetup.withTestSetup {
+            let context = TestContainer.shared.context
+            let mockSong = TestModelFactory.createSong(in: context)
+
+            let loader = BaseSwiftDataRelationshipLoader(
+                model: mockSong,
+                defaultData: "default"
+            ) { _ in
+                try? await Task.sleep(nanoseconds: 300_000_000)
+                return "loaded"
+            }
+
+            // Cancel any auto-started load first so we can control timing for this assertion.
+            loader.stopObserving()
+
+            let loadingTask = Task {
+                await loader.loadRelationshipData()
+            }
+
+            try await Task.sleep(nanoseconds: 30_000_000)
+            loader.stopObserving()
+            await loadingTask.value
+
+            #expect(loader.relationshipData == "default")
         }
     }
 


### PR DESCRIPTION
## Summary
- Added 1050+ lines of test coverage across 7 new test files
- Tests cover server song management utilities (Cache, FileManager, Service, StatusManager)
- Tests cover InputSettingsManager key mapping and persistence
- Tests cover SwiftDataRelationshipLoader computed data, refresh, and cancellation
- Tests cover DrumType extensions and constants

## Files Changed
- VirgoTests/ServerSongCacheTests.swift (80 lines)
- VirgoTests/ServerSongFileManagerTests.swift (55 lines)
- VirgoTests/ServerSongServiceTests.swift (151 lines)
- VirgoTests/ServerSongStatusManagerTests.swift (235 lines)
- VirgoTests/InputSettingsManagerTests.swift (200 lines)
- VirgoTests/SwiftDataRelationshipLoaderTests.swift (174 lines)
- VirgoTests/DrumTypeExtensionsAndConstantsTests.swift (155 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for core modules including drum type handling, input settings, server song management, and data relationship loading to improve code quality and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->