### PR TITLE
fix: ensure deterministic UserDefaults key generation and improve test coverage

### DIFF
--- a/Virgo/services/HighScoreService.swift
+++ b/Virgo/services/HighScoreService.swift
@@ -9,7 +9,6 @@
 
 import Foundation
 import SwiftData
-import CryptoKit
 
 /// Service that persists the best score achieved for each chart.
 @MainActor
@@ -22,11 +21,6 @@ final class HighScoreService {
     // MARK: - Dependencies
 
     private let userDefaults: UserDefaults
-    private let jsonEncoder: JSONEncoder = {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        return encoder
-    }()
 
     // MARK: - Initialization
 
@@ -38,9 +32,7 @@ final class HighScoreService {
 
     /// Returns the saved high score for a chart, or 0 if none has been recorded.
     func highScore(for chartID: PersistentIdentifier) -> Int {
-        let key = persistenceKey(for: chartID)
-        let scores = readPersistedScores()
-        return scores[key] ?? 0
+        resolvedScore(for: chartID)?.score ?? 0
     }
 
     /// Saves the score if it is strictly greater than the previous record.
@@ -51,6 +43,16 @@ final class HighScoreService {
 
         let key = persistenceKey(for: chartID)
         var scores = readPersistedScores()
+        if let resolved = PersistentIdentifierPersistenceKey.resolve(
+            for: chartID,
+            in: scores,
+            logPrefix: "HighScoreService"
+        ), resolved.needsMigration {
+            scores.removeValue(forKey: resolved.matchedKey)
+            scores[resolved.canonicalKey] = resolved.value
+            userDefaults.set(scores, forKey: settingsKey)
+        }
+
         let current = scores[key] ?? 0
         guard score > current else { return false }
 
@@ -75,27 +77,33 @@ final class HighScoreService {
 
     // MARK: - Private
 
+    private func resolvedScore(for chartID: PersistentIdentifier) -> (key: String, score: Int)? {
+        let scores = readPersistedScores()
+        guard let resolved = PersistentIdentifierPersistenceKey.resolve(
+            for: chartID,
+            in: scores,
+            logPrefix: "HighScoreService"
+        ) else {
+            return nil
+        }
+
+        if resolved.needsMigration {
+            var migratedScores = scores
+            migratedScores.removeValue(forKey: resolved.matchedKey)
+            migratedScores[resolved.canonicalKey] = resolved.value
+            userDefaults.set(migratedScores, forKey: settingsKey)
+        }
+
+        return (resolved.canonicalKey, resolved.value)
+    }
+
     /// Creates a stable persistence key from a PersistentIdentifier.
     /// Uses the same JSONEncoder + SHA-256 fallback strategy as PracticeSettingsService.
     private func persistenceKey(for chartID: PersistentIdentifier) -> String {
-        do {
-            let data = try jsonEncoder.encode(chartID)
-            if let key = String(data: data, encoding: .utf8) {
-                return key
-            }
-            Logger.error("HighScoreService: Failed to convert PersistentIdentifier to UTF-8 string")
-        } catch {
-            Logger.error("HighScoreService: Failed to encode PersistentIdentifier: \(error.localizedDescription)")
-        }
-
-        // SHA-256 fallback: PersistentIdentifier.description stability is not guaranteed by Apple API.
-        // Log a warning so key-mismatch issues can be diagnosed post-hoc.
-        Logger.warning("HighScoreService: Using SHA-256 fallback key for chart \(String(describing: chartID).prefix(40))")
-        let stableIdentifier = String(describing: chartID)
-        let inputData = Data(stableIdentifier.utf8)
-        let digest = SHA256.hash(data: inputData)
-        let hashString = digest.compactMap { String(format: "%02x", $0) }.joined()
-        return "chart_\(String(hashString.prefix(32)))"
+        PersistentIdentifierPersistenceKey.canonicalKey(
+            for: chartID,
+            logPrefix: "HighScoreService"
+        )
     }
 
     /// Reads the persisted score dictionary, tolerating NSNumber bridging.

--- a/Virgo/services/PracticeSettingsService.swift
+++ b/Virgo/services/PracticeSettingsService.swift
@@ -40,6 +40,11 @@ final class PracticeSettingsService: ObservableObject {
     // MARK: - Dependencies
 
     private let userDefaults: UserDefaults
+    private let jsonEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
     private let settingsKey = "PracticeSettingsSpeedMultipliers"
     private var sessionSpeedCache: [PersistentIdentifier: Double] = [:]
 
@@ -127,7 +132,7 @@ final class PracticeSettingsService: ObservableObject {
     private func persistenceKey(for chartID: PersistentIdentifier) -> String {
         // Encode using JSONEncoder for stable, deterministic representation
         do {
-            let data = try JSONEncoder().encode(chartID)
+            let data = try jsonEncoder.encode(chartID)
             if let key = String(data: data, encoding: .utf8) {
                 return key
             }

--- a/Virgo/services/PracticeSettingsService.swift
+++ b/Virgo/services/PracticeSettingsService.swift
@@ -9,7 +9,6 @@
 
 import Foundation
 import SwiftData
-import CryptoKit
 
 /// Service that manages practice settings for gameplay sessions.
 /// Handles speed control state, validation, and per-chart persistence.
@@ -40,11 +39,6 @@ final class PracticeSettingsService: ObservableObject {
     // MARK: - Dependencies
 
     private let userDefaults: UserDefaults
-    private let jsonEncoder: JSONEncoder = {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        return encoder
-    }()
     private let settingsKey = "PracticeSettingsSpeedMultipliers"
     private var sessionSpeedCache: [PersistentIdentifier: Double] = [:]
 
@@ -130,27 +124,10 @@ final class PracticeSettingsService: ObservableObject {
     /// - Parameter chartID: The persistent identifier of the chart
     /// - Returns: A stable string key for UserDefaults storage
     private func persistenceKey(for chartID: PersistentIdentifier) -> String {
-        // Encode using JSONEncoder for stable, deterministic representation
-        do {
-            let data = try jsonEncoder.encode(chartID)
-            if let key = String(data: data, encoding: .utf8) {
-                return key
-            }
-            Logger.error("Failed to convert PersistentIdentifier JSON data to UTF-8 string")
-        } catch {
-            Logger.error("Failed to JSON-encode PersistentIdentifier: \(error.localizedDescription)")
-        }
-
-        // Fallback: SHA-256 digest of description string.
-        // Note: PersistentIdentifier.description stability is not guaranteed by Apple API;
-        // this fallback may produce different keys across OS/framework updates.
-        // The primary JSONEncoder path should handle most cases reliably.
-        let stableIdentifier = String(describing: chartID)
-        let inputData = Data(stableIdentifier.utf8)
-        let digest = SHA256.hash(data: inputData)
-        let hashString = digest.compactMap { String(format: "%02x", $0) }.joined()
-        // Use first 32 hex characters (128 bits) of SHA-256 digest
-        return "chart_\(String(hashString.prefix(32)))"
+        PersistentIdentifierPersistenceKey.canonicalKey(
+            for: chartID,
+            logPrefix: "PracticeSettingsService"
+        )
     }
 
     /// Loads the saved speed for a specific chart.
@@ -162,9 +139,20 @@ final class PracticeSettingsService: ObservableObject {
         }
 
         let key = persistenceKey(for: chartID)
-        let speeds = readPersistedSpeeds()
-        guard let savedSpeed = speeds[key] else {
+        var speeds = readPersistedSpeeds()
+        guard let resolved = PersistentIdentifierPersistenceKey.resolve(
+            for: chartID,
+            in: speeds,
+            logPrefix: "PracticeSettingsService"
+        ) else {
             return 1.0
+        }
+        let savedSpeed = resolved.value
+
+        if resolved.needsMigration {
+            speeds.removeValue(forKey: resolved.matchedKey)
+            speeds[resolved.canonicalKey] = savedSpeed
+            userDefaults.set(speeds, forKey: settingsKey)
         }
 
         // Validate loaded value is within bounds and finite

--- a/Virgo/utilities/PersistentIdentifierPersistenceKey.swift
+++ b/Virgo/utilities/PersistentIdentifierPersistenceKey.swift
@@ -1,0 +1,69 @@
+//
+//  PersistentIdentifierPersistenceKey.swift
+//  Virgo
+//
+//  Backward-compatible persistence key resolution for SwiftData identifiers.
+//
+
+import Foundation
+import SwiftData
+import CryptoKit
+
+enum PersistentIdentifierPersistenceKey {
+    struct Resolution<Value> {
+        let canonicalKey: String
+        let matchedKey: String
+        let value: Value
+
+        var needsMigration: Bool {
+            canonicalKey != matchedKey
+        }
+    }
+
+    static func canonicalKey(for identifier: PersistentIdentifier, logPrefix: String) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        do {
+            let data = try encoder.encode(identifier)
+            if let key = String(data: data, encoding: .utf8) {
+                return key
+            }
+            Logger.error("\(logPrefix): Failed to convert PersistentIdentifier JSON data to UTF-8 string")
+        } catch {
+            Logger.error("\(logPrefix): Failed to JSON-encode PersistentIdentifier: \(error.localizedDescription)")
+        }
+
+        let stableIdentifier = String(describing: identifier)
+        let inputData = Data(stableIdentifier.utf8)
+        let digest = SHA256.hash(data: inputData)
+        let hashString = digest.compactMap { String(format: "%02x", $0) }.joined()
+        Logger.warning("\(logPrefix): Using SHA-256 fallback key for chart \(stableIdentifier.prefix(40))")
+        return "chart_\(String(hashString.prefix(32)))"
+    }
+
+    static func resolve<Value>(
+        for identifier: PersistentIdentifier,
+        in persistedValues: [String: Value],
+        logPrefix: String
+    ) -> Resolution<Value>? {
+        let canonicalKey = canonicalKey(for: identifier, logPrefix: logPrefix)
+        if let value = persistedValues[canonicalKey] {
+            return Resolution(canonicalKey: canonicalKey, matchedKey: canonicalKey, value: value)
+        }
+
+        let decoder = JSONDecoder()
+        for (candidateKey, value) in persistedValues where candidateKey != canonicalKey {
+            guard let candidateData = candidateKey.data(using: .utf8),
+                  let decodedIdentifier = try? decoder.decode(PersistentIdentifier.self, from: candidateData),
+                  decodedIdentifier == identifier else {
+                continue
+            }
+
+            Logger.debug("\(logPrefix): Migrating legacy persistence key to canonical format")
+            return Resolution(canonicalKey: canonicalKey, matchedKey: candidateKey, value: value)
+        }
+
+        return nil
+    }
+}

--- a/Virgo/utilities/PersistentIdentifierPersistenceKey.swift
+++ b/Virgo/utilities/PersistentIdentifierPersistenceKey.swift
@@ -52,6 +52,13 @@ enum PersistentIdentifierPersistenceKey {
             return Resolution(canonicalKey: canonicalKey, matchedKey: canonicalKey, value: value)
         }
 
+        for (candidateKey, value) in persistedValues where candidateKey != canonicalKey {
+            if normalizeJSONKey(candidateKey) == canonicalKey {
+                Logger.debug("\(logPrefix): Migrating legacy persistence key to canonical format")
+                return Resolution(canonicalKey: canonicalKey, matchedKey: candidateKey, value: value)
+            }
+        }
+
         let decoder = JSONDecoder()
         for (candidateKey, value) in persistedValues where candidateKey != canonicalKey {
             guard let candidateData = candidateKey.data(using: .utf8),
@@ -65,5 +72,17 @@ enum PersistentIdentifierPersistenceKey {
         }
 
         return nil
+    }
+
+    private static func normalizeJSONKey(_ key: String) -> String? {
+        guard let data = key.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              JSONSerialization.isValidJSONObject(object),
+              let normalizedData = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+              let normalizedKey = String(data: normalizedData, encoding: .utf8) else {
+            return nil
+        }
+
+        return normalizedKey
     }
 }

--- a/VirgoTests/DTXFileParserTests.swift
+++ b/VirgoTests/DTXFileParserTests.swift
@@ -278,4 +278,124 @@ struct DTXFileParserTests {
         #expect(!chartData.notes.isEmpty)
         #expect(chartData.notes.first?.toNoteType() == .bass)
     }
+
+    @Test func testParseDTXMetadataFromFileURL() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("virgo-dtx-\(UUID().uuidString)")
+            .appendingPathExtension("dtx")
+
+        let content = """
+        #TITLE: File Song
+        #ARTIST: File Artist
+        #BPM: 128
+        #DLEVEL: 35
+        #00113: 01000000
+        """
+
+        try content.write(to: fileURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let chartData = try DTXFileParser.parseChartMetadata(from: fileURL)
+
+        #expect(chartData.title == "File Song")
+        #expect(chartData.artist == "File Artist")
+        #expect(chartData.bpm == 128)
+        #expect(chartData.difficultyLevel == 35)
+        #expect(chartData.notes.count == 1)
+    }
+
+    @Test func testParseDTXMetadataMissingFileURLThrows() {
+        let missingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-\(UUID().uuidString)")
+            .appendingPathExtension("dtx")
+
+        do {
+            _ = try DTXFileParser.parseChartMetadata(from: missingURL)
+            Issue.record("Expected parseChartMetadata(from:) to throw fileNotFound")
+        } catch DTXParseError.fileNotFound {
+            // Expected path
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test func testParseDTXMissingRequiredFields() {
+        let testCases: [(content: String, field: String)] = [
+            (
+                """
+                #TITLE: Missing Artist
+                #BPM: 120
+                #DLEVEL: 50
+                """,
+                "ARTIST"
+            ),
+            (
+                """
+                #TITLE: Missing BPM
+                #ARTIST: Test Artist
+                #DLEVEL: 50
+                """,
+                "BPM"
+            ),
+            (
+                """
+                #TITLE: Missing Level
+                #ARTIST: Test Artist
+                #BPM: 120
+                """,
+                "DLEVEL"
+            )
+        ]
+
+        for testCase in testCases {
+            do {
+                _ = try DTXFileParser.parseChartMetadata(from: testCase.content)
+                Issue.record("Expected missing required field error for \(testCase.field)")
+            } catch DTXParseError.missingRequiredField(let field) {
+                #expect(field == testCase.field)
+            } catch {
+                Issue.record("Unexpected error for \(testCase.field): \(error)")
+            }
+        }
+    }
+
+    @Test func testParseNoteLineRejectsMalformedInput() throws {
+        let malformedLines = [
+            "invalid",
+            "#0013: 01",
+            "#00A13: 0101",
+            "#00113: 010",
+            "#00113:"
+        ]
+
+        for line in malformedLines {
+            let notes = try DTXFileParser.parseNoteLine(line)
+            #expect(notes.isEmpty)
+        }
+    }
+
+    @Test func testDTXNoteIntervalConversions() {
+        let testCases: [(positions: Int, expectedInterval: NoteInterval)] = [
+            (1, .full),
+            (2, .half),
+            (4, .quarter),
+            (8, .eighth),
+            (16, .sixteenth),
+            (32, .thirtysecond),
+            (64, .sixtyfourth),
+            (12, .quarter)
+        ]
+
+        for testCase in testCases {
+            let note = DTXNote(
+                measureNumber: 0,
+                laneID: "13",
+                noteID: "01",
+                notePosition: 0,
+                totalPositions: testCase.positions
+            )
+
+            #expect(note.toNoteInterval() == testCase.expectedInterval)
+        }
+    }
 }

--- a/VirgoTests/GameplayLayoutTests.swift
+++ b/VirgoTests/GameplayLayoutTests.swift
@@ -1,0 +1,78 @@
+import Testing
+import SwiftUI
+@testable import Virgo
+
+@Suite("GameplayLayout Tests")
+struct GameplayLayoutTests {
+    @Test("totalHeight uses the highest occupied row")
+    func testTotalHeightUsesMaxRow() {
+        let positions = [
+            GameplayLayout.MeasurePosition(row: 0, xOffset: 100, measureIndex: 0),
+            GameplayLayout.MeasurePosition(row: 2, xOffset: 140, measureIndex: 5)
+        ]
+
+        let totalHeight = GameplayLayout.totalHeight(for: positions)
+        let expectedHeight = GameplayLayout.baseStaffY +
+            CGFloat(3) * (GameplayLayout.rowHeight + GameplayLayout.rowVerticalSpacing) +
+            100
+
+        #expect(totalHeight == expectedHeight)
+    }
+
+    @Test("noteXPosition uses measure offset and beat spacing")
+    func testNoteXPositionForMeasurePosition() {
+        let measurePosition = GameplayLayout.MeasurePosition(row: 1, xOffset: 220, measureIndex: 3)
+
+        let xPosition = GameplayLayout.noteXPosition(
+            measurePosition: measurePosition,
+            beatIndex: 2,
+            timeSignature: .fourFour
+        )
+
+        let expected = measurePosition.xOffset +
+            GameplayLayout.barLineWidth +
+            GameplayLayout.uniformSpacing +
+            CGFloat(2) * GameplayLayout.uniformSpacing
+
+        #expect(xPosition == expected)
+    }
+
+    @Test("noteXPosition lookup by measure index returns fallback for missing measures")
+    func testNoteXPositionLookupAndFallback() {
+        let positions = [
+            GameplayLayout.MeasurePosition(row: 0, xOffset: 100, measureIndex: 0),
+            GameplayLayout.MeasurePosition(row: 1, xOffset: 180, measureIndex: 2)
+        ]
+
+        let matchedXPosition = GameplayLayout.noteXPosition(
+            measureIndex: 2,
+            beatIndex: 1,
+            timeSignature: .fourFour,
+            positions: positions
+        )
+        let expectedMatchedX = positions[1].xOffset +
+            GameplayLayout.barLineWidth +
+            GameplayLayout.uniformSpacing +
+            GameplayLayout.uniformSpacing
+
+        let fallbackXPosition = GameplayLayout.noteXPosition(
+            measureIndex: 99,
+            beatIndex: 0,
+            timeSignature: .fourFour,
+            positions: positions
+        )
+
+        #expect(matchedXPosition == expectedMatchedX)
+        #expect(fallbackXPosition == GameplayLayout.leftMargin)
+    }
+
+    @Test("rowWidth and noteYPosition reuse layout constants")
+    func testRowWidthAndNoteYPosition() {
+        let rowWidth = GameplayLayout.rowWidth(for: .threeFour)
+        let noteYPosition = GameplayLayout.noteYPosition(row: 2, notePosition: .line3)
+        let expectedNoteY = GameplayLayout.NotePosition.line3.absoluteY(for: 2)
+
+        #expect(rowWidth == GameplayLayout.maxRowWidth)
+        #expect(noteYPosition == expectedNoteY)
+    }
+}

--- a/VirgoTests/HighScoreServiceTests.swift
+++ b/VirgoTests/HighScoreServiceTests.swift
@@ -29,6 +29,50 @@ struct HighScoreServiceTests {
         return chart
     }
 
+    private func makeLegacyPersistenceKey(for chartID: PersistentIdentifier) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let canonicalData = try encoder.encode(chartID)
+        guard let canonicalKey = String(data: canonicalData, encoding: .utf8) else {
+            throw NSError(domain: "HighScoreServiceTests", code: 1)
+        }
+
+        return addWhitespaceOutsideStrings(to: canonicalKey)
+    }
+
+    private func addWhitespaceOutsideStrings(to json: String) -> String {
+        var result = ""
+        var inString = false
+        var isEscaping = false
+
+        for character in json {
+            if isEscaping {
+                result.append(character)
+                isEscaping = false
+                continue
+            }
+
+            if character == "\\" {
+                result.append(character)
+                isEscaping = true
+                continue
+            }
+
+            if character == "\"" {
+                result.append(character)
+                inString.toggle()
+                continue
+            }
+
+            result.append(character)
+            if !inString && (character == ":" || character == ",") {
+                result.append(" ")
+            }
+        }
+
+        return result
+    }
+
     // MARK: - Default State
 
     @Test("Default high score is 0 for an unseen chart")
@@ -255,6 +299,26 @@ struct HighScoreServiceTests {
 
             #expect(isNewHighScore == true)
             #expect(reloadedService.highScore(for: chart.persistentModelID) == 1200)
+        }
+    }
+
+    @Test("highScore reads legacy persistence keys and migrates them to canonical format")
+    func testHighScoreMigratesLegacyPersistenceKeys() async throws {
+        try await TestSetup.withTestSetup {
+            let (ud, _) = TestUserDefaults.makeIsolated()
+            let chart = try makeTestChart()
+            let legacyKey = try makeLegacyPersistenceKey(for: chart.persistentModelID)
+
+            ud.set([legacyKey: 2400], forKey: "HighScorePerChart")
+
+            let loadedScore = HighScoreService(userDefaults: ud).highScore(for: chart.persistentModelID)
+            #expect(loadedScore == 2400)
+
+            let persistedKeys = ud.dictionary(forKey: "HighScorePerChart").map {
+                Array($0.keys)
+            } ?? []
+            #expect(persistedKeys.contains(legacyKey) == false)
+            #expect(persistedKeys.count == 1)
         }
     }
 }

--- a/VirgoTests/HighScoreServiceTests.swift
+++ b/VirgoTests/HighScoreServiceTests.swift
@@ -175,4 +175,86 @@ struct HighScoreServiceTests {
             #expect(service.highScore(for: chart.persistentModelID) == 0)
         }
     }
+
+    @Test("highScore reads NSNumber payloads from UserDefaults")
+    func testHighScoreReadsNSNumberPayload() async throws {
+        try await TestSetup.withTestSetup {
+            let (ud, _) = TestUserDefaults.makeIsolated()
+            let chart = try makeTestChart()
+            let service = HighScoreService(userDefaults: ud)
+
+            _ = service.saveIfHighScore(100, for: chart.persistentModelID)
+
+            guard let key = ud.dictionary(forKey: "HighScorePerChart")?.keys.first else {
+                Issue.record("Expected a persisted high score key to be created")
+                return
+            }
+
+            ud.set([key: NSNumber(value: 2400)], forKey: "HighScorePerChart")
+
+            let reloadedService = HighScoreService(userDefaults: ud)
+            #expect(reloadedService.highScore(for: chart.persistentModelID) == 2400)
+        }
+    }
+
+    @Test("highScore ignores malformed payloads while keeping valid NSNumber entries")
+    func testHighScoreIgnoresMalformedPayloads() async throws {
+        try await TestSetup.withTestSetup {
+            let (ud, _) = TestUserDefaults.makeIsolated()
+            let service = HighScoreService(userDefaults: ud)
+            let chartA = try makeTestChart(difficulty: .easy)
+            let chartB = try makeTestChart(difficulty: .hard)
+
+            _ = service.saveIfHighScore(1500, for: chartA.persistentModelID)
+
+            guard let keyA = ud.dictionary(forKey: "HighScorePerChart")?.keys.first else {
+                Issue.record("Expected a persisted high score key for chart A")
+                return
+            }
+
+            _ = service.saveIfHighScore(800, for: chartB.persistentModelID)
+
+            guard let persistedScores = ud.dictionary(forKey: "HighScorePerChart"),
+                  let keyB = persistedScores.keys.first(where: { $0 != keyA }) else {
+                Issue.record("Expected a persisted high score key for chart B")
+                return
+            }
+
+            ud.set(
+                [
+                    keyA: NSNumber(value: 1600),
+                    keyB: "bad-score"
+                ],
+                forKey: "HighScorePerChart"
+            )
+
+            let reloadedService = HighScoreService(userDefaults: ud)
+            #expect(reloadedService.highScore(for: chartA.persistentModelID) == 1600)
+            #expect(reloadedService.highScore(for: chartB.persistentModelID) == 0)
+        }
+    }
+
+    @Test("saveIfHighScore compares against raw persisted NSNumber values")
+    func testSaveIfHighScoreAgainstRawPersistedValue() async throws {
+        try await TestSetup.withTestSetup {
+            let (ud, _) = TestUserDefaults.makeIsolated()
+            let chart = try makeTestChart()
+            let service = HighScoreService(userDefaults: ud)
+
+            _ = service.saveIfHighScore(500, for: chart.persistentModelID)
+
+            guard let key = ud.dictionary(forKey: "HighScorePerChart")?.keys.first else {
+                Issue.record("Expected a persisted high score key to be created")
+                return
+            }
+
+            ud.set([key: NSNumber(value: 900)], forKey: "HighScorePerChart")
+
+            let reloadedService = HighScoreService(userDefaults: ud)
+            let isNewHighScore = reloadedService.saveIfHighScore(1200, for: chart.persistentModelID)
+
+            #expect(isNewHighScore == true)
+            #expect(reloadedService.highScore(for: chart.persistentModelID) == 1200)
+        }
+    }
 }

--- a/VirgoTests/LoggerTests.swift
+++ b/VirgoTests/LoggerTests.swift
@@ -1,0 +1,23 @@
+import Testing
+import Foundation
+@testable import Virgo
+
+@Suite("Logger Tests")
+struct LoggerTests {
+    private struct TestError: LocalizedError {
+        var errorDescription: String? { "Logger test failure" }
+    }
+
+    @Test("Logger convenience methods accept messages and errors")
+    func testLoggerConvenienceMethods() {
+        Logger.database("Saving test data")
+        Logger.databaseError(TestError())
+        Logger.audioPlayback("Preview started")
+        Logger.userAction("Tapped test button")
+        Logger.debug("Debug message")
+        Logger.info("Info message")
+        Logger.warning("Warning message")
+        Logger.error("Error message")
+        Logger.critical("Critical message")
+    }
+}

--- a/VirgoTests/PracticeSettingsServiceTests.swift
+++ b/VirgoTests/PracticeSettingsServiceTests.swift
@@ -12,6 +12,17 @@ import SwiftData
 @Suite("PracticeSettingsService Tests", .serialized)
 @MainActor
 struct PracticeSettingsServiceTests {
+    private func makeTestChartID(difficulty: Difficulty = .medium) throws -> PersistentIdentifier {
+        let context = TestContainer.shared.context
+        let song = Song(title: "Test", artist: "Test", bpm: 120.0, duration: "3:00", genre: "Test")
+        context.insert(song)
+
+        let chart = Chart(difficulty: difficulty, song: song)
+        context.insert(chart)
+        try context.save()
+
+        return chart.persistentModelID
+    }
 
     // MARK: - Initialization Tests
 
@@ -345,6 +356,95 @@ struct PracticeSettingsServiceTests {
             #expect(service.loadSpeed(for: charts[0].persistentModelID) == 0.5)
             #expect(service.loadSpeed(for: charts[1].persistentModelID) == 0.75)
             #expect(service.loadSpeed(for: charts[2].persistentModelID) == 1.25)
+        }
+    }
+
+    @Test("loadSpeed decodes NSNumber and String payloads from UserDefaults")
+    func testLoadSpeedDecodesNSNumberAndStringValues() async throws {
+        try await TestSetup.withTestSetup {
+            let (userDefaults, _) = TestUserDefaults.makeIsolated()
+            let chartID = try makeTestChartID()
+            let seedingService = PracticeSettingsService(userDefaults: userDefaults)
+            seedingService.saveSpeed(1.0, for: chartID)
+
+            guard let key = userDefaults.dictionary(forKey: "PracticeSettingsSpeedMultipliers")?.keys.first else {
+                Issue.record("Expected a persisted speed key to be created")
+                return
+            }
+
+            userDefaults.set([key: NSNumber(value: 0.75)], forKey: "PracticeSettingsSpeedMultipliers")
+            let numberLoaded = PracticeSettingsService(userDefaults: userDefaults).loadSpeed(for: chartID)
+            #expect(numberLoaded == 0.75)
+
+            userDefaults.set([key: "1.25"], forKey: "PracticeSettingsSpeedMultipliers")
+            let stringLoaded = PracticeSettingsService(userDefaults: userDefaults).loadSpeed(for: chartID)
+            #expect(stringLoaded == 1.25)
+        }
+    }
+
+    @Test("loadSpeed clamps out-of-range values and ignores unsupported payload types")
+    func testLoadSpeedClampsAndIgnoresUnsupportedPersistedValues() async throws {
+        try await TestSetup.withTestSetup {
+            let (userDefaults, _) = TestUserDefaults.makeIsolated()
+            let chartID = try makeTestChartID()
+            let seedingService = PracticeSettingsService(userDefaults: userDefaults)
+            seedingService.saveSpeed(1.0, for: chartID)
+
+            guard let key = userDefaults.dictionary(forKey: "PracticeSettingsSpeedMultipliers")?.keys.first else {
+                Issue.record("Expected a persisted speed key to be created")
+                return
+            }
+
+            userDefaults.set([key: -2.0], forKey: "PracticeSettingsSpeedMultipliers")
+            let clampedLow = PracticeSettingsService(userDefaults: userDefaults).loadSpeed(for: chartID)
+            #expect(clampedLow == PracticeSettingsService.minSpeed)
+
+            userDefaults.set([key: 3.0], forKey: "PracticeSettingsSpeedMultipliers")
+            let clampedHigh = PracticeSettingsService(userDefaults: userDefaults).loadSpeed(for: chartID)
+            #expect(clampedHigh == PracticeSettingsService.maxSpeed)
+
+            userDefaults.set([key: ["unsupported"]], forKey: "PracticeSettingsSpeedMultipliers")
+            let fallbackValue = PracticeSettingsService(userDefaults: userDefaults).loadSpeed(for: chartID)
+            #expect(fallbackValue == 1.0)
+        }
+    }
+
+    @Test("saveSpeed clamps persisted values and ignores non-finite input")
+    func testSaveSpeedClampsAndIgnoresNonFiniteValues() async throws {
+        try await TestSetup.withTestSetup {
+            let (userDefaults, _) = TestUserDefaults.makeIsolated()
+            let service = PracticeSettingsService(userDefaults: userDefaults)
+            let chartID = try makeTestChartID()
+
+            service.saveSpeed(0.1, for: chartID)
+            let clampedLow = PracticeSettingsService(userDefaults: userDefaults).loadSpeed(for: chartID)
+            #expect(clampedLow == PracticeSettingsService.minSpeed)
+
+            service.saveSpeed(3.0, for: chartID)
+            let clampedHigh = PracticeSettingsService(userDefaults: userDefaults).loadSpeed(for: chartID)
+            #expect(clampedHigh == PracticeSettingsService.maxSpeed)
+
+            service.saveSpeed(0.75, for: chartID)
+            service.saveSpeed(Double.nan, for: chartID)
+            let preservedValue = PracticeSettingsService(userDefaults: userDefaults).loadSpeed(for: chartID)
+            #expect(preservedValue == 0.75)
+        }
+    }
+
+    @Test("clearAllSavedSpeeds clears persisted values and session cache")
+    func testClearAllSavedSpeedsClearsSessionCache() async throws {
+        try await TestSetup.withTestSetup {
+            let (userDefaults, _) = TestUserDefaults.makeIsolated()
+            let service = PracticeSettingsService(userDefaults: userDefaults)
+            let chartID = try makeTestChartID()
+
+            service.saveSpeed(0.75, for: chartID)
+            #expect(service.loadSpeed(for: chartID) == 0.75)
+
+            service.clearAllSavedSpeeds()
+
+            #expect(service.loadSpeed(for: chartID) == 1.0)
+            #expect(userDefaults.dictionary(forKey: "PracticeSettingsSpeedMultipliers") == nil)
         }
     }
 }

--- a/VirgoTests/PracticeSettingsServiceTests.swift
+++ b/VirgoTests/PracticeSettingsServiceTests.swift
@@ -24,6 +24,50 @@ struct PracticeSettingsServiceTests {
         return chart.persistentModelID
     }
 
+    private func makeLegacyPersistenceKey(for chartID: PersistentIdentifier) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let canonicalData = try encoder.encode(chartID)
+        guard let canonicalKey = String(data: canonicalData, encoding: .utf8) else {
+            throw NSError(domain: "PracticeSettingsServiceTests", code: 1)
+        }
+
+        return addWhitespaceOutsideStrings(to: canonicalKey)
+    }
+
+    private func addWhitespaceOutsideStrings(to json: String) -> String {
+        var result = ""
+        var inString = false
+        var isEscaping = false
+
+        for character in json {
+            if isEscaping {
+                result.append(character)
+                isEscaping = false
+                continue
+            }
+
+            if character == "\\" {
+                result.append(character)
+                isEscaping = true
+                continue
+            }
+
+            if character == "\"" {
+                result.append(character)
+                inString.toggle()
+                continue
+            }
+
+            result.append(character)
+            if !inString && (character == ":" || character == ",") {
+                result.append(" ")
+            }
+        }
+
+        return result
+    }
+
     // MARK: - Initialization Tests
 
     @Test("Service initializes with default speed of 1.0")
@@ -379,6 +423,26 @@ struct PracticeSettingsServiceTests {
             userDefaults.set([key: "1.25"], forKey: "PracticeSettingsSpeedMultipliers")
             let stringLoaded = PracticeSettingsService(userDefaults: userDefaults).loadSpeed(for: chartID)
             #expect(stringLoaded == 1.25)
+        }
+    }
+
+    @Test("loadSpeed reads legacy persistence keys and migrates them to canonical format")
+    func testLoadSpeedMigratesLegacyPersistenceKeys() async throws {
+        try await TestSetup.withTestSetup {
+            let (userDefaults, _) = TestUserDefaults.makeIsolated()
+            let chartID = try makeTestChartID()
+            let legacyKey = try makeLegacyPersistenceKey(for: chartID)
+
+            userDefaults.set([legacyKey: 0.8], forKey: "PracticeSettingsSpeedMultipliers")
+
+            let loadedSpeed = PracticeSettingsService(userDefaults: userDefaults).loadSpeed(for: chartID)
+            #expect(loadedSpeed == 0.8)
+
+            let persistedKeys = userDefaults.dictionary(forKey: "PracticeSettingsSpeedMultipliers").map {
+                Array($0.keys)
+            } ?? []
+            #expect(persistedKeys.contains(legacyKey) == false)
+            #expect(persistedKeys.count == 1)
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix `PracticeSettingsService` to use `JSONEncoder` with sorted keys for deterministic `PersistentIdentifier` encoding, preventing issues with non-deterministic UserDefaults key generation
- Add comprehensive test coverage for `DTXFileParser` edge cases and error handling (file URL parsing, missing required fields, malformed note lines, interval conversions)
- Add test coverage for `HighScoreService` NSNumber payload handling and malformed payload resilience
- Add test coverage for `PracticeSettingsService` value clamping, non-finite value handling, and session cache clearing
- Add new test files: `GameplayLayoutTests` and `LoggerTests`

## Changes
- Modified `Virgo/services/PracticeSettingsService.swift` to use a dedicated `JSONEncoder` with `.sortedKeys` formatting
- Modified multiple test files to add edge case and error handling coverage
- Created new test files for untested components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added backward-compatible persistence and automatic migration for saved high scores and practice settings to handle identifier changes and ensure data continuity.

* **Bug Fixes**
  * Improved resilience and validation around persisted values, handling malformed or out-of-range data more safely.

* **Tests**
  * Expanded test coverage for chart parsing, layout math, score and speed persistence, migration scenarios, and edge-case validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->