### PR TITLE
Fix negative elapsed time clamping in MetronomeTimingEngine

### DIFF
--- a/Virgo/utilities/MetronomeTimingEngine.swift
+++ b/Virgo/utilities/MetronomeTimingEngine.swift
@@ -286,7 +286,7 @@ class MetronomeTimingEngine: ObservableObject {
     /// Get current playback time - same time reference used for audio scheduling
     func getCurrentPlaybackTime() -> TimeInterval? {
         guard isPlaying else { return nil }
-        return CFAbsoluteTimeGetCurrent() - startTime
+        return max(0, CFAbsoluteTimeGetCurrent() - startTime)
     }
     
     /// Get precise beat progress for visual synchronization

--- a/VirgoTests/MetronomeEngineTests.swift
+++ b/VirgoTests/MetronomeEngineTests.swift
@@ -504,4 +504,71 @@ struct MetronomeTimingEngineTests {
 
         timingEngine.stop()
     }
+
+    @Test("MetronomeTimingEngine clamps playback time and beat progress before a future scheduled start")
+    func testFutureScheduledStartClampsNegativeElapsedTime() {
+        let timingEngine = MetronomeTimingEngine()
+        timingEngine.bpm = 120
+        timingEngine.timeSignature = .fourFour
+
+        let futureStartTime = CFAbsoluteTimeGetCurrent() + 5.0
+        timingEngine.startAtTime(startTime: futureStartTime, totalBeatsElapsed: 6)
+
+        let playbackTime = timingEngine.getCurrentPlaybackTime()
+        let progress = timingEngine.getCurrentBeatProgress(timeSignature: .fourFour)
+
+        #expect(playbackTime != nil)
+        #expect((playbackTime ?? -1) >= 0)
+        #expect(progress != nil)
+        #expect((progress?.totalBeats ?? -1) >= 0)
+        #expect((progress?.beatInMeasure ?? -1) >= 0)
+        #expect((progress?.beatInMeasure ?? 4) < 4)
+
+        timingEngine.stop()
+    }
+
+    @Test("MetronomeTimingEngine stop clears scheduled timing state")
+    func testStopClearsScheduledTimingState() {
+        let timingEngine = MetronomeTimingEngine()
+        timingEngine.bpm = 120
+        timingEngine.startAtTime(startTime: 100.0, totalBeatsElapsed: 3)
+
+        timingEngine.stop()
+
+        let beatOffset = timingEngineValue(timingEngine, label: "beatOffset", as: Int.self)
+        let beatOriginTime = timingEngineValue(timingEngine, label: "beatOriginTime", as: Double.self)
+        let storedStartTime = timingEngineValue(timingEngine, label: "startTime", as: Double.self)
+
+        #expect(timingEngine.isPlaying == false)
+        #expect(timingEngine.currentBeat == 1)
+        #expect(beatOffset == 0)
+        #expect(storedStartTime == 0)
+        #expect(beatOriginTime == 0)
+        #expect(timingEngine.getCurrentPlaybackTime() == nil)
+    }
+
+    @Test("MetronomeTimingEngine rebuilds timing origin after stop and reschedule")
+    func testRescheduleAfterStopRebuildsTimingOrigin() {
+        let timingEngine = MetronomeTimingEngine()
+        timingEngine.bpm = 120
+
+        timingEngine.startAtTime(startTime: 100.0, totalBeatsElapsed: 4)
+        timingEngine.stop()
+        timingEngine.startAtTime(startTime: 200.0, totalBeatsElapsed: 1)
+
+        let beatOffset = timingEngineValue(timingEngine, label: "beatOffset", as: Int.self)
+        let beatOriginTime = timingEngineValue(timingEngine, label: "beatOriginTime", as: Double.self)
+        let storedStartTime = timingEngineValue(timingEngine, label: "startTime", as: Double.self)
+
+        #expect(timingEngine.currentBeat == 2)
+        #expect(beatOffset == 1)
+        #expect(storedStartTime == 200.0)
+        if let beatOriginTime {
+            #expect(abs(beatOriginTime - 199.5) < 0.0001)
+        } else {
+            #expect(Bool(false), "Expected beatOriginTime to be rebuilt")
+        }
+
+        timingEngine.stop()
+    }
 }

--- a/VirgoTests/SwiftUIRenderingCoverageTests.swift
+++ b/VirgoTests/SwiftUIRenderingCoverageTests.swift
@@ -177,6 +177,140 @@ struct SwiftUIRenderingCoverageTests {
         }
     }
 
+    @Test("SessionResultsView renders a verified new high score state")
+    func testSessionResultsViewRenderingForNewRecord() async throws {
+        try await TestSetup.withTestSetup {
+            let view = SessionResultsView(
+                finalScore: 2450,
+                highScore: 2450,
+                isNewRecord: true,
+                scoreEngine: makeScoreEngineForResults(),
+                onPlayAgain: {},
+                onDone: {}
+            )
+
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 900, height: 900)
+            )
+        }
+    }
+
+    @Test("SessionResultsView renders non-record results without the badge path")
+    func testSessionResultsViewRenderingWithoutRecordBadge() async throws {
+        try await TestSetup.withTestSetup {
+            var scoreEngine = ScoreEngine()
+            scoreEngine.processHit(accuracy: .great, timingError: 12.0)
+            scoreEngine.processHit(accuracy: .miss)
+
+            let view = SessionResultsView(
+                finalScore: 80,
+                highScore: 900,
+                isNewRecord: false,
+                scoreEngine: scoreEngine,
+                onPlayAgain: {},
+                onDone: {}
+            )
+
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 900, height: 900)
+            )
+        }
+    }
+
+    @Test("ProfileView renders inside a navigation stack")
+    func testProfileViewRendering() async throws {
+        try await TestSetup.withTestSetup {
+            let view = NavigationStack {
+                ProfileView()
+            }
+
+            SwiftUITestUtilities.assertViewWithEnvironment(view)
+        }
+    }
+
+    @Test("InputSettingsView renders its default mapping state")
+    func testInputSettingsViewRendering() async throws {
+        try await TestSetup.withTestSetup {
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                InputSettingsView(),
+                size: CGSize(width: 1440, height: 1400)
+            )
+        }
+    }
+
+    @Test("InputSettingsView renders key capture overlay state")
+    func testInputSettingsViewRenderingWithCaptureOverlay() async throws {
+        try await TestSetup.withTestSetup {
+            var view = InputSettingsView()
+            view.startKeyCapture(for: .snare)
+
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 1440, height: 1400)
+            )
+        }
+    }
+
+    @Test("MetronomeView renders practice tips and settings layout")
+    func testMetronomeViewRendering() async throws {
+        try await TestSetup.withTestSetup {
+            let view = NavigationStack {
+                MetronomeView()
+            }
+            .environmentObject(MetronomeEngine(audioDriver: RecordingAudioDriver()))
+
+            SwiftUITestUtilities.assertViewWithEnvironment(view)
+        }
+    }
+
+    @Test("GameplayHeaderView renders score and transport controls")
+    func testGameplayHeaderViewRendering() async throws {
+        try await TestSetup.withTestSetup {
+            let chart = Chart(difficulty: .hard, level: 70)
+            let song = Song(
+                title: "Header Song",
+                artist: "Header Artist",
+                bpm: 160,
+                duration: "2:34",
+                genre: "Render Test",
+                charts: [chart]
+            )
+            chart.song = song
+            let track = DrumTrack(chart: chart)
+
+            let view = GameplayHeaderView(
+                track: track,
+                isPlaying: .constant(true),
+                viewModel: nil,
+                onDismiss: {},
+                onPlayPause: {},
+                onRestart: {}
+            )
+            .background(Color.black)
+
+            SwiftUITestUtilities.assertViewWithEnvironment(view, size: CGSize(width: 1280, height: 120))
+        }
+    }
+
+    @Test("DrumBeatView renders simultaneous beamed notes")
+    func testDrumBeatViewRendering() async throws {
+        try await TestSetup.withTestSetup {
+            let beat = DrumBeat(
+                id: 42,
+                drums: [.snare, .crash, .ride],
+                timePosition: 1.5,
+                interval: .eighth
+            )
+
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                DrumBeatView(beat: beat, isActive: true, row: 0, isBeamed: true),
+                size: CGSize(width: 240, height: 180)
+            )
+        }
+    }
+
     private func makeDownloadedSong(title: String) -> Song {
         let notes = [
             Note(interval: .quarter, noteType: .bass, measureNumber: 1, measureOffset: 0.0),
@@ -231,5 +365,14 @@ struct SwiftUIRenderingCoverageTests {
 
         charts.forEach { $0.serverSong = song }
         return song
+    }
+
+    private func makeScoreEngineForResults() -> ScoreEngine {
+        var engine = ScoreEngine()
+        for _ in 0..<15 { engine.processHit(accuracy: .perfect, timingError: -8.0) }
+        for _ in 0..<5 { engine.processHit(accuracy: .great, timingError: 15.0) }
+        for _ in 0..<2 { engine.processHit(accuracy: .good, timingError: 45.0) }
+        for _ in 0..<3 { engine.processHit(accuracy: .miss) }
+        return engine
     }
 }


### PR DESCRIPTION
## Summary
- Fixed `MetronomeTimingEngine.getCurrentPlaybackTime()` to clamp negative elapsed time when start time is in the future
- Added comprehensive test coverage for timing edge cases, including future scheduled starts and state cleanup after stop
- Enhanced UI rendering test coverage for SessionResultsView (record/non-record states), ProfileView, InputSettingsView, MetronomeView, GameplayHeaderView, and DrumBeatView

## Changes
- `MetronomeTimingEngine.swift`: Use `max(0, ...)` to ensure playback time never goes negative
- `MetronomeEngineTests.swift`: 3 new tests covering negative elapsed time, state cleanup, and reschedule behavior
- `SwiftUIRenderingCoverageTests.swift`: 8 new rendering tests for previously uncovered views

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed playback time calculations to prevent negative elapsed durations, ensuring the metronome timing engine displays accurate playback progress.

* **Tests**
  * Expanded test coverage for metronome timing engine state management and UI rendering across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->