### PR TITLE
test: stabilize gameplay render coverage

### DIFF
--- a/Virgo/VirgoApp.swift
+++ b/Virgo/VirgoApp.swift
@@ -39,11 +39,7 @@ struct VirgoApp: App {
     }()
 
     init() {
-        if ProcessInfo.processInfo.arguments.contains(LaunchArguments.uiTesting) {
-            #if canImport(UIKit)
-            UIView.setAnimationsEnabled(false)
-            #endif
-        }
+        VirgoAppLaunchBehavior.applyLaunchBehavior(arguments: ProcessInfo.processInfo.arguments)
     }
 
     var body: some Scene {

--- a/Virgo/VirgoApp.swift
+++ b/Virgo/VirgoApp.swift
@@ -39,7 +39,11 @@ struct VirgoApp: App {
     }()
 
     init() {
-        VirgoAppLaunchBehavior.applyLaunchBehavior(arguments: ProcessInfo.processInfo.arguments)
+        #if canImport(UIKit)
+        if VirgoAppLaunchBehavior.shouldDisableAnimations(arguments: ProcessInfo.processInfo.arguments) {
+            UIView.setAnimationsEnabled(false)
+        }
+        #endif
     }
 
     var body: some Scene {

--- a/Virgo/VirgoApp.swift
+++ b/Virgo/VirgoApp.swift
@@ -39,11 +39,11 @@ struct VirgoApp: App {
     }()
 
     init() {
-        #if canImport(UIKit)
         if VirgoAppLaunchBehavior.shouldDisableAnimations(arguments: ProcessInfo.processInfo.arguments) {
+            #if canImport(UIKit)
             UIView.setAnimationsEnabled(false)
+            #endif
         }
-        #endif
     }
 
     var body: some Scene {

--- a/Virgo/utilities/ContentStartupPolicy.swift
+++ b/Virgo/utilities/ContentStartupPolicy.swift
@@ -1,0 +1,44 @@
+//
+//  ContentStartupPolicy.swift
+//  Virgo
+//
+//  Startup decision helpers for ContentView.
+//
+
+import Foundation
+
+/// The action ContentView should take at startup based on launch arguments and data state.
+enum ContentStartupAction: Equatable {
+    /// Delete all existing songs then seed fresh fixture data.
+    case clearAndSeed
+    /// Delete all existing songs without seeding.
+    case clearOnly
+    /// Seed only the missing fixture songs (non-destructive).
+    case seedIfNeeded
+    /// No startup data manipulation needed.
+    case noAction
+}
+
+/// Pure decision helpers for ContentView startup logic.
+enum ContentStartupPolicy {
+
+    /// Determines which startup action to perform based on launch arguments and missing fixture data.
+    static func startupAction(arguments: [String], missingFixtureTitles: Set<String>) -> ContentStartupAction {
+        guard arguments.contains(LaunchArguments.uiTesting) else { return .noAction }
+
+        if arguments.contains(LaunchArguments.resetState) {
+            return arguments.contains(LaunchArguments.skipSeed) ? .clearOnly : .clearAndSeed
+        }
+
+        if !arguments.contains(LaunchArguments.skipSeed) && !missingFixtureTitles.isEmpty {
+            return .seedIfNeeded
+        }
+
+        return .noAction
+    }
+
+    /// Returns true when the song should use `AudioPlaybackService` (preview-file-backed playback).
+    static func shouldUsePreviewPlayer(for song: Song) -> Bool {
+        song.genre == "DTX Import" && song.previewFilePath != nil
+    }
+}

--- a/Virgo/utilities/VirgoAppLaunchBehavior.swift
+++ b/Virgo/utilities/VirgoAppLaunchBehavior.swift
@@ -18,12 +18,4 @@ enum VirgoAppLaunchBehavior {
         arguments.contains(LaunchArguments.uiTesting)
     }
 
-    /// Applies animation suppression when appropriate. Call once in `VirgoApp.init()`.
-    static func applyLaunchBehavior(arguments: [String]) {
-        #if canImport(UIKit)
-        if shouldDisableAnimations(arguments: arguments) {
-            UIView.setAnimationsEnabled(false)
-        }
-        #endif
-    }
 }

--- a/Virgo/utilities/VirgoAppLaunchBehavior.swift
+++ b/Virgo/utilities/VirgoAppLaunchBehavior.swift
@@ -1,0 +1,29 @@
+//
+//  VirgoAppLaunchBehavior.swift
+//  Virgo
+//
+//  App-level launch behaviour helpers.
+//
+
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Pure helpers for VirgoApp startup decisions.
+enum VirgoAppLaunchBehavior {
+
+    /// Returns true when UI animations should be disabled (UI testing mode).
+    static func shouldDisableAnimations(arguments: [String]) -> Bool {
+        arguments.contains(LaunchArguments.uiTesting)
+    }
+
+    /// Applies animation suppression when appropriate. Call once in `VirgoApp.init()`.
+    static func applyLaunchBehavior(arguments: [String]) {
+        #if canImport(UIKit)
+        if shouldDisableAnimations(arguments: arguments) {
+            UIView.setAnimationsEnabled(false)
+        }
+        #endif
+    }
+}

--- a/Virgo/utilities/VirgoAppLaunchBehavior.swift
+++ b/Virgo/utilities/VirgoAppLaunchBehavior.swift
@@ -6,9 +6,6 @@
 //
 
 import Foundation
-#if canImport(UIKit)
-import UIKit
-#endif
 
 /// Pure helpers for VirgoApp startup decisions.
 enum VirgoAppLaunchBehavior {

--- a/Virgo/views/ContentView.swift
+++ b/Virgo/views/ContentView.swift
@@ -104,9 +104,14 @@ struct ContentView: View {
         .tint(.purple)
         .onAppear {
             let args = ProcessInfo.processInfo.arguments
-            let fixtureTitles = Set(Song.sampleData.map { $0.title })
-            let existingTitles = Set(allSongs.map { $0.title })
-            let missingFixtures = fixtureTitles.subtracting(existingTitles)
+            let missingFixtures: Set<String>
+            if args.contains(LaunchArguments.uiTesting) {
+                let fixtureTitles = Set(Song.sampleData.map { $0.title })
+                let existingTitles = Set(allSongs.map { $0.title })
+                missingFixtures = fixtureTitles.subtracting(existingTitles)
+            } else {
+                missingFixtures = []
+            }
 
             switch ContentStartupPolicy.startupAction(arguments: args, missingFixtureTitles: missingFixtures) {
             case .clearAndSeed:

--- a/Virgo/views/ContentView.swift
+++ b/Virgo/views/ContentView.swift
@@ -24,20 +24,6 @@ struct ContentView: View {
 
     @State private var databaseService: DatabaseMaintenanceService?
 
-    /// Detects if the app is running in UI testing mode.
-    /// Uses the LaunchArguments.uiTesting launch argument to distinguish from unit tests.
-    private var isUITesting: Bool {
-        ProcessInfo.processInfo.arguments.contains(LaunchArguments.uiTesting)
-    }
-
-    private var shouldResetState: Bool {
-        ProcessInfo.processInfo.arguments.contains(LaunchArguments.resetState)
-    }
-
-    private var shouldSkipSeed: Bool {
-        ProcessInfo.processInfo.arguments.contains(LaunchArguments.skipSeed)
-    }
-
     var body: some View {
         TabView(selection: $selectedTab) {
             // Songs Tab with Sub-tabs
@@ -52,8 +38,7 @@ struct ContentView: View {
                 navigateToGameplay: $navigateToGameplay,
                 audioPlaybackService: audioPlaybackService,
                 onPlayTap: { song in
-                    // Use AudioPlaybackService for downloaded songs with preview files
-                    if song.genre == "DTX Import" && song.previewFilePath != nil {
+                    if ContentStartupPolicy.shouldUsePreviewPlayer(for: song) {
                         audioPlaybackService.togglePlayback(for: song)
                     } else {
                         playbackService.togglePlayback(for: song)
@@ -118,16 +103,21 @@ struct ContentView: View {
         }
         .tint(.purple)
         .onAppear {
-            if isUITesting && shouldResetState {
+            let args = ProcessInfo.processInfo.arguments
+            let fixtureTitles = Set(Song.sampleData.map { $0.title })
+            let existingTitles = Set(allSongs.map { $0.title })
+            let missingFixtures = fixtureTitles.subtracting(existingTitles)
+
+            switch ContentStartupPolicy.startupAction(arguments: args, missingFixtureTitles: missingFixtures) {
+            case .clearAndSeed:
                 clearPersistedTestState()
-                // When resetting state in UI testing mode, unconditionally seed fresh data
-                // to avoid stale data issues from @Query not refreshing synchronously
-                // Skip seeding if -SkipSeed flag is present (for empty-state tests)
-                if !shouldSkipSeed {
-                    seedUITestData()
-                }
-            } else if isUITesting && !shouldSkipSeed {
-                seedUITestDataIfNeeded()
+                seedUITestData()
+            case .clearOnly:
+                clearPersistedTestState()
+            case .seedIfNeeded:
+                seedUITestData(missingFixtures: missingFixtures)
+            case .noAction:
+                break
             }
             if databaseService == nil {
                 databaseService = DatabaseMaintenanceService(modelContext: modelContext)
@@ -159,20 +149,6 @@ struct ContentView: View {
         }
     }
 
-    private func seedUITestDataIfNeeded() {
-        // Check for specific fixture songs rather than just isEmpty
-        // This ensures UI tests always have the expected data even if
-        // the simulator/device has songs from previous runs
-        let fixtureTitles = Set(Song.sampleData.map { $0.title })
-        let existingTitles = Set(allSongs.map { $0.title })
-        let missingFixtures = fixtureTitles.subtracting(existingTitles)
-
-        guard !missingFixtures.isEmpty else { return }
-
-        seedUITestData(missingFixtures: missingFixtures)
-    }
-
-    /// Unconditionally seeds all UI test data. Used after reset to ensure fresh data.
     private func seedUITestData(missingFixtures: Set<String>? = nil) {
         let fixturesToSeed = missingFixtures ?? Set(Song.sampleData.map { $0.title })
         let sampleSongs = Song.sampleData.filter { fixturesToSeed.contains($0.title) }

--- a/Virgo/views/GameplayView.swift
+++ b/Virgo/views/GameplayView.swift
@@ -24,10 +24,11 @@ struct GameplayView: View {
     /// Cached fallback track to avoid constructing a new DrumTrack on every render
     @State private var cachedFallbackTrack: DrumTrack
 
-    init(chart: Chart, metronome: MetronomeEngine) {
+    init(chart: Chart, metronome: MetronomeEngine, initialViewModel: GameplayViewModel? = nil) {
         self.chart = chart
         self.metronome = metronome
         self._cachedFallbackTrack = State(initialValue: DrumTrack(chart: chart))
+        self._viewModel = State(initialValue: initialViewModel)
     }
 
     /// Creates a binding for isPlaying when viewModel exists, or returns a constant false binding

--- a/Virgo/views/GameplayView.swift
+++ b/Virgo/views/GameplayView.swift
@@ -17,6 +17,7 @@ struct GameplayView: View {
 
     let chart: Chart
     let metronome: MetronomeEngine
+    private let usesInjectedViewModel: Bool
 
     // MARK: - ViewModel
     /// Consolidated state management - initialized lazily with environment dependencies
@@ -27,6 +28,7 @@ struct GameplayView: View {
     init(chart: Chart, metronome: MetronomeEngine, initialViewModel: GameplayViewModel? = nil) {
         self.chart = chart
         self.metronome = metronome
+        self.usesInjectedViewModel = initialViewModel != nil
         self._cachedFallbackTrack = State(initialValue: DrumTrack(chart: chart))
         self._viewModel = State(initialValue: initialViewModel)
     }
@@ -70,6 +72,9 @@ struct GameplayView: View {
         .background(Color.black)
         .foregroundColor(.white)
         .task {
+            if usesInjectedViewModel {
+                return
+            }
             // Reset speed to default before creating ViewModel to prevent stale speed from previous chart
             practiceSettings.resetSpeed()
             // Initialize viewModel with environment dependencies

--- a/VirgoTests/AppShellCoverageTests.swift
+++ b/VirgoTests/AppShellCoverageTests.swift
@@ -7,8 +7,7 @@ import Testing
 import Foundation
 @testable import Virgo
 
-@Suite("App Shell Coverage Tests", .serialized)
-@MainActor
+@Suite("App Shell Coverage Tests")
 struct AppShellCoverageTests {
 
     // MARK: - ContentStartupPolicy.startupAction

--- a/VirgoTests/AppShellCoverageTests.swift
+++ b/VirgoTests/AppShellCoverageTests.swift
@@ -123,4 +123,12 @@ struct AppShellCoverageTests {
         let result = VirgoAppLaunchBehavior.shouldDisableAnimations(arguments: [])
         #expect(result == false)
     }
+
+    @Test("shouldDisableAnimations returns false when arguments lack uiTesting flag")
+    func testShouldDisableAnimationsFalseForOtherArguments() {
+        let result = VirgoAppLaunchBehavior.shouldDisableAnimations(
+            arguments: [LaunchArguments.resetState]
+        )
+        #expect(result == false)
+    }
 }

--- a/VirgoTests/AppShellCoverageTests.swift
+++ b/VirgoTests/AppShellCoverageTests.swift
@@ -13,7 +13,8 @@ struct AppShellCoverageTests {
 
     // MARK: - ContentStartupPolicy.startupAction
 
-    @Test func testStartupActionClearAndSeed() {
+    @Test("startupAction returns clearAndSeed when uiTesting+resetState with no missing fixtures")
+    func testStartupActionClearAndSeed() {
         let action = ContentStartupPolicy.startupAction(
             arguments: [LaunchArguments.uiTesting, LaunchArguments.resetState],
             missingFixtureTitles: []
@@ -21,7 +22,8 @@ struct AppShellCoverageTests {
         #expect(action == .clearAndSeed)
     }
 
-    @Test func testStartupActionClearOnly() {
+    @Test("startupAction returns clearOnly when uiTesting+resetState+skipSeed")
+    func testStartupActionClearOnly() {
         let action = ContentStartupPolicy.startupAction(
             arguments: [LaunchArguments.uiTesting, LaunchArguments.resetState, LaunchArguments.skipSeed],
             missingFixtureTitles: []
@@ -29,7 +31,8 @@ struct AppShellCoverageTests {
         #expect(action == .clearOnly)
     }
 
-    @Test func testStartupActionSeedIfNeeded() {
+    @Test("startupAction returns seedIfNeeded when uiTesting and missing fixtures present")
+    func testStartupActionSeedIfNeeded() {
         let action = ContentStartupPolicy.startupAction(
             arguments: [LaunchArguments.uiTesting],
             missingFixtureTitles: ["Thunder Beat"]
@@ -37,7 +40,8 @@ struct AppShellCoverageTests {
         #expect(action == .seedIfNeeded)
     }
 
-    @Test func testStartupActionNoActionWhenNotUITesting() {
+    @Test("startupAction returns noAction when not in UI testing mode")
+    func testStartupActionNoActionWhenNotUITesting() {
         let action = ContentStartupPolicy.startupAction(
             arguments: [],
             missingFixtureTitles: ["Thunder Beat"]
@@ -45,7 +49,8 @@ struct AppShellCoverageTests {
         #expect(action == .noAction)
     }
 
-    @Test func testStartupActionNoActionWhenSkipSeedAndNoReset() {
+    @Test("startupAction returns noAction when skipSeed set without resetState")
+    func testStartupActionNoActionWhenSkipSeedAndNoReset() {
         let action = ContentStartupPolicy.startupAction(
             arguments: [LaunchArguments.uiTesting, LaunchArguments.skipSeed],
             missingFixtureTitles: ["Thunder Beat"]
@@ -53,7 +58,8 @@ struct AppShellCoverageTests {
         #expect(action == .noAction)
     }
 
-    @Test func testStartupActionNoActionWhenNoMissingFixtures() {
+    @Test("startupAction returns noAction when uiTesting but no missing fixtures")
+    func testStartupActionNoActionWhenNoMissingFixtures() {
         let action = ContentStartupPolicy.startupAction(
             arguments: [LaunchArguments.uiTesting],
             missingFixtureTitles: []
@@ -63,7 +69,8 @@ struct AppShellCoverageTests {
 
     // MARK: - ContentStartupPolicy.shouldUsePreviewPlayer
 
-    @Test func testShouldUsePreviewPlayerTrueForDTXImportWithPreview() {
+    @Test("shouldUsePreviewPlayer returns true for DTX Import genre with preview file")
+    func testShouldUsePreviewPlayerTrueForDTXImportWithPreview() {
         let song = Song(
             title: "Test Song",
             artist: "Artist",
@@ -76,7 +83,8 @@ struct AppShellCoverageTests {
         #expect(ContentStartupPolicy.shouldUsePreviewPlayer(for: song) == true)
     }
 
-    @Test func testShouldUsePreviewPlayerFalseForNonDTXImport() {
+    @Test("shouldUsePreviewPlayer returns false for non-DTX Import genre")
+    func testShouldUsePreviewPlayerFalseForNonDTXImport() {
         let song = Song(
             title: "Rock Song",
             artist: "Artist",
@@ -88,7 +96,8 @@ struct AppShellCoverageTests {
         #expect(ContentStartupPolicy.shouldUsePreviewPlayer(for: song) == false)
     }
 
-    @Test func testShouldUsePreviewPlayerFalseForDTXImportWithoutPreview() {
+    @Test("shouldUsePreviewPlayer returns false for DTX Import genre without preview file")
+    func testShouldUsePreviewPlayerFalseForDTXImportWithoutPreview() {
         let song = Song(
             title: "Test Song",
             artist: "Artist",
@@ -102,14 +111,16 @@ struct AppShellCoverageTests {
 
     // MARK: - VirgoAppLaunchBehavior.shouldDisableAnimations
 
-    @Test func testShouldDisableAnimationsTrueForUITesting() {
+    @Test("shouldDisableAnimations returns true when uiTesting argument present")
+    func testShouldDisableAnimationsTrueForUITesting() {
         let result = VirgoAppLaunchBehavior.shouldDisableAnimations(
             arguments: [LaunchArguments.uiTesting]
         )
         #expect(result == true)
     }
 
-    @Test func testShouldDisableAnimationsFalseForEmptyArguments() {
+    @Test("shouldDisableAnimations returns false when arguments are empty")
+    func testShouldDisableAnimationsFalseForEmptyArguments() {
         let result = VirgoAppLaunchBehavior.shouldDisableAnimations(arguments: [])
         #expect(result == false)
     }

--- a/VirgoTests/AppShellCoverageTests.swift
+++ b/VirgoTests/AppShellCoverageTests.swift
@@ -1,0 +1,116 @@
+//
+//  AppShellCoverageTests.swift
+//  VirgoTests
+//
+
+import Testing
+import Foundation
+@testable import Virgo
+
+@Suite("App Shell Coverage Tests", .serialized)
+@MainActor
+struct AppShellCoverageTests {
+
+    // MARK: - ContentStartupPolicy.startupAction
+
+    @Test func testStartupActionClearAndSeed() {
+        let action = ContentStartupPolicy.startupAction(
+            arguments: [LaunchArguments.uiTesting, LaunchArguments.resetState],
+            missingFixtureTitles: []
+        )
+        #expect(action == .clearAndSeed)
+    }
+
+    @Test func testStartupActionClearOnly() {
+        let action = ContentStartupPolicy.startupAction(
+            arguments: [LaunchArguments.uiTesting, LaunchArguments.resetState, LaunchArguments.skipSeed],
+            missingFixtureTitles: []
+        )
+        #expect(action == .clearOnly)
+    }
+
+    @Test func testStartupActionSeedIfNeeded() {
+        let action = ContentStartupPolicy.startupAction(
+            arguments: [LaunchArguments.uiTesting],
+            missingFixtureTitles: ["Thunder Beat"]
+        )
+        #expect(action == .seedIfNeeded)
+    }
+
+    @Test func testStartupActionNoActionWhenNotUITesting() {
+        let action = ContentStartupPolicy.startupAction(
+            arguments: [],
+            missingFixtureTitles: ["Thunder Beat"]
+        )
+        #expect(action == .noAction)
+    }
+
+    @Test func testStartupActionNoActionWhenSkipSeedAndNoReset() {
+        let action = ContentStartupPolicy.startupAction(
+            arguments: [LaunchArguments.uiTesting, LaunchArguments.skipSeed],
+            missingFixtureTitles: ["Thunder Beat"]
+        )
+        #expect(action == .noAction)
+    }
+
+    @Test func testStartupActionNoActionWhenNoMissingFixtures() {
+        let action = ContentStartupPolicy.startupAction(
+            arguments: [LaunchArguments.uiTesting],
+            missingFixtureTitles: []
+        )
+        #expect(action == .noAction)
+    }
+
+    // MARK: - ContentStartupPolicy.shouldUsePreviewPlayer
+
+    @Test func testShouldUsePreviewPlayerTrueForDTXImportWithPreview() {
+        let song = Song(
+            title: "Test Song",
+            artist: "Artist",
+            bpm: 120,
+            duration: "3:00",
+            genre: "DTX Import",
+            timeSignature: .fourFour
+        )
+        song.previewFilePath = "/some/preview.mp3"
+        #expect(ContentStartupPolicy.shouldUsePreviewPlayer(for: song) == true)
+    }
+
+    @Test func testShouldUsePreviewPlayerFalseForNonDTXImport() {
+        let song = Song(
+            title: "Rock Song",
+            artist: "Artist",
+            bpm: 140,
+            duration: "3:30",
+            genre: "Rock",
+            timeSignature: .fourFour
+        )
+        #expect(ContentStartupPolicy.shouldUsePreviewPlayer(for: song) == false)
+    }
+
+    @Test func testShouldUsePreviewPlayerFalseForDTXImportWithoutPreview() {
+        let song = Song(
+            title: "Test Song",
+            artist: "Artist",
+            bpm: 120,
+            duration: "3:00",
+            genre: "DTX Import",
+            timeSignature: .fourFour
+        )
+        #expect(ContentStartupPolicy.shouldUsePreviewPlayer(for: song) == false)
+    }
+
+    // MARK: - VirgoAppLaunchBehavior.shouldDisableAnimations
+
+    @Test func testShouldDisableAnimationsTrueForUITesting() {
+        let result = VirgoAppLaunchBehavior.shouldDisableAnimations(
+            arguments: [LaunchArguments.uiTesting]
+        )
+        #expect(result == true)
+    }
+
+    @Test func testShouldDisableAnimationsFalseForEmptyArguments() {
+        let result = VirgoAppLaunchBehavior.shouldDisableAnimations(arguments: [])
+        #expect(result == false)
+    }
+}

--- a/VirgoTests/GameplayRenderCoverageTests.swift
+++ b/VirgoTests/GameplayRenderCoverageTests.swift
@@ -18,6 +18,16 @@ import Foundation
 @MainActor
 struct GameplayRenderCoverageTests {
 
+    // MARK: - Fixtures
+
+    /// Returns a standard pair of eighth-note beats used across beam-related tests.
+    private static func makeEighthNotePair() -> [DrumBeat] {
+        [
+            DrumBeat(id: 0, drums: [.kick], timePosition: 0.0, interval: .eighth),
+            DrumBeat(id: 1, drums: [.snare], timePosition: 0.25, interval: .eighth)
+        ]
+    }
+
     // MARK: - Loading-state render path
 
     /// Mounts `GameplayView(chart:metronome:)` without an initial view model.
@@ -122,10 +132,7 @@ struct GameplayRenderCoverageTests {
     @Test("BeamGroupView renders its BeamView children for an eighth-note group")
     func testBeamGroupView_renders() async throws {
         try await TestSetup.withTestSetup {
-            let beats = [
-                DrumBeat(id: 0, drums: [.kick],  timePosition: 0.0,  interval: .eighth),
-                DrumBeat(id: 1, drums: [.snare], timePosition: 0.25, interval: .eighth)
-            ]
+            let beats = Self.makeEighthNotePair()
             let beamGroup = BeamGroup(id: "bg1", beats: beats)
             let positions = GameplayLayout.calculateMeasurePositions(
                 totalMeasures: 1, timeSignature: .fourFour
@@ -151,10 +158,7 @@ struct GameplayRenderCoverageTests {
     @Test("BeamView renders a beam line when two beats share the same row")
     func testBeamView_sameRow_renders() async throws {
         try await TestSetup.withTestSetup {
-            let beats = [
-                DrumBeat(id: 0, drums: [.kick],  timePosition: 0.0,  interval: .eighth),
-                DrumBeat(id: 1, drums: [.snare], timePosition: 0.25, interval: .eighth)
-            ]
+            let beats = Self.makeEighthNotePair()
             let positions = GameplayLayout.calculateMeasurePositions(
                 totalMeasures: 1, timeSignature: .fourFour
             )
@@ -179,10 +183,7 @@ struct GameplayRenderCoverageTests {
     @Test("BeamView renders EmptyView when fewer than two beats pass the beamLevel filter")
     func testBeamView_fewerThanTwoBeats_doesNotRender() async throws {
         try await TestSetup.withTestSetup {
-            let beats = [
-                DrumBeat(id: 0, drums: [.kick],  timePosition: 0.0,  interval: .eighth),
-                DrumBeat(id: 1, drums: [.snare], timePosition: 0.25, interval: .eighth)
-            ]
+            let beats = Self.makeEighthNotePair()
             let positions = GameplayLayout.calculateMeasurePositions(
                 totalMeasures: 1, timeSignature: .fourFour
             )
@@ -214,7 +215,7 @@ struct GameplayRenderCoverageTests {
             #expect(positions[3].row == 1, "Measure 3 must remain on row 1 for the row-mismatch fixture")
 
             // timePosition 2.0 → measureIndex 2 (row 0); 3.0 → measureIndex 3 (row 1).
-            let beatRow0 = DrumBeat(id: 0, drums: [.kick],  timePosition: 2.0, interval: .eighth)
+            let beatRow0 = DrumBeat(id: 0, drums: [.kick], timePosition: 2.0, interval: .eighth)
             let beatRow1 = DrumBeat(id: 1, drums: [.snare], timePosition: 3.0, interval: .eighth)
 
             let view = BeamView(

--- a/VirgoTests/GameplayRenderCoverageTests.swift
+++ b/VirgoTests/GameplayRenderCoverageTests.swift
@@ -48,7 +48,6 @@ struct GameplayRenderCoverageTests {
     func testGameplayView_withPreparedViewModel_rendersPopulatedState() async throws {
         try await TestSetup.withTestSetup {
             let vm = await GameplayViewModelCoverageTestSupport.makePreparedViewModel()
-            let settings = GameplayViewModelCoverageTestSupport.makeSettings()
 
             // Verify the view model was fully prepared before mounting.
             #expect(vm.isDataLoaded, "makePreparedViewModel must call loadChartData()")
@@ -56,7 +55,7 @@ struct GameplayRenderCoverageTests {
             #expect(vm.staticStaffLinesView != nil, "makePreparedViewModel must build staticStaffLinesView via setupGameplay()")
 
             let view = GameplayView(chart: vm.chart, metronome: vm.metronome, initialViewModel: vm)
-                .environmentObject(settings)
+                .environmentObject(vm.practiceSettings)
 
             // Mounting with a non-nil viewModel exercises the populated notation branch.
             SwiftUITestUtilities.assertViewWithEnvironment(

--- a/VirgoTests/GameplayRenderCoverageTests.swift
+++ b/VirgoTests/GameplayRenderCoverageTests.swift
@@ -2,9 +2,11 @@
 //  GameplayRenderCoverageTests.swift
 //  VirgoTests
 //
-//  Render-path coverage for GameplayView's two principal visual branches:
+//  Render-path coverage for GameplayView's principal visual branches:
 //  1. Loading state (viewModel == nil) — exercised on first layout pass.
 //  2. Populated state (viewModel != nil) — exercised via the injection seam.
+//  3. Sub-view branches: StaffLinesBackgroundView, BeamView/BeamGroupView,
+//     controlsView placeholder/loaded, DrumClefSymbol, TimeSignatureSymbol.
 //
 
 import Testing
@@ -61,6 +63,228 @@ struct GameplayRenderCoverageTests {
             SwiftUITestUtilities.assertViewWithEnvironment(
                 view,
                 size: CGSize(width: 1280, height: 900)
+            )
+        }
+    }
+
+    // MARK: - Dynamic staff lines fallback (staticStaffLinesPresent: false)
+
+    /// Passes `staticStaffLinesPresent: false` so `viewModel.staticStaffLinesView` is nil,
+    /// exercising the else-branch in `sheetMusicView` that falls back to `staffLinesView(...)`.
+    @Test("GameplayView renders dynamic staff lines when staticStaffLinesView is nil")
+    func testGameplayView_dynamicStaffLinesFallback() async throws {
+        try await TestSetup.withTestSetup {
+            let vm = await GameplayViewModelCoverageTestSupport.makePreparedViewModel(staticStaffLinesPresent: false)
+            #expect(vm.staticStaffLinesView == nil, "Fixture must clear staticStaffLinesView")
+
+            let view = GameplayView(chart: vm.chart, metronome: vm.metronome, initialViewModel: vm)
+                .environmentObject(vm.practiceSettings)
+
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 1280, height: 900)
+            )
+        }
+    }
+
+    // MARK: - controlsView branches
+
+    /// Mounts `GameplayView` without a viewModel, causing `controlsView` to show the
+    /// placeholder `Color.black.frame(height: 100)` branch.
+    @Test("GameplayView controlsView shows placeholder when viewModel is nil")
+    func testGameplayView_controlsPlaceholder_rendersWhenNoViewModel() async throws {
+        try await TestSetup.withTestSetup {
+            let chart = GameplayViewModelCoverageTestSupport.makeChart()
+            let metronome = GameplayViewModelCoverageTestSupport.makeMetronome()
+            let settings = GameplayViewModelCoverageTestSupport.makeSettings()
+
+            let view = GameplayView(chart: chart, metronome: metronome)
+                .environmentObject(settings)
+
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 1280, height: 900)
+            )
+        }
+    }
+
+    /// Mounts `GameplayView` with a populated viewModel, causing `controlsView` to render
+    /// the full `GameplayControlsView` branch.
+    @Test("GameplayView controlsView shows loaded controls when viewModel is populated")
+    func testGameplayView_controlsLoaded_rendersWhenViewModelPresent() async throws {
+        try await TestSetup.withTestSetup {
+            let vm = await GameplayViewModelCoverageTestSupport.makePreparedViewModel()
+
+            let view = GameplayView(chart: vm.chart, metronome: vm.metronome, initialViewModel: vm)
+                .environmentObject(vm.practiceSettings)
+
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 1280, height: 900)
+            )
+        }
+    }
+
+    // MARK: - StaffLinesBackgroundView
+
+    /// Creates a `StaffLinesBackgroundView` whose `measurePositions` span multiple rows,
+    /// ensuring the `ForEach(rows, …)` iteration in `body` visits more than one row.
+    @Test("StaffLinesBackgroundView renders staff lines across multiple rows")
+    func testStaffLinesBackgroundView_multipleRows() async throws {
+        try await TestSetup.withTestSetup {
+            // 4 four-four measures wraps at measure index 3 → rows 0 and 1 are present.
+            let positions = GameplayLayout.calculateMeasurePositions(
+                totalMeasures: 4, timeSignature: .fourFour
+            )
+            let rows = Set(positions.map { $0.row })
+            #expect(rows.count >= 2, "Fixture must produce at least 2 rows")
+
+            let view = StaffLinesBackgroundView(measurePositions: positions)
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 1280, height: 900)
+            )
+        }
+    }
+
+    // MARK: - BeamGroupView
+
+    /// Renders a `BeamGroupView` whose `beats` are eighth notes in the same measure.
+    /// The `body` iterates `beamCount` times and builds a child `BeamView` for each.
+    @Test("BeamGroupView renders its BeamView children for an eighth-note group")
+    func testBeamGroupView_renders() async throws {
+        try await TestSetup.withTestSetup {
+            let beats = [
+                DrumBeat(id: 0, drums: [.kick],  timePosition: 0.0,  interval: .eighth),
+                DrumBeat(id: 1, drums: [.snare], timePosition: 0.25, interval: .eighth)
+            ]
+            let beamGroup = BeamGroup(id: "bg1", beats: beats)
+            let positions = GameplayLayout.calculateMeasurePositions(
+                totalMeasures: 1, timeSignature: .fourFour
+            )
+
+            let view = BeamGroupView(
+                beamGroup: beamGroup,
+                measurePositions: positions,
+                timeSignature: .fourFour,
+                isActive: false
+            )
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 1280, height: 900)
+            )
+        }
+    }
+
+    // MARK: - BeamView branches
+
+    /// Two eighth-note beats in measure 0 (same row) → `beamedBeats.count >= 2` and
+    /// `firstMeasurePos.row == lastMeasurePos.row` → the `Path` rendering branch executes.
+    @Test("BeamView renders a beam line when two beats share the same row")
+    func testBeamView_sameRow_renders() async throws {
+        try await TestSetup.withTestSetup {
+            let beats = [
+                DrumBeat(id: 0, drums: [.kick],  timePosition: 0.0,  interval: .eighth),
+                DrumBeat(id: 1, drums: [.snare], timePosition: 0.25, interval: .eighth)
+            ]
+            let positions = GameplayLayout.calculateMeasurePositions(
+                totalMeasures: 1, timeSignature: .fourFour
+            )
+            #expect(positions[0].row == 0, "Single-measure fixture must be in row 0")
+
+            let view = BeamView(
+                beats: beats,
+                beamLevel: 0,
+                measurePositions: positions,
+                timeSignature: .fourFour,
+                isActive: false
+            )
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 1280, height: 900)
+            )
+        }
+    }
+
+    /// `beamLevel = 1` with eighth notes (flagCount = 1): `1 > 1` is false for every beat,
+    /// so `beamedBeats` is empty → the `count < 2` guard fires → `EmptyView()` branch.
+    @Test("BeamView renders EmptyView when fewer than two beats pass the beamLevel filter")
+    func testBeamView_fewerThanTwoBeats_doesNotRender() async throws {
+        try await TestSetup.withTestSetup {
+            let beats = [
+                DrumBeat(id: 0, drums: [.kick],  timePosition: 0.0,  interval: .eighth),
+                DrumBeat(id: 1, drums: [.snare], timePosition: 0.25, interval: .eighth)
+            ]
+            let positions = GameplayLayout.calculateMeasurePositions(
+                totalMeasures: 1, timeSignature: .fourFour
+            )
+            // beamLevel 1 requires flagCount > 1; eighth notes have flagCount == 1, so none pass.
+            let view = BeamView(
+                beats: beats,
+                beamLevel: 1,
+                measurePositions: positions,
+                timeSignature: .fourFour,
+                isActive: false
+            )
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 1280, height: 900)
+            )
+        }
+    }
+
+    /// Measures 2 and 3 are in different rows when `totalMeasures == 4`.
+    /// `firstMeasurePos.row != lastMeasurePos.row` → the row-mismatch `EmptyView()` branch.
+    @Test("BeamView renders EmptyView when beats span different rows")
+    func testBeamView_rowMismatch_doesNotRender() async throws {
+        try await TestSetup.withTestSetup {
+            // 4 four-four measures: measures 0-2 row 0, measure 3 row 1.
+            let positions = GameplayLayout.calculateMeasurePositions(
+                totalMeasures: 4, timeSignature: .fourFour
+            )
+            let rowsPresent = Set(positions.map { $0.row })
+            #expect(rowsPresent.contains(0) && rowsPresent.contains(1),
+                    "Fixture must span two rows for the row-mismatch branch")
+
+            // timePosition 2.0 → measureIndex 2 (row 0); 3.0 → measureIndex 3 (row 1).
+            let beatRow0 = DrumBeat(id: 0, drums: [.kick],  timePosition: 2.0, interval: .eighth)
+            let beatRow1 = DrumBeat(id: 1, drums: [.snare], timePosition: 3.0, interval: .eighth)
+
+            let view = BeamView(
+                beats: [beatRow0, beatRow1],
+                beamLevel: 0,
+                measurePositions: positions,
+                timeSignature: .fourFour,
+                isActive: false
+            )
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 1280, height: 900)
+            )
+        }
+    }
+
+    // MARK: - MusicNotationViews
+
+    @Test("DrumClefSymbol renders without error")
+    func testDrumClefSymbol_renders() async throws {
+        try await TestSetup.withTestSetup {
+            let view = DrumClefSymbol()
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 100, height: 100)
+            )
+        }
+    }
+
+    @Test("TimeSignatureSymbol renders the correct numerals for 3/4 time")
+    func testTimeSignatureSymbol_threeFour_renders() async throws {
+        try await TestSetup.withTestSetup {
+            let view = TimeSignatureSymbol(timeSignature: .threeFour)
+            SwiftUITestUtilities.assertView(
+                view,
+                containsStrings: ["3", "4"],
+                size: CGSize(width: 100, height: 100)
             )
         }
     }

--- a/VirgoTests/GameplayRenderCoverageTests.swift
+++ b/VirgoTests/GameplayRenderCoverageTests.swift
@@ -52,6 +52,7 @@ struct GameplayRenderCoverageTests {
     func testGameplayView_withPreparedViewModel_rendersPopulatedState() async throws {
         try await TestSetup.withTestSetup {
             let vm = await GameplayViewModelCoverageTestSupport.makePreparedViewModel()
+            defer { vm.cleanup() }
 
             // Verify the view model was fully prepared before mounting.
             #expect(vm.isDataLoaded, "makePreparedViewModel must call loadChartData()")
@@ -77,6 +78,7 @@ struct GameplayRenderCoverageTests {
     func testGameplayView_dynamicStaffLinesFallback() async throws {
         try await TestSetup.withTestSetup {
             let vm = await GameplayViewModelCoverageTestSupport.makePreparedViewModel(staticStaffLinesPresent: false)
+            defer { vm.cleanup() }
             #expect(vm.staticStaffLinesView == nil, "Fixture must clear staticStaffLinesView")
 
             let view = GameplayView(chart: vm.chart, metronome: vm.metronome, initialViewModel: vm)
@@ -86,6 +88,8 @@ struct GameplayRenderCoverageTests {
                 view,
                 size: CGSize(width: 1280, height: 900)
             )
+            #expect(vm.staticStaffLinesView == nil,
+                    "Injected view model must preserve a nil staticStaffLinesView during mount")
         }
     }
 
@@ -206,9 +210,8 @@ struct GameplayRenderCoverageTests {
             let positions = GameplayLayout.calculateMeasurePositions(
                 totalMeasures: 4, timeSignature: .fourFour
             )
-            let rowsPresent = Set(positions.map { $0.row })
-            #expect(rowsPresent.contains(0) && rowsPresent.contains(1),
-                    "Fixture must span two rows for the row-mismatch branch")
+            #expect(positions[2].row == 0, "Measure 2 must remain on row 0 for the row-mismatch fixture")
+            #expect(positions[3].row == 1, "Measure 3 must remain on row 1 for the row-mismatch fixture")
 
             // timePosition 2.0 → measureIndex 2 (row 0); 3.0 → measureIndex 3 (row 1).
             let beatRow0 = DrumBeat(id: 0, drums: [.kick],  timePosition: 2.0, interval: .eighth)

--- a/VirgoTests/GameplayRenderCoverageTests.swift
+++ b/VirgoTests/GameplayRenderCoverageTests.swift
@@ -162,6 +162,7 @@ struct GameplayRenderCoverageTests {
             let positions = GameplayLayout.calculateMeasurePositions(
                 totalMeasures: 1, timeSignature: .fourFour
             )
+            #expect(!positions.isEmpty, "calculateMeasurePositions must return at least one position for 1 measure")
             #expect(positions[0].row == 0, "Single-measure fixture must be in row 0")
 
             let view = BeamView(
@@ -181,7 +182,7 @@ struct GameplayRenderCoverageTests {
     /// `beamLevel = 1` with eighth notes (flagCount = 1): `1 > 1` is false for every beat,
     /// so `beamedBeats` is empty → the `count < 2` guard fires → `EmptyView()` branch.
     @Test("BeamView renders EmptyView when fewer than two beats pass the beamLevel filter")
-    func testBeamView_fewerThanTwoBeats_doesNotRender() async throws {
+    func testBeamView_fewerThanTwoBeats_mountsSuccessfully() async throws {
         try await TestSetup.withTestSetup {
             let beats = Self.makeEighthNotePair()
             let positions = GameplayLayout.calculateMeasurePositions(
@@ -205,12 +206,13 @@ struct GameplayRenderCoverageTests {
     /// Measures 2 and 3 are in different rows when `totalMeasures == 4`.
     /// `firstMeasurePos.row != lastMeasurePos.row` → the row-mismatch `EmptyView()` branch.
     @Test("BeamView renders EmptyView when beats span different rows")
-    func testBeamView_rowMismatch_doesNotRender() async throws {
+    func testBeamView_rowMismatch_mountsSuccessfully() async throws {
         try await TestSetup.withTestSetup {
             // 4 four-four measures: measures 0-2 row 0, measure 3 row 1.
             let positions = GameplayLayout.calculateMeasurePositions(
                 totalMeasures: 4, timeSignature: .fourFour
             )
+            #expect(positions.count >= 4, "calculateMeasurePositions must return at least 4 positions for 4 measures")
             #expect(positions[2].row == 0, "Measure 2 must remain on row 0 for the row-mismatch fixture")
             #expect(positions[3].row == 1, "Measure 3 must remain on row 1 for the row-mismatch fixture")
 

--- a/VirgoTests/GameplayRenderCoverageTests.swift
+++ b/VirgoTests/GameplayRenderCoverageTests.swift
@@ -1,0 +1,68 @@
+//
+//  GameplayRenderCoverageTests.swift
+//  VirgoTests
+//
+//  Render-path coverage for GameplayView's two principal visual branches:
+//  1. Loading state (viewModel == nil) — exercised on first layout pass.
+//  2. Populated state (viewModel != nil) — exercised via the injection seam.
+//
+
+import Testing
+import SwiftUI
+import Foundation
+@testable import Virgo
+
+@Suite("GameplayRenderCoverageTests", .serialized)
+@MainActor
+struct GameplayRenderCoverageTests {
+
+    // MARK: - Loading-state render path
+
+    /// Mounts `GameplayView(chart:metronome:)` without an initial view model.
+    /// `layoutSubtreeIfNeeded()` evaluates the body with `viewModel == nil`,
+    /// which exercises the loading-state branch in `sheetMusicView`.
+    @Test("GameplayView mounts in loading state when no viewModel is provided")
+    func testGameplayView_noInitialViewModel_rendersLoadingState() async throws {
+        try await TestSetup.withTestSetup {
+            let chart = GameplayViewModelCoverageTestSupport.makeChart()
+            let metronome = GameplayViewModelCoverageTestSupport.makeMetronome()
+            let settings = GameplayViewModelCoverageTestSupport.makeSettings()
+
+            let view = GameplayView(chart: chart, metronome: metronome)
+                .environmentObject(settings)
+
+            // Initial layout evaluates the body with viewModel == nil,
+            // exercising the loading-state branch for coverage.
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 1280, height: 900)
+            )
+        }
+    }
+
+    // MARK: - Populated render path
+
+    /// Injects a fully-prepared view model via the new `initialViewModel` seam.
+    /// The view renders the populated notation branch from the very first layout pass.
+    @Test("GameplayView mounts in populated state when a prepared viewModel is injected")
+    func testGameplayView_withPreparedViewModel_rendersPopulatedState() async throws {
+        try await TestSetup.withTestSetup {
+            let vm = await GameplayViewModelCoverageTestSupport.makePreparedViewModel()
+            let settings = GameplayViewModelCoverageTestSupport.makeSettings()
+
+            // Verify the view model was fully prepared before mounting.
+            #expect(vm.isDataLoaded, "makePreparedViewModel must call loadChartData()")
+            #expect(!vm.cachedDrumBeats.isEmpty, "makePreparedViewModel must populate cachedDrumBeats via setupGameplay()")
+            #expect(vm.staticStaffLinesView != nil, "makePreparedViewModel must build staticStaffLinesView via setupGameplay()")
+
+            let view = GameplayView(chart: vm.chart, metronome: vm.metronome, initialViewModel: vm)
+                .environmentObject(settings)
+
+            // Mounting with a non-nil viewModel exercises the populated notation branch.
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 1280, height: 900)
+            )
+        }
+    }
+}

--- a/VirgoTests/GameplayRenderCoverageTests.swift
+++ b/VirgoTests/GameplayRenderCoverageTests.swift
@@ -22,7 +22,8 @@ struct GameplayRenderCoverageTests {
 
     /// Mounts `GameplayView(chart:metronome:)` without an initial view model.
     /// `layoutSubtreeIfNeeded()` evaluates the body with `viewModel == nil`,
-    /// which exercises the loading-state branch in `sheetMusicView`.
+    /// which exercises the loading-state branch in `sheetMusicView` and also
+    /// the `controlsView` placeholder (`Color.black.frame(height: 100)`) branch.
     @Test("GameplayView mounts in loading state when no viewModel is provided")
     func testGameplayView_noInitialViewModel_rendersLoadingState() async throws {
         try await TestSetup.withTestSetup {
@@ -45,7 +46,8 @@ struct GameplayRenderCoverageTests {
     // MARK: - Populated render path
 
     /// Injects a fully-prepared view model via the new `initialViewModel` seam.
-    /// The view renders the populated notation branch from the very first layout pass.
+    /// The view renders the populated notation branch from the very first layout pass,
+    /// and also exercises the `controlsView` full `GameplayControlsView` branch.
     @Test("GameplayView mounts in populated state when a prepared viewModel is injected")
     func testGameplayView_withPreparedViewModel_rendersPopulatedState() async throws {
         try await TestSetup.withTestSetup {
@@ -76,44 +78,6 @@ struct GameplayRenderCoverageTests {
         try await TestSetup.withTestSetup {
             let vm = await GameplayViewModelCoverageTestSupport.makePreparedViewModel(staticStaffLinesPresent: false)
             #expect(vm.staticStaffLinesView == nil, "Fixture must clear staticStaffLinesView")
-
-            let view = GameplayView(chart: vm.chart, metronome: vm.metronome, initialViewModel: vm)
-                .environmentObject(vm.practiceSettings)
-
-            SwiftUITestUtilities.assertViewWithEnvironment(
-                view,
-                size: CGSize(width: 1280, height: 900)
-            )
-        }
-    }
-
-    // MARK: - controlsView branches
-
-    /// Mounts `GameplayView` without a viewModel, causing `controlsView` to show the
-    /// placeholder `Color.black.frame(height: 100)` branch.
-    @Test("GameplayView controlsView shows placeholder when viewModel is nil")
-    func testGameplayView_controlsPlaceholder_rendersWhenNoViewModel() async throws {
-        try await TestSetup.withTestSetup {
-            let chart = GameplayViewModelCoverageTestSupport.makeChart()
-            let metronome = GameplayViewModelCoverageTestSupport.makeMetronome()
-            let settings = GameplayViewModelCoverageTestSupport.makeSettings()
-
-            let view = GameplayView(chart: chart, metronome: metronome)
-                .environmentObject(settings)
-
-            SwiftUITestUtilities.assertViewWithEnvironment(
-                view,
-                size: CGSize(width: 1280, height: 900)
-            )
-        }
-    }
-
-    /// Mounts `GameplayView` with a populated viewModel, causing `controlsView` to render
-    /// the full `GameplayControlsView` branch.
-    @Test("GameplayView controlsView shows loaded controls when viewModel is populated")
-    func testGameplayView_controlsLoaded_rendersWhenViewModelPresent() async throws {
-        try await TestSetup.withTestSetup {
-            let vm = await GameplayViewModelCoverageTestSupport.makePreparedViewModel()
 
             let view = GameplayView(chart: vm.chart, metronome: vm.metronome, initialViewModel: vm)
                 .environmentObject(vm.practiceSettings)

--- a/VirgoTests/GameplayRenderCoverageTests.swift
+++ b/VirgoTests/GameplayRenderCoverageTests.swift
@@ -24,7 +24,7 @@ struct GameplayRenderCoverageTests {
     private static func makeEighthNotePair() -> [DrumBeat] {
         [
             DrumBeat(id: 0, drums: [.kick], timePosition: 0.0, interval: .eighth),
-            DrumBeat(id: 1, drums: [.snare], timePosition: 0.25, interval: .eighth)
+            DrumBeat(id: 1, drums: [.snare], timePosition: 0.125, interval: .eighth)
         ]
     }
 

--- a/VirgoTests/GameplayViewModelCoverageTestSupport.swift
+++ b/VirgoTests/GameplayViewModelCoverageTestSupport.swift
@@ -56,12 +56,12 @@ enum GameplayViewModelCoverageTestSupport {
 
     /// Builds a fully-prepared view model suitable for deterministic render-path tests.
     ///
-    /// Creates an eighth-note chart (measureOffset stride 0.25), then drives the
+    /// Creates an eighth-note chart (measureOffset stride 0.125), then drives the
     /// normal view-model lifecycle (`loadChartData` → `setupGameplay`) so that all
     /// pre-computed layout caches are populated.  Pass `staticStaffLinesPresent: false`
     /// to cover the dynamic staff-lines fallback branch.
     static func makePreparedViewModel(staticStaffLinesPresent: Bool = true) async -> GameplayViewModel {
-        let chart = makeChart(noteCount: 4, interval: .eighth, measureOffset: 0.25)
+        let chart = makeChart(noteCount: 4, interval: .eighth, measureOffset: 0.125)
         let vm = makeViewModel(chart: chart)
         await vm.loadChartData()
         vm.setupGameplay()

--- a/VirgoTests/GameplayViewModelCoverageTestSupport.swift
+++ b/VirgoTests/GameplayViewModelCoverageTestSupport.swift
@@ -22,11 +22,11 @@ enum GameplayViewModelCoverageTestSupport {
         MetronomeEngine(audioDriver: driver ?? RecordingAudioDriver())
     }
 
-    static func makeChart(noteCount: Int = 4, measureOffset stride: Double = 0.1) -> Chart {
+    static func makeChart(noteCount: Int = 4, interval: NoteInterval = .quarter, measureOffset stride: Double = 0.1) -> Chart {
         let chart = Chart(difficulty: .medium)
         for i in 0..<noteCount {
             let note = Note(
-                interval: .quarter,
+                interval: interval,
                 noteType: i.isMultiple(of: 2) ? .bass : .snare,
                 measureNumber: 1,
                 measureOffset: Double(i) * stride
@@ -52,5 +52,27 @@ enum GameplayViewModelCoverageTestSupport {
             practiceSettings: resolvedSettings,
             highScoreService: resolvedHighScoreService
         )
+    }
+
+    /// Builds a fully-prepared view model suitable for deterministic render-path tests.
+    ///
+    /// Creates an eighth-note chart (measureOffset stride 0.25), then drives the
+    /// normal view-model lifecycle (`loadChartData` → `setupGameplay`) so that all
+    /// pre-computed layout caches are populated.  Pass `staticStaffLinesPresent: false`
+    /// to cover the dynamic staff-lines fallback branch.
+    static func makePreparedViewModel(staticStaffLinesPresent: Bool = true) async -> GameplayViewModel {
+        let chart = makeChart(noteCount: 4, interval: .eighth, measureOffset: 0.25)
+        let vm = GameplayViewModel(
+            chart: chart,
+            metronome: makeMetronome(),
+            practiceSettings: makeSettings(),
+            highScoreService: makeHighScoreService()
+        )
+        await vm.loadChartData()
+        vm.setupGameplay()
+        if !staticStaffLinesPresent {
+            vm.staticStaffLinesView = nil
+        }
+        return vm
     }
 }

--- a/VirgoTests/GameplayViewModelCoverageTestSupport.swift
+++ b/VirgoTests/GameplayViewModelCoverageTestSupport.swift
@@ -62,12 +62,7 @@ enum GameplayViewModelCoverageTestSupport {
     /// to cover the dynamic staff-lines fallback branch.
     static func makePreparedViewModel(staticStaffLinesPresent: Bool = true) async -> GameplayViewModel {
         let chart = makeChart(noteCount: 4, interval: .eighth, measureOffset: 0.25)
-        let vm = GameplayViewModel(
-            chart: chart,
-            metronome: makeMetronome(),
-            practiceSettings: makeSettings(),
-            highScoreService: makeHighScoreService()
-        )
+        let vm = makeViewModel(chart: chart)
         await vm.loadChartData()
         vm.setupGameplay()
         if !staticStaffLinesPresent {

--- a/docs/superpowers/specs/2026-04-08-coverage-improvement-design.md
+++ b/docs/superpowers/specs/2026-04-08-coverage-improvement-design.md
@@ -126,6 +126,22 @@ This fallback is intentionally limited to avoid turning the work into an open-en
 - Prefer direct render-state coverage and pure helper tests over interaction-heavy tests
 - Avoid sleeps; use existing deterministic helpers and precomputed state
 
+## Coverage Measurement and Checkpoints
+
+Use the app-target coverage report from:
+
+```bash
+xcrun xccov view --report <result-bundle>.xcresult
+```
+
+The implementation should make coverage decisions at explicit checkpoints:
+
+1. After the **gameplay render coverage pass**
+2. After the **app shell and startup coverage pass**
+3. Only if coverage is still below **90.03%**, execute the fallback sweep
+
+The fallback sweep is not the default path; it is triggered only if the first two passes are insufficient.
+
 ## Risks and Mitigations
 
 ### Risk: gameplay render tests become timing-sensitive

--- a/docs/superpowers/specs/2026-04-08-coverage-improvement-design.md
+++ b/docs/superpowers/specs/2026-04-08-coverage-improvement-design.md
@@ -1,0 +1,148 @@
+# Coverage Improvement Design
+
+## Problem
+
+`Virgo.app` currently sits at **85.03% coverage (15282/17972 executable lines)** from the baseline unit-test coverage report. The target for this work is an **absolute 5-point increase**, bringing the app target to **at least 90.03%**.
+
+The baseline full-suite run also exposed a **pre-existing flaky failure** in `GameplayViewModelTests.testResumePlaybackMultipleTimesMaintainsTiming`. That test passed when `GameplayViewModelTests` was run in isolation, so this design keeps that failure out of scope unless the coverage work directly touches the same code path.
+
+## Goals
+
+- Raise `Virgo.app` coverage to **>= 90.03%**
+- Prefer **deterministic unit/render tests** over timing-sensitive interaction tests
+- Reuse the repo's existing Swift Testing, SwiftData, and SwiftUI test helpers
+- Limit production changes to **small internal seams** that improve testability without changing behavior
+
+## Non-Goals
+
+- Fixing the pre-existing `GameplayViewModelTests` timing flake
+- Broad refactors unrelated to the coverage target
+- Behavioral changes to gameplay, startup, or persistence flows
+
+## Coverage Hotspots That Drive the Design
+
+The baseline coverage report shows that the biggest practical gains are concentrated in a handful of SwiftUI-heavy files:
+
+| File | Covered / Executable | Coverage | Uncovered lines |
+| --- | ---: | ---: | ---: |
+| `Virgo/views/subviews/GameplaySheetMusicView.swift` | 0 / 474 | 0.00% | 474 |
+| `Virgo/views/GameplayView.swift` | 10 / 276 | 3.62% | 266 |
+| `Virgo/views/BeamView.swift` | 0 / 95 | 0.00% | 95 |
+| `Virgo/views/subviews/GameplayPlaybackControls.swift` | 0 / 71 | 0.00% | 71 |
+| `Virgo/views/MusicNotationViews.swift` | 0 / 54 | 0.00% | 54 |
+| `Virgo/views/ContentView.swift` | 242 / 338 | 71.60% | 96 |
+| `Virgo/views/ProfileView.swift` | 419 / 516 | 81.20% | 97 |
+| `Virgo/views/DrumBeatView.swift` | 217 / 333 | 65.17% | 116 |
+
+These numbers make an app-shell-only pass insufficient for a +5-point increase. The design therefore targets the **gameplay rendering surface first**, then adds **app-shell/startup branch coverage**, with a final fallback pass if the first two waves do not clear the target.
+
+## Proposed Design
+
+### 1. Gameplay Render Coverage Pass
+
+Add a focused gameplay render coverage suite that exercises `GameplayView` and its owned subviews in deterministic states.
+
+#### Files to cover
+
+- `Virgo/views/GameplayView.swift`
+- `Virgo/views/subviews/GameplaySheetMusicView.swift`
+- `Virgo/views/BeamView.swift`
+- `Virgo/views/subviews/GameplayPlaybackControls.swift`
+- `Virgo/views/MusicNotationViews.swift`
+
+#### Test approach
+
+- Reuse `GameplayViewModelCoverageTestSupport` to build a prepared `GameplayViewModel`
+- Reuse `SwiftUITestUtilities.assertViewWithEnvironment` to mount views in both:
+  - **placeholder/loading states** (`viewModel == nil`)
+  - **fully prepared states** with cached notes, beam groups, measure positions, and beat positions
+- Cover both the high-level `GameplayView` render path and the low-level subview branches directly so zero-coverage helpers are forced through:
+  - `sheetMusicView` loading fallback vs populated sheet-music layout
+  - `controlsView` placeholder vs populated controls
+  - `StaffLinesBackgroundView` with multi-row measure positions
+  - `BeamGroupView` / `BeamView` active and inactive beams, plus non-rendering branches (`< 2` beats, row mismatch)
+  - `DrumClefSymbol` and `TimeSignatureSymbol`
+
+#### Why this is the first wave
+
+This cluster contains the highest number of uncovered lines that can be exercised through render-state tests without invasive production changes.
+
+### 2. App Shell and Startup Coverage Pass
+
+Add a second suite focused on app entry and startup orchestration.
+
+#### Files to cover
+
+- `Virgo/views/MainMenuView.swift`
+- `Virgo/VirgoApp.swift`
+- `Virgo/views/ContentView.swift`
+
+#### Test approach
+
+- Add `MainMenuView` coverage for renderability and stable identifiers (`logoText`, `subtitleText`, `startButton`)
+- Cover `VirgoApp` launch-argument behavior by testing a small extracted helper for the UI-testing animation-disable decision
+- Cover `ContentView` startup and routing branches, especially:
+  - UI-testing + reset-state path
+  - UI-testing + seed-if-needed path
+  - skip-seed path
+  - preview-vs-standard playback routing for `onPlayTap`
+
+### 3. Minimal Production Seams
+
+Production changes are allowed only where they make existing logic testable without altering behavior.
+
+#### Planned seams
+
+1. **`ContentView` startup helper**
+   - Extract launch-argument/startup decisions into a small internal helper or static functions
+   - Inputs should be simple values (argument list, fixture titles, song metadata)
+   - Outputs should drive the same existing behavior already in `onAppear`
+
+2. **`VirgoApp` launch helper**
+   - Extract the "should disable animations for UI testing" decision into a small helper so it can be tested without bootstrapping the app lifecycle
+
+#### Explicit constraint
+
+These seams must stay **internal and behavior-preserving**. The surrounding view logic should keep the same runtime flow and call sites.
+
+### 4. Fallback Coverage Sweep If Needed
+
+If the gameplay and app-shell passes do not push coverage to `>= 90.03%`, finish with the lowest-risk follow-up targets already close to coverage payoff:
+
+- `Virgo/views/ProfileView.swift`
+- `Virgo/views/DrumBeatView.swift`
+
+This fallback is intentionally limited to avoid turning the work into an open-ended refactor.
+
+## Testing Strategy
+
+- Use **Swift Testing** with `@Suite(..., .serialized)` and `@MainActor` where stateful SwiftUI or SwiftData fixtures are involved
+- Use existing helpers:
+  - `TestSetup.withTestSetup`
+  - `GameplayViewModelCoverageTestSupport`
+  - `TestModelFactory`
+  - `SwiftUICoverageFixtures`
+  - `SwiftUITestUtilities.assertViewWithEnvironment`
+- Prefer direct render-state coverage and pure helper tests over interaction-heavy tests
+- Avoid sleeps; use existing deterministic helpers and precomputed state
+
+## Risks and Mitigations
+
+### Risk: gameplay render tests become timing-sensitive
+
+**Mitigation:** build view-model state explicitly and target render branches directly instead of driving playback.
+
+### Risk: helper extraction accidentally changes behavior
+
+**Mitigation:** keep extracted seams pure, internal, and narrowly scoped to existing branching logic.
+
+### Risk: full-suite flake obscures final verification
+
+**Mitigation:** keep the known `GameplayViewModelTests` flake out of scope, compare against the baseline failure, and use app-target coverage numbers from `xccov` to measure the coverage improvement directly.
+
+## Success Criteria
+
+- `Virgo.app` coverage reaches **at least 90.03%**
+- New tests follow existing repo conventions
+- Any production changes are small internal seams only
+- No new product behavior is introduced as part of the coverage work


### PR DESCRIPTION
## Summary
- Add AppShellCoverageTests covering app startup and content view rendering
- Add GameplayRenderCoverageTests for gameplay view rendering branches
- Refactor GameplayView to expose deterministic injection seam for testing
- Extract ContentStartupPolicy and VirgoAppLaunchBehavior helpers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Startup and animation decisions delegated to focused utilities; UI animations are disabled during UI-testing mode when detected.
  * Content startup now follows a clear policy to decide reset/seed behavior and when to use preview-backed playback.

* **New Features**
  * Gameplay view accepts an optional injected view model to skip redundant initialization.

* **Tests**
  * New suites covering startup actions, preview-player logic, gameplay render branches, and view-model scenarios.

* **Documentation**
  * Added a coverage-improvement design spec.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->