### PR TITLE
feat: Implement gameplay note rendering with sheet music notation

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+language: en-US
+
+reviews:
+  path_filters:
+    - "!docs/superpowers/**"

--- a/Virgo.xcodeproj/xcshareddata/xcschemes/Virgo.xcscheme
+++ b/Virgo.xcodeproj/xcshareddata/xcschemes/Virgo.xcscheme
@@ -29,28 +29,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "24829CF92E1217CC00F99FD7"
-               BuildableName = "VirgoTests.xctest"
-               BlueprintName = "VirgoTests"
-               ReferencedContainer = "container:Virgo.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "24829D032E1217CC00F99FD7"
-               BuildableName = "VirgoUITests.xctest"
-               BlueprintName = "VirgoUITests"
-               ReferencedContainer = "container:Virgo.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -60,6 +38,28 @@
             ReferencedContainer = "container:Virgo.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "24829CF72E1217CC00F99FD7"
+               BuildableName = "VirgoTests.xctest"
+               BlueprintName = "VirgoTests"
+               ReferencedContainer = "container:Virgo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "24829D012E1217CC00F99FD7"
+               BuildableName = "VirgoUITests.xctest"
+               BlueprintName = "VirgoUITests"
+               ReferencedContainer = "container:Virgo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Virgo/layout/NotationLayout.swift
+++ b/Virgo/layout/NotationLayout.swift
@@ -78,7 +78,12 @@ struct NotationLayout {
     var ledgerLines: [RenderedLedgerLine]
     var measureBars: [RenderedMeasureBar]
     var beatLookup: [UInt64: CGPoint]
+    var noteHeadIDsByTimePosition: [Int: Set<UInt64>]
     var totalHeight: CGFloat
+
+    static func timePositionKey(_ timePosition: Double) -> Int {
+        Int((timePosition * 1_000_000).rounded())
+    }
 
     static let empty = NotationLayout(
         measures: [],
@@ -88,6 +93,7 @@ struct NotationLayout {
         ledgerLines: [],
         measureBars: [],
         beatLookup: [:],
+        noteHeadIDsByTimePosition: [:],
         totalHeight: 0
     )
 }

--- a/Virgo/layout/NotationLayout.swift
+++ b/Virgo/layout/NotationLayout.swift
@@ -4,15 +4,18 @@ import Foundation
 struct NotationLayoutInput {
     let notes: [Note]
     let timeSignature: TimeSignature
+    let minimumMeasureCount: Int
     let style: NotationLayoutStyle
 
     init(
         notes: [Note],
         timeSignature: TimeSignature,
+        minimumMeasureCount: Int = 1,
         style: NotationLayoutStyle = .gameplayDefault
     ) {
         self.notes = notes
         self.timeSignature = timeSignature
+        self.minimumMeasureCount = minimumMeasureCount
         self.style = style
     }
 }

--- a/Virgo/layout/NotationLayout.swift
+++ b/Virgo/layout/NotationLayout.swift
@@ -89,6 +89,25 @@ struct NotationLayout {
         Int((timePosition * 1_000_000).rounded())
     }
 
+    /// Minimum content width needed to contain all rendered primitives.
+    var contentWidth: CGFloat {
+        let primitiveMaxX = [
+            noteHeads.map(\.position.x),
+            measureBars.map(\.x),
+            beams.flatMap { [$0.start.x, $0.end.x] },
+            ledgerLines.flatMap { [$0.start.x, $0.end.x] },
+            stems.flatMap { [$0.start.x, $0.end.x] }
+        ]
+        .flatMap { $0 }
+        .max()
+
+        guard let maxX = primitiveMaxX else {
+            return GameplayLayout.maxRowWidth
+        }
+
+        return max(GameplayLayout.maxRowWidth, maxX + GameplayLayout.uniformSpacing)
+    }
+
     static let empty = NotationLayout(
         measures: [],
         noteHeads: [],

--- a/Virgo/layout/NotationLayout.swift
+++ b/Virgo/layout/NotationLayout.swift
@@ -1,0 +1,136 @@
+import CoreGraphics
+import Foundation
+
+struct NotationLayoutInput {
+    let notes: [Note]
+    let timeSignature: TimeSignature
+    let style: NotationLayoutStyle
+
+    init(
+        notes: [Note],
+        timeSignature: TimeSignature,
+        style: NotationLayoutStyle = .gameplayDefault
+    ) {
+        self.notes = notes
+        self.timeSignature = timeSignature
+        self.style = style
+    }
+}
+
+struct NotationLayoutStyle: Equatable {
+    let minimumNoteColumnGap: CGFloat
+    let minimumQuarterBeatGap: CGFloat
+    let measurePadding: CGFloat
+    let rowWidth: CGFloat
+    let staffLineSpacing: CGFloat
+    let noteHeadWidth: CGFloat
+    let noteHeadHeight: CGFloat
+    let stemLength: CGFloat
+    let stemWidth: CGFloat
+    let stemXInset: CGFloat
+    let beamThickness: CGFloat
+    let beamLevelSpacing: CGFloat
+    let ledgerLineOverhang: CGFloat
+    let voiceCollisionOffset: CGFloat
+
+    static let gameplayDefault = NotationLayoutStyle(
+        minimumNoteColumnGap: 28,
+        minimumQuarterBeatGap: GameplayLayout.uniformSpacing,
+        measurePadding: 16,
+        rowWidth: GameplayLayout.maxRowWidth,
+        staffLineSpacing: GameplayLayout.staffLineSpacing,
+        noteHeadWidth: GameplayLayout.beatColumnWidth,
+        noteHeadHeight: GameplayLayout.drumSymbolFontSize,
+        stemLength: GameplayLayout.stemHeight,
+        stemWidth: GameplayLayout.stemWidth,
+        stemXInset: GameplayLayout.stemXOffset,
+        beamThickness: 4,
+        beamLevelSpacing: GameplayLayout.beamLevelSpacing,
+        ledgerLineOverhang: 6,
+        voiceCollisionOffset: 8
+    )
+}
+
+enum NotationVoice: String, Hashable {
+    case upper
+    case lower
+
+    static func voice(for drumType: DrumType) -> NotationVoice {
+        switch drumType {
+        case .kick, .hiHatPedal:
+            return .lower
+        case .crash, .hiHat, .tom1, .snare, .tom2, .tom3, .ride, .cowbell:
+            return .upper
+        }
+    }
+}
+
+enum StemDirection: String, Hashable {
+    case up
+    case down
+}
+
+struct NotationLayout {
+    var measures: [RenderedMeasure]
+    var noteHeads: [RenderedNoteHead]
+    var stems: [RenderedStem]
+    var beams: [RenderedBeam]
+    var ledgerLines: [RenderedLedgerLine]
+    var measureBars: [RenderedMeasureBar]
+    var beatLookup: [UInt64: CGPoint]
+    var totalHeight: CGFloat
+}
+
+struct RenderedMeasure: Identifiable, Hashable {
+    let id: Int
+    let measureIndex: Int
+    let row: Int
+    let xOffset: CGFloat
+    let width: CGFloat
+}
+
+struct RenderedNoteHead: Identifiable, Hashable {
+    let id: UInt64
+    let sourceNoteID: ObjectIdentifier
+    let drumType: DrumType
+    let voice: NotationVoice
+    let timePosition: Double
+    let measureIndex: Int
+    let row: Int
+    let position: CGPoint
+    let staffStep: Int
+    let stemDirection: StemDirection
+    let interval: NoteInterval
+}
+
+struct RenderedStem: Identifiable, Hashable {
+    let id: String
+    let noteHeadIDs: [UInt64]
+    let direction: StemDirection
+    let start: CGPoint
+    let end: CGPoint
+}
+
+struct RenderedBeam: Identifiable, Hashable {
+    let id: String
+    let noteHeadIDs: [UInt64]
+    let direction: StemDirection
+    let level: Int
+    let start: CGPoint
+    let end: CGPoint
+    let thickness: CGFloat
+}
+
+struct RenderedLedgerLine: Identifiable, Hashable {
+    let id: String
+    let row: Int
+    let start: CGPoint
+    let end: CGPoint
+}
+
+struct RenderedMeasureBar: Identifiable, Hashable {
+    let id: String
+    let row: Int
+    let x: CGFloat
+    let isFinal: Bool
+}

--- a/Virgo/layout/NotationLayout.swift
+++ b/Virgo/layout/NotationLayout.swift
@@ -78,6 +78,7 @@ struct NotationLayout {
     var noteHeads: [RenderedNoteHead]
     var stems: [RenderedStem]
     var beams: [RenderedBeam]
+    var flags: [RenderedFlag]
     var ledgerLines: [RenderedLedgerLine]
     var measureBars: [RenderedMeasureBar]
     var beatLookup: [UInt64: CGPoint]
@@ -93,6 +94,7 @@ struct NotationLayout {
         noteHeads: [],
         stems: [],
         beams: [],
+        flags: [],
         ledgerLines: [],
         measureBars: [],
         beatLookup: [:],
@@ -146,6 +148,14 @@ struct RenderedLedgerLine: Identifiable, Hashable {
     let row: Int
     let start: CGPoint
     let end: CGPoint
+}
+
+struct RenderedFlag: Identifiable, Hashable {
+    let id: String
+    let noteHeadID: UInt64
+    let stemDirection: StemDirection
+    let flagIndex: Int
+    let origin: CGPoint
 }
 
 struct RenderedMeasureBar: Identifiable, Hashable {

--- a/Virgo/layout/NotationLayout.swift
+++ b/Virgo/layout/NotationLayout.swift
@@ -23,7 +23,6 @@ struct NotationLayoutInput {
 struct NotationLayoutStyle: Equatable {
     let minimumNoteColumnGap: CGFloat
     let minimumQuarterBeatGap: CGFloat
-    let measurePadding: CGFloat
     let rowWidth: CGFloat
     let staffLineSpacing: CGFloat
     let noteHeadWidth: CGFloat
@@ -39,7 +38,6 @@ struct NotationLayoutStyle: Equatable {
     static let gameplayDefault = NotationLayoutStyle(
         minimumNoteColumnGap: 28,
         minimumQuarterBeatGap: GameplayLayout.uniformSpacing,
-        measurePadding: 16,
         rowWidth: GameplayLayout.maxRowWidth,
         staffLineSpacing: GameplayLayout.staffLineSpacing,
         noteHeadWidth: GameplayLayout.beatColumnWidth,
@@ -81,7 +79,7 @@ struct NotationLayout {
     var flags: [RenderedFlag]
     var ledgerLines: [RenderedLedgerLine]
     var measureBars: [RenderedMeasureBar]
-    var beatLookup: [UInt64: CGPoint]
+    var noteHeadPositionsByID: [UInt64: CGPoint]
     var noteHeadIDsByTimePosition: [Int: Set<UInt64>]
     var totalHeight: CGFloat
 
@@ -116,7 +114,7 @@ struct NotationLayout {
         flags: [],
         ledgerLines: [],
         measureBars: [],
-        beatLookup: [:],
+        noteHeadPositionsByID: [:],
         noteHeadIDsByTimePosition: [:],
         totalHeight: 0
     )

--- a/Virgo/layout/NotationLayout.swift
+++ b/Virgo/layout/NotationLayout.swift
@@ -79,6 +79,17 @@ struct NotationLayout {
     var measureBars: [RenderedMeasureBar]
     var beatLookup: [UInt64: CGPoint]
     var totalHeight: CGFloat
+
+    static let empty = NotationLayout(
+        measures: [],
+        noteHeads: [],
+        stems: [],
+        beams: [],
+        ledgerLines: [],
+        measureBars: [],
+        beatLookup: [:],
+        totalHeight: 0
+    )
 }
 
 struct RenderedMeasure: Identifiable, Hashable {

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -1,0 +1,157 @@
+import CoreGraphics
+import Foundation
+
+struct NotationLayoutEngine {
+    func layout(input: NotationLayoutInput) -> NotationLayout {
+        let normalizedNotes = input.notes.sorted {
+            MeasureUtils.timePosition(measureNumber: $0.measureNumber, measureOffset: $0.measureOffset)
+            < MeasureUtils.timePosition(measureNumber: $1.measureNumber, measureOffset: $1.measureOffset)
+        }
+        let totalMeasures = max(1, (normalizedNotes.map(\.measureNumber).max() ?? 1))
+        let measures = buildMeasures(totalMeasures: totalMeasures, notes: normalizedNotes, input: input)
+        let noteHeads = buildNoteHeads(notes: normalizedNotes, measures: measures, input: input)
+        let measureBars = buildMeasureBars(measures: measures)
+        let beatLookup = Dictionary(uniqueKeysWithValues: noteHeads.map { ($0.id, $0.position) })
+        let totalHeight = GameplayLayout.totalHeight(
+            for: measures.map {
+                GameplayLayout.MeasurePosition(row: $0.row, xOffset: $0.xOffset, measureIndex: $0.measureIndex)
+            }
+        )
+
+        return NotationLayout(
+            measures: measures,
+            noteHeads: noteHeads,
+            stems: [],
+            beams: [],
+            ledgerLines: [],
+            measureBars: measureBars,
+            beatLookup: beatLookup,
+            totalHeight: totalHeight
+        )
+    }
+
+    private func buildMeasures(
+        totalMeasures: Int,
+        notes: [Note],
+        input: NotationLayoutInput
+    ) -> [RenderedMeasure] {
+        var result: [RenderedMeasure] = []
+        var currentRow = 0
+        var currentX = GameplayLayout.leftMargin
+
+        for measureIndex in 0..<totalMeasures {
+            let width = measureWidth(measureIndex: measureIndex, notes: notes, input: input)
+            if currentX + width > input.style.rowWidth, measureIndex > 0 {
+                currentRow += 1
+                currentX = GameplayLayout.leftMargin
+            }
+            result.append(
+                RenderedMeasure(
+                    id: measureIndex,
+                    measureIndex: measureIndex,
+                    row: currentRow,
+                    xOffset: currentX,
+                    width: width
+                )
+            )
+            currentX += width + GameplayLayout.measureSpacing
+        }
+
+        return result
+    }
+
+    private func measureWidth(
+        measureIndex: Int,
+        notes: [Note],
+        input: NotationLayoutInput
+    ) -> CGFloat {
+        let measureNumber = MeasureUtils.toOneBasedNumber(measureIndex)
+        let offsets = notes
+            .filter { $0.measureNumber == measureNumber }
+            .map(\.measureOffset)
+            .sorted()
+
+        guard offsets.count > 1 else {
+            return GameplayLayout.measureWidth(for: input.timeSignature)
+        }
+
+        let smallestGap = zip(offsets.dropFirst(), offsets)
+            .map { pair in pair.0 - pair.1 }
+            .min() ?? 0.25
+        let beatGap = max(
+            input.style.minimumQuarterBeatGap,
+            input.style.minimumNoteColumnGap / CGFloat(max(smallestGap * Double(input.timeSignature.beatsPerMeasure), 0.001))
+        )
+        return GameplayLayout.barLineWidth
+            + input.style.measurePadding
+            + CGFloat(input.timeSignature.beatsPerMeasure) * beatGap
+            + input.style.measurePadding
+    }
+
+    private func buildNoteHeads(
+        notes: [Note],
+        measures: [RenderedMeasure],
+        input: NotationLayoutInput
+    ) -> [RenderedNoteHead] {
+        var nextID: UInt64 = 0
+        let measuresByIndex = Dictionary(uniqueKeysWithValues: measures.map { ($0.measureIndex, $0) })
+
+        return notes.compactMap { note in
+            guard let drumType = DrumType.from(noteType: note.noteType) else { return nil }
+            let measureIndex = MeasureUtils.toZeroBasedIndex(note.measureNumber)
+            guard let measure = measuresByIndex[measureIndex] else { return nil }
+            let beatGap = beatGap(for: measure, input: input)
+            let x = measure.xOffset + GameplayLayout.barLineWidth + input.style.measurePadding
+                + CGFloat(note.measureOffset * Double(input.timeSignature.beatsPerMeasure)) * beatGap
+            let y = GameplayLayout.StaffLinePosition.line1.absoluteY(for: measure.row)
+                + drumType.notePosition.yOffset
+            let id = nextID
+            nextID += 1
+
+            return RenderedNoteHead(
+                id: id,
+                sourceNoteID: ObjectIdentifier(note),
+                drumType: drumType,
+                voice: NotationVoice.voice(for: drumType),
+                timePosition: MeasureUtils.timePosition(
+                    measureNumber: note.measureNumber,
+                    measureOffset: note.measureOffset
+                ),
+                measureIndex: measureIndex,
+                row: measure.row,
+                position: CGPoint(x: x, y: y),
+                staffStep: staffStep(for: drumType.notePosition),
+                stemDirection: .up,
+                interval: note.interval
+            )
+        }
+    }
+
+    private func beatGap(for measure: RenderedMeasure, input: NotationLayoutInput) -> CGFloat {
+        let drawableWidth = measure.width - GameplayLayout.barLineWidth - input.style.measurePadding * 2
+        return drawableWidth / CGFloat(input.timeSignature.beatsPerMeasure)
+    }
+
+    private func staffStep(for position: GameplayLayout.NotePosition) -> Int {
+        Int((position.yOffset / (GameplayLayout.staffLineSpacing / 2)).rounded())
+    }
+
+    private func buildMeasureBars(measures: [RenderedMeasure]) -> [RenderedMeasureBar] {
+        measures.flatMap { measure in
+            [
+                RenderedMeasureBar(
+                    id: "bar_\(measure.measureIndex)",
+                    row: measure.row,
+                    x: measure.xOffset,
+                    isFinal: false
+                ),
+                RenderedMeasureBar(
+                    id: "bar_\(measure.measureIndex)_end",
+                    row: measure.row,
+                    x: measure.xOffset + measure.width,
+                    isFinal: measure.measureIndex == measures.last?.measureIndex
+                )
+            ]
+        }
+    }
+}

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -320,8 +320,7 @@ private extension NotationLayoutEngine {
         noteHeads: [RenderedNoteHead],
         style: NotationLayoutStyle
     ) -> [RenderedBeam] {
-        let beamableHeads = noteHeads.filter { $0.interval.needsFlag }
-        let groupedHeads = Dictionary(grouping: beamableHeads) {
+        let groupedHeads = Dictionary(grouping: noteHeads) {
             BeamGroupKey(
                 measureIndex: $0.measureIndex,
                 row: $0.row,
@@ -344,7 +343,7 @@ private extension NotationLayoutEngine {
                     return $0.start.x < $1.start.x
                 }
                 return $0.level < $1.level
-            }
+        }
     }
 
     private func beamRuns(from noteHeads: [RenderedNoteHead]) -> [[RenderedNoteHead]] {
@@ -358,6 +357,14 @@ private extension NotationLayoutEngine {
         var currentRun: [RenderedNoteHead] = []
 
         for noteHead in sortedHeads {
+            guard noteHead.interval.needsFlag else {
+                if currentRun.count >= 2 {
+                    runs.append(currentRun)
+                }
+                currentRun = []
+                continue
+            }
+
             if let previousHead = currentRun.last {
                 let timeDifference = abs(noteHead.timePosition - previousHead.timePosition)
                 if timeDifference <= BeamGroupingConstants.maxConsecutiveInterval
@@ -387,26 +394,65 @@ private extension NotationLayoutEngine {
     ) -> [RenderedBeam] {
         let maxFlagCount = noteHeads.map(\.interval.flagCount).max() ?? 0
 
-        return (0..<maxFlagCount).compactMap { level in
-            let levelHeads = noteHeads.filter { $0.interval.flagCount > level }
-            guard let firstHead = levelHeads.first, let lastHead = levelHeads.last, levelHeads.count >= 2 else {
-                return nil
+        return (0..<maxFlagCount).flatMap { level in
+            beamSegments(for: noteHeads, level: level).compactMap { levelHeads in
+                guard let firstHead = levelHeads.first, let lastHead = levelHeads.last, levelHeads.count >= 2 else {
+                    return nil
+                }
+
+                let start = beamPoint(for: firstHead, level: level, style: style)
+                let end = beamPoint(for: lastHead, level: level, style: style)
+                guard hasPositiveBeamSpan(from: firstHead, to: lastHead, start: start, end: end) else {
+                    return nil
+                }
+
+                return RenderedBeam(
+                    id: "beam_\(firstHead.measureIndex)_\(firstHead.row)_\(firstHead.voice.rawValue)_"
+                        + "\(firstHead.stemDirection.rawValue)_\(level)_\(firstHead.id)_\(lastHead.id)",
+                    noteHeadIDs: levelHeads.map(\.id),
+                    direction: firstHead.stemDirection,
+                    level: level,
+                    start: start,
+                    end: end,
+                    thickness: style.beamThickness
+                )
             }
-
-            let start = beamPoint(for: firstHead, level: level, style: style)
-            let end = beamPoint(for: lastHead, level: level, style: style)
-
-            return RenderedBeam(
-                id: "beam_\(firstHead.measureIndex)_\(firstHead.row)_\(firstHead.voice.rawValue)_"
-                    + "\(firstHead.stemDirection.rawValue)_\(level)_\(firstHead.id)_\(lastHead.id)",
-                noteHeadIDs: levelHeads.map(\.id),
-                direction: firstHead.stemDirection,
-                level: level,
-                start: start,
-                end: end,
-                thickness: style.beamThickness
-            )
         }
+    }
+
+    private func beamSegments(
+        for noteHeads: [RenderedNoteHead],
+        level: Int
+    ) -> [[RenderedNoteHead]] {
+        var segments: [[RenderedNoteHead]] = []
+        var currentSegment: [RenderedNoteHead] = []
+
+        for noteHead in noteHeads {
+            if noteHead.interval.flagCount > level {
+                currentSegment.append(noteHead)
+            } else {
+                if currentSegment.count >= 2 {
+                    segments.append(currentSegment)
+                }
+                currentSegment = []
+            }
+        }
+
+        if currentSegment.count >= 2 {
+            segments.append(currentSegment)
+        }
+
+        return segments
+    }
+
+    private func hasPositiveBeamSpan(
+        from firstHead: RenderedNoteHead,
+        to lastHead: RenderedNoteHead,
+        start: CGPoint,
+        end: CGPoint
+    ) -> Bool {
+        abs(lastHead.timePosition - firstHead.timePosition) > BeamGroupingConstants.comparisonTolerance
+            && abs(end.x - start.x) > BeamGroupingConstants.comparisonTolerance
     }
 
     private func stemStart(

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -457,11 +457,26 @@ private extension NotationLayoutEngine {
         beams: [RenderedBeam],
         style: NotationLayoutStyle
     ) -> [RenderedFlag] {
-        let beamedNoteHeadIDs = Set(beams.filter { $0.level == 0 }.flatMap(\.noteHeadIDs))
+        // Count how many beam levels each notehead is covered by.
+        // A notehead in a level-0 beam has 1 covered level, level-0 and level-1
+        // beams means 2 covered levels, etc.  Flags should only be emitted for
+        // levels NOT already represented by beams.
+        var coveredLevelsByNoteHead: [UInt64: Int] = [:]
+        for beam in beams {
+            for noteHeadID in beam.noteHeadIDs {
+                let current = coveredLevelsByNoteHead[noteHeadID] ?? 0
+                coveredLevelsByNoteHead[noteHeadID] = max(current, beam.level + 1)
+            }
+        }
 
         return noteHeads
-            .filter { $0.interval.needsFlag && !beamedNoteHeadIDs.contains($0.id) }
+            .filter { $0.interval.needsFlag }
             .flatMap { noteHead -> [RenderedFlag] in
+                let coveredLevels = coveredLevelsByNoteHead[noteHead.id] ?? 0
+                let totalFlags = noteHead.interval.flagCount
+                // Emit flags only for levels not already represented by beams
+                guard coveredLevels < totalFlags else { return [] }
+
                 let stemBottom = stemStart(for: noteHead, style: style)
                 let flagOrigin = CGPoint(
                     x: stemBottom.x + GameplayLayout.flagXOffset,
@@ -470,7 +485,7 @@ private extension NotationLayoutEngine {
                         : stemBottom.y + style.stemLength
                 )
 
-                return (0..<noteHead.interval.flagCount).map { flagIndex in
+                return (coveredLevels..<totalFlags).map { flagIndex in
                     let yOffset = noteHead.stemDirection == .up
                         ? CGFloat(flagIndex) * GameplayLayout.flagVerticalSpacing
                         : -CGFloat(flagIndex) * GameplayLayout.flagVerticalSpacing

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -346,26 +346,27 @@ struct NotationLayoutEngine {
             )
         }
 
-        return grouped.map { key, group in
+        return grouped.compactMap { key, group in
             let allIDs = group.map(\.id)
 
-            // Pick the representative noteHead: the one furthest in the stem direction.
-            // For up-stems: highest y (lowest on staff) — stem goes up from there.
-            // For down-stems: lowest y (highest on staff) — stem goes down from there.
             let representative: RenderedNoteHead
             switch key.direction {
             case .up:
-                representative = group.max(by: { $0.position.y < $1.position.y })!
+                guard let r = group.max(by: { $0.position.y < $1.position.y }) else {
+                    Logger.error("Stem grouping empty for key \(key) — skipping"); return nil
+                }
+                representative = r
             case .down:
-                representative = group.min(by: { $0.position.y < $1.position.y })!
+                guard let r = group.min(by: { $0.position.y < $1.position.y }) else {
+                    Logger.error("Stem grouping empty for key \(key) — skipping"); return nil
+                }
+                representative = r
             }
 
             let start = stemStart(for: representative, style: style)
 
-            // Check if ANY member of the group belongs to a beam.
-            // Pick the outermost beam across all group members.
             let candidateBeams = group.flatMap { head in
-                (beamsByNoteHeadID[head.id] ?? [])
+                beamsByNoteHeadID[head.id] ?? []
             }
             let outermostBeam = key.direction == .up
                 ? candidateBeams.min(by: { $0.start.y < $1.start.y })
@@ -406,17 +407,13 @@ struct NotationLayoutEngine {
         // Only extend to beam if beam has multiple note heads.
         guard beam.noteHeadIDs.count > 1 else { return nil }
 
-        // The beam spans from start.x to end.x. Find the Y at noteHead's X by linear interpolation.
-        let startX = beam.start.x
-        let endX = beam.end.x
+        let startX = beam.start.x, endX = beam.end.x
         let stemX = stemStart(for: noteHead, style: style).x
 
-        // Check if stem X is within beam span.
-        guard stemX >= min(startX, endX) && stemX <= max(startX, endX) else {
-            return nil
-        }
+        guard stemX >= min(startX, endX) && stemX <= max(startX, endX) else { return nil }
 
-        // Linear interpolation for Y at stemX.
+        guard endX != startX else { return nil }
+
         let t = (stemX - startX) / (endX - startX)
         let beamY = beam.start.y + t * (beam.end.y - beam.start.y)
 

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -24,13 +24,20 @@ struct NotationLayoutEngine {
     }
 
     func layout(input: NotationLayoutInput) -> NotationLayout {
-        let normalizedNotes = input.notes.sorted {
+        let sortedNotes = input.notes.sorted {
             MeasureUtils.timePosition(measureNumber: $0.measureNumber, measureOffset: $0.measureOffset)
             < MeasureUtils.timePosition(measureNumber: $1.measureNumber, measureOffset: $1.measureOffset)
         }
-        let totalMeasures = max(input.minimumMeasureCount, (normalizedNotes.map(\.measureNumber).max() ?? 1), 1)
-        let measures = buildMeasures(totalMeasures: totalMeasures, notes: normalizedNotes, input: input)
-        let noteHeads = buildNoteHeads(notes: normalizedNotes, measures: measures, input: input)
+        // Derive total measures from normalized positions so notes with
+        // measureOffset >= 1.0 (which roll into the next measure) are allocated correctly.
+        let maxNormalizedMeasureIndex = sortedNotes.map { note in
+            MeasureUtils.measureIndex(from: MeasureUtils.timePosition(
+                measureNumber: note.measureNumber, measureOffset: note.measureOffset
+            ))
+        }.max() ?? 0
+        let totalMeasures = max(input.minimumMeasureCount, maxNormalizedMeasureIndex + 1, 1)
+        let measures = buildMeasures(totalMeasures: totalMeasures, notes: sortedNotes, input: input)
+        let noteHeads = buildNoteHeads(notes: sortedNotes, measures: measures, input: input)
         let stems = buildStems(noteHeads: noteHeads, style: input.style)
         let beams = buildBeams(noteHeads: noteHeads, style: input.style)
         let flags = buildFlags(noteHeads: noteHeads, beams: beams, style: input.style)
@@ -96,8 +103,7 @@ struct NotationLayoutEngine {
         notes: [Note],
         input: NotationLayoutInput
     ) -> CGFloat {
-        let measureNumber = MeasureUtils.toOneBasedNumber(measureIndex)
-        let offsets = columnOffsets(for: measureNumber, notes: notes)
+        let offsets = columnOffsets(forMeasureIndex: measureIndex, notes: notes)
         let legacyWidth = GameplayLayout.measureWidth(for: input.timeSignature)
 
         guard offsets.count > 1 else {
@@ -108,7 +114,7 @@ struct NotationLayoutEngine {
             .map { pair in pair.0 - pair.1 }
             .min() ?? 0.25
         let requiredColumnGap = minimumColumnGap(
-            measureNumber: measureNumber,
+            measureIndex: measureIndex,
             notes: notes,
             style: input.style
         )
@@ -127,21 +133,21 @@ struct NotationLayoutEngine {
     }
 
     private func minimumColumnGap(
-        measureNumber: Int,
+        measureIndex: Int,
         notes: [Note],
         style: NotationLayoutStyle
     ) -> CGFloat {
-        guard containsCrossVoiceCollision(measureNumber: measureNumber, notes: notes) else {
+        guard containsCrossVoiceCollision(measureIndex: measureIndex, notes: notes) else {
             return style.minimumNoteColumnGap
         }
 
         return style.minimumNoteColumnGap + 2 * style.voiceCollisionOffset
     }
 
-    private func containsCrossVoiceCollision(measureNumber: Int, notes: [Note]) -> Bool {
+    private func containsCrossVoiceCollision(measureIndex: Int, notes: [Note]) -> Bool {
         Dictionary(
-            grouping: notes.filter { $0.measureNumber == measureNumber },
-            by: { quantizedColumn(for: $0.measureOffset) }
+            grouping: notes.filter { normalizedMeasureIndex(for: $0) == measureIndex },
+            by: { quantizedColumn(for: normalizedOffset(for: $0)) }
         )
         .values
         .contains { columnNotes in
@@ -254,15 +260,30 @@ struct NotationLayoutEngine {
         return drawableWidth / CGFloat(input.timeSignature.beatsPerMeasure)
     }
 
-    private func columnOffsets(for measureNumber: Int, notes: [Note]) -> [Double] {
+    private func columnOffsets(forMeasureIndex measureIndex: Int, notes: [Note]) -> [Double] {
         Set(notes
-            .filter { $0.measureNumber == measureNumber }
-            .map { quantizedOffset(for: $0.measureOffset) })
+            .filter { normalizedMeasureIndex(for: $0) == measureIndex }
+            .map { quantizedOffset(for: normalizedOffset(for: $0)) })
             .sorted()
     }
 
     private func quantizedOffset(for measureOffset: Double) -> Double {
         (measureOffset * Self.columnResolution).rounded() / Self.columnResolution
+    }
+
+    /// Zero-based measure index after normalizing measureOffset >= 1.0 into the next measure.
+    private func normalizedMeasureIndex(for note: Note) -> Int {
+        MeasureUtils.measureIndex(from: MeasureUtils.timePosition(
+            measureNumber: note.measureNumber, measureOffset: note.measureOffset
+        ))
+    }
+
+    /// Offset within the normalized measure (always in [0, 1)).
+    private func normalizedOffset(for note: Note) -> Double {
+        let timePos = MeasureUtils.timePosition(
+            measureNumber: note.measureNumber, measureOffset: note.measureOffset
+        )
+        return timePos - Double(MeasureUtils.measureIndex(from: timePos))
     }
 
     private func quantizedColumn(for measureOffset: Double) -> Int {

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -11,7 +11,6 @@ struct NotationLayoutEngine {
         let measureIndex: Int
         let quantizedColumn: Int
     }
-
     private struct NoteHeadDraft {
         let noteHead: RenderedNoteHead
         let collisionColumn: VoiceCollisionColumn
@@ -37,7 +36,6 @@ struct NotationLayoutEngine {
         let totalMeasures = max(input.minimumMeasureCount, maxNormalizedMeasureIndex + 1, 1)
         let measures = buildMeasures(totalMeasures: totalMeasures, notes: sortedNotes, input: input)
         let noteHeads = buildNoteHeads(notes: sortedNotes, measures: measures, input: input)
-        // Build beams first so stems can extend to beam lines when notes are beamed.
         let beams = buildBeams(noteHeads: noteHeads, style: input.style)
         let stems = buildStems(noteHeads: noteHeads, beams: beams, style: input.style)
         let flags = buildFlags(noteHeads: noteHeads, beams: beams, style: input.style)
@@ -78,7 +76,6 @@ struct NotationLayoutEngine {
         var result: [RenderedMeasure] = []
         var currentRow = 0
         var currentX = GameplayLayout.leftMargin
-
         for measureIndex in 0..<totalMeasures {
             let width = measureWidth(measureIndex: measureIndex, notes: notes, input: input)
             if currentX + width > input.style.rowWidth, measureIndex > 0 {
@@ -87,11 +84,8 @@ struct NotationLayoutEngine {
             }
             result.append(
                 RenderedMeasure(
-                    id: measureIndex,
-                    measureIndex: measureIndex,
-                    row: currentRow,
-                    xOffset: currentX,
-                    width: width
+                    id: measureIndex, measureIndex: measureIndex,
+                    row: currentRow, xOffset: currentX, width: width
                 )
             )
             currentX += width + GameplayLayout.measureSpacing
@@ -190,15 +184,13 @@ struct NotationLayoutEngine {
                 + CGFloat(beatPosition) * beatGap
             let y = GameplayLayout.StaffLinePosition.line1.absoluteY(for: measure.row)
                 + drumType.notePosition.yOffset
-            let id = nextID
             let voice = NotationVoice.voice(for: drumType)
             let direction = stemDirection(for: drumType, voice: voice)
             nextID += 1
-
             drafts.append(
                 NoteHeadDraft(
                     noteHead: RenderedNoteHead(
-                        id: id,
+                        id: nextID - 1,
                         sourceNoteID: ObjectIdentifier(note),
                         drumType: drumType,
                         voice: voice,
@@ -334,6 +326,8 @@ struct NotationLayoutEngine {
         // (i.e., chord tones) so they share a single stem instead of overlapping.
         struct StemGroupKey: Hashable {
             let x: Int // Rounded to avoid floating-point drift
+            let row: Int
+            let measureIndex: Int
             let voice: NotationVoice
             let direction: StemDirection
         }
@@ -341,6 +335,8 @@ struct NotationLayoutEngine {
         let grouped = Dictionary(grouping: headsNeedingStems) { head in
             StemGroupKey(
                 x: Int((head.position.x * 1000).rounded()),
+                row: head.row,
+                measureIndex: head.measureIndex,
                 voice: head.voice,
                 direction: head.stemDirection
             )
@@ -375,7 +371,7 @@ struct NotationLayoutEngine {
             if let beam = outermostBeam,
                let beamY = beamEndY(for: representative, beam: beam, style: style) {
                 return RenderedStem(
-                    id: "stem_group_\(key.x)_\(key.voice.rawValue)_\(key.direction.rawValue)",
+                    id: "stem_group_\(key.x)_r\(key.row)_m\(key.measureIndex)_\(key.voice.rawValue)_\(key.direction.rawValue)",
                     noteHeadIDs: allIDs,
                     direction: key.direction,
                     start: start,
@@ -389,7 +385,7 @@ struct NotationLayoutEngine {
             }
 
             return RenderedStem(
-                id: "stem_group_\(key.x)_\(key.voice.rawValue)_\(key.direction.rawValue)",
+                id: "stem_group_\(key.x)_r\(key.row)_m\(key.measureIndex)_\(key.voice.rawValue)_\(key.direction.rawValue)",
                 noteHeadIDs: allIDs,
                 direction: key.direction,
                 start: start,

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -16,6 +16,13 @@ struct NotationLayoutEngine {
         let collisionColumn: VoiceCollisionColumn
     }
 
+    private struct BeamGroupKey: Hashable {
+        let measureIndex: Int
+        let row: Int
+        let voice: NotationVoice
+        let stemDirection: StemDirection
+    }
+
     func layout(input: NotationLayoutInput) -> NotationLayout {
         let normalizedNotes = input.notes.sorted {
             MeasureUtils.timePosition(measureNumber: $0.measureNumber, measureOffset: $0.measureOffset)
@@ -24,6 +31,8 @@ struct NotationLayoutEngine {
         let totalMeasures = max(1, (normalizedNotes.map(\.measureNumber).max() ?? 1))
         let measures = buildMeasures(totalMeasures: totalMeasures, notes: normalizedNotes, input: input)
         let noteHeads = buildNoteHeads(notes: normalizedNotes, measures: measures, input: input)
+        let stems = buildStems(noteHeads: noteHeads, style: input.style)
+        let beams = buildBeams(noteHeads: noteHeads, style: input.style)
         let ledgerLines = buildLedgerLines(noteHeads: noteHeads, style: input.style)
         let measureBars = buildMeasureBars(measures: measures)
         let beatLookup = Dictionary(uniqueKeysWithValues: noteHeads.map { ($0.id, $0.position) })
@@ -36,8 +45,8 @@ struct NotationLayoutEngine {
         return NotationLayout(
             measures: measures,
             noteHeads: noteHeads,
-            stems: [],
-            beams: [],
+            stems: stems,
+            beams: beams,
             ledgerLines: ledgerLines,
             measureBars: measureBars,
             beatLookup: beatLookup,
@@ -161,6 +170,7 @@ struct NotationLayoutEngine {
                 + drumType.notePosition.yOffset
             let id = nextID
             let voice = NotationVoice.voice(for: drumType)
+            let direction = stemDirection(for: drumType, voice: voice)
             nextID += 1
 
             drafts.append(
@@ -178,7 +188,7 @@ struct NotationLayoutEngine {
                         row: measure.row,
                         position: CGPoint(x: x, y: y),
                         staffStep: staffStep(for: drumType.notePosition),
-                        stemDirection: .up,
+                        stemDirection: direction,
                         interval: note.interval
                     ),
                     collisionColumn: VoiceCollisionColumn(
@@ -252,6 +262,181 @@ struct NotationLayoutEngine {
 
     private func staffStep(for position: GameplayLayout.NotePosition) -> Int {
         Int((position.yOffset / (GameplayLayout.staffLineSpacing / 2)).rounded())
+    }
+}
+
+private extension NotationLayoutEngine {
+    private func stemDirection(for drumType: DrumType, voice: NotationVoice) -> StemDirection {
+        guard voice == .upper else { return .down }
+
+        switch drumType.notePosition {
+        case .aboveLine9, .aboveLine8, .aboveLine7, .aboveLine6, .aboveLine5, .line5:
+            return .down
+        case .spaceBetween4And5,
+             .line4,
+             .spaceBetween3And4,
+             .line3,
+             .spaceBetween2And3,
+             .line2,
+             .spaceBetween1And2,
+             .line1,
+             .spaceBetweenLine1AndBelow,
+             .belowLine1,
+             .belowLine2,
+             .belowLine3,
+             .belowLine4,
+             .belowLine5,
+             .belowLine6:
+            return .up
+        }
+    }
+
+    private func buildStems(
+        noteHeads: [RenderedNoteHead],
+        style: NotationLayoutStyle
+    ) -> [RenderedStem] {
+        noteHeads
+            .filter { $0.interval.needsStem }
+            .map { noteHead in
+                let start = stemStart(for: noteHead, style: style)
+                let endY = switch noteHead.stemDirection {
+                case .up:
+                    start.y - style.stemLength
+                case .down:
+                    start.y + style.stemLength
+                }
+
+                return RenderedStem(
+                    id: "stem_\(noteHead.id)",
+                    noteHeadIDs: [noteHead.id],
+                    direction: noteHead.stemDirection,
+                    start: start,
+                    end: CGPoint(x: start.x, y: endY)
+                )
+            }
+    }
+
+    private func buildBeams(
+        noteHeads: [RenderedNoteHead],
+        style: NotationLayoutStyle
+    ) -> [RenderedBeam] {
+        let beamableHeads = noteHeads.filter { $0.interval.needsFlag }
+        let groupedHeads = Dictionary(grouping: beamableHeads) {
+            BeamGroupKey(
+                measureIndex: $0.measureIndex,
+                row: $0.row,
+                voice: $0.voice,
+                stemDirection: $0.stemDirection
+            )
+        }
+
+        return groupedHeads.values
+            .flatMap { heads in
+                beamRuns(from: heads).flatMap { run in
+                    beams(for: run, style: style)
+                }
+            }
+            .sorted {
+                if $0.start.y != $1.start.y {
+                    return $0.start.y < $1.start.y
+                }
+                if $0.start.x != $1.start.x {
+                    return $0.start.x < $1.start.x
+                }
+                return $0.level < $1.level
+            }
+    }
+
+    private func beamRuns(from noteHeads: [RenderedNoteHead]) -> [[RenderedNoteHead]] {
+        let sortedHeads = noteHeads.sorted {
+            if abs($0.timePosition - $1.timePosition) > BeamGroupingConstants.comparisonTolerance {
+                return $0.timePosition < $1.timePosition
+            }
+            return $0.id < $1.id
+        }
+        var runs: [[RenderedNoteHead]] = []
+        var currentRun: [RenderedNoteHead] = []
+
+        for noteHead in sortedHeads {
+            if let previousHead = currentRun.last {
+                let timeDifference = abs(noteHead.timePosition - previousHead.timePosition)
+                if timeDifference <= BeamGroupingConstants.maxConsecutiveInterval
+                    + BeamGroupingConstants.comparisonTolerance {
+                    currentRun.append(noteHead)
+                } else {
+                    if currentRun.count >= 2 {
+                        runs.append(currentRun)
+                    }
+                    currentRun = [noteHead]
+                }
+            } else {
+                currentRun = [noteHead]
+            }
+        }
+
+        if currentRun.count >= 2 {
+            runs.append(currentRun)
+        }
+
+        return runs
+    }
+
+    private func beams(
+        for noteHeads: [RenderedNoteHead],
+        style: NotationLayoutStyle
+    ) -> [RenderedBeam] {
+        let maxFlagCount = noteHeads.map(\.interval.flagCount).max() ?? 0
+
+        return (0..<maxFlagCount).compactMap { level in
+            let levelHeads = noteHeads.filter { $0.interval.flagCount > level }
+            guard let firstHead = levelHeads.first, let lastHead = levelHeads.last, levelHeads.count >= 2 else {
+                return nil
+            }
+
+            let start = beamPoint(for: firstHead, level: level, style: style)
+            let end = beamPoint(for: lastHead, level: level, style: style)
+
+            return RenderedBeam(
+                id: "beam_\(firstHead.measureIndex)_\(firstHead.row)_\(firstHead.voice.rawValue)_"
+                    + "\(firstHead.stemDirection.rawValue)_\(level)_\(firstHead.id)_\(lastHead.id)",
+                noteHeadIDs: levelHeads.map(\.id),
+                direction: firstHead.stemDirection,
+                level: level,
+                start: start,
+                end: end,
+                thickness: style.beamThickness
+            )
+        }
+    }
+
+    private func stemStart(
+        for noteHead: RenderedNoteHead,
+        style: NotationLayoutStyle
+    ) -> CGPoint {
+        let xOffset = switch noteHead.stemDirection {
+        case .up:
+            style.stemXInset
+        case .down:
+            -style.stemXInset
+        }
+
+        return CGPoint(x: noteHead.position.x + xOffset, y: noteHead.position.y)
+    }
+
+    private func beamPoint(
+        for noteHead: RenderedNoteHead,
+        level: Int,
+        style: NotationLayoutStyle
+    ) -> CGPoint {
+        let start = stemStart(for: noteHead, style: style)
+        let yOffset = switch noteHead.stemDirection {
+        case .up:
+            -style.stemLength - CGFloat(level) * style.beamLevelSpacing
+        case .down:
+            style.stemLength + CGFloat(level) * style.beamLevelSpacing
+        }
+
+        return CGPoint(x: start.x, y: noteHead.position.y + yOffset)
     }
 
     private func buildLedgerLines(

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -91,7 +91,12 @@ struct NotationLayoutEngine {
         let smallestGap = zip(offsets.dropFirst(), offsets)
             .map { pair in pair.0 - pair.1 }
             .min() ?? 0.25
-        let minimumBeatGap = input.style.minimumNoteColumnGap / CGFloat(
+        let requiredColumnGap = minimumColumnGap(
+            measureNumber: measureNumber,
+            notes: notes,
+            style: input.style
+        )
+        let minimumBeatGap = requiredColumnGap / CGFloat(
             max(smallestGap * Double(input.timeSignature.beatsPerMeasure), 0.001)
         )
         let beatGap = max(
@@ -103,6 +108,36 @@ struct NotationLayoutEngine {
             + CGFloat(input.timeSignature.beatsPerMeasure) * beatGap
 
         return max(legacyWidth, adaptiveWidth)
+    }
+
+    private func minimumColumnGap(
+        measureNumber: Int,
+        notes: [Note],
+        style: NotationLayoutStyle
+    ) -> CGFloat {
+        guard containsCrossVoiceCollision(measureNumber: measureNumber, notes: notes) else {
+            return style.minimumNoteColumnGap
+        }
+
+        return style.minimumNoteColumnGap + 2 * style.voiceCollisionOffset
+    }
+
+    private func containsCrossVoiceCollision(measureNumber: Int, notes: [Note]) -> Bool {
+        Dictionary(
+            grouping: notes.filter { $0.measureNumber == measureNumber },
+            by: { quantizedColumn(for: $0.measureOffset) }
+        )
+        .values
+        .contains { columnNotes in
+            let voices = Set(columnNotes.compactMap { note -> NotationVoice? in
+                guard let drumType = DrumType.from(noteType: note.noteType) else {
+                    return nil
+                }
+                return NotationVoice.voice(for: drumType)
+            })
+
+            return voices.count > 1
+        }
     }
 
     private func buildNoteHeads(

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -328,43 +328,73 @@ struct NotationLayoutEngine {
             }
         }
 
-        return noteHeads
-            .filter { $0.interval.needsStem }
-            .map { noteHead in
-                let start = stemStart(for: noteHead, style: style)
-                // Check if this noteHead belongs to beams. If so, compute stem end from beam geometry.
-                // Pick the beam farthest in the stem direction so the stem extends through all levels.
-                // Beams are sorted by Y ascending: up-stems need .first (lowest Y = outermost),
-                // down-stems need .last (highest Y = outermost).
-                if let beamsForNote = beamsByNoteHeadID[noteHead.id],
-                   let outermostBeam = noteHead.stemDirection == .up
-                       ? beamsForNote.first
-                       : beamsForNote.last,
-                   let beamY = beamEndY(for: noteHead, beam: outermostBeam, style: style) {
-                    return RenderedStem(
-                        id: "stem_\(noteHead.id)",
-                        noteHeadIDs: [noteHead.id],
-                        direction: noteHead.stemDirection,
-                        start: start,
-                        end: CGPoint(x: start.x, y: beamY)
-                    )
-                }
-                // Not beamed - use fixed stem length.
-                let endY = switch noteHead.stemDirection {
-                case .up:
-                    start.y - style.stemLength
-                case .down:
-                    start.y + style.stemLength
-                }
+        let headsNeedingStems = noteHeads.filter { $0.interval.needsStem }
 
+        // Group note heads that share the same x, voice, and stem direction
+        // (i.e., chord tones) so they share a single stem instead of overlapping.
+        struct StemGroupKey: Hashable {
+            let x: Int // Rounded to avoid floating-point drift
+            let voice: NotationVoice
+            let direction: StemDirection
+        }
+
+        let grouped = Dictionary(grouping: headsNeedingStems) { head in
+            StemGroupKey(
+                x: Int((head.position.x * 1000).rounded()),
+                voice: head.voice,
+                direction: head.stemDirection
+            )
+        }
+
+        return grouped.map { key, group in
+            let allIDs = group.map(\.id)
+
+            // Pick the representative noteHead: the one furthest in the stem direction.
+            // For up-stems: highest y (lowest on staff) — stem goes up from there.
+            // For down-stems: lowest y (highest on staff) — stem goes down from there.
+            let representative: RenderedNoteHead
+            switch key.direction {
+            case .up:
+                representative = group.max(by: { $0.position.y < $1.position.y })!
+            case .down:
+                representative = group.min(by: { $0.position.y < $1.position.y })!
+            }
+
+            let start = stemStart(for: representative, style: style)
+
+            // Check if ANY member of the group belongs to a beam.
+            // Pick the outermost beam across all group members.
+            let candidateBeams = group.flatMap { head in
+                (beamsByNoteHeadID[head.id] ?? [])
+            }
+            let outermostBeam = key.direction == .up
+                ? candidateBeams.min(by: { $0.start.y < $1.start.y })
+                : candidateBeams.max(by: { $0.start.y < $1.start.y })
+
+            if let beam = outermostBeam,
+               let beamY = beamEndY(for: representative, beam: beam, style: style) {
                 return RenderedStem(
-                    id: "stem_\(noteHead.id)",
-                    noteHeadIDs: [noteHead.id],
-                    direction: noteHead.stemDirection,
+                    id: "stem_group_\(key.x)_\(key.voice.rawValue)_\(key.direction.rawValue)",
+                    noteHeadIDs: allIDs,
+                    direction: key.direction,
                     start: start,
-                    end: CGPoint(x: start.x, y: endY)
+                    end: CGPoint(x: start.x, y: beamY)
                 )
             }
+            // Not beamed — use fixed stem length from the representative head.
+            let endY: CGFloat = switch key.direction {
+            case .up: start.y - style.stemLength
+            case .down: start.y + style.stemLength
+            }
+
+            return RenderedStem(
+                id: "stem_group_\(key.x)_\(key.voice.rawValue)_\(key.direction.rawValue)",
+                noteHeadIDs: allIDs,
+                direction: key.direction,
+                start: start,
+                end: CGPoint(x: start.x, y: endY)
+            )
+        }
     }
 
     /// Computes stem end Y from beam geometry if noteHead is beamed.

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -2,7 +2,7 @@ import CoreGraphics
 import Foundation
 
 struct NotationLayoutEngine {
-    private static let columnResolution = 1000.0
+    private static let columnResolution = 960.0
 
     func layout(input: NotationLayoutInput) -> NotationLayout {
         let normalizedNotes = input.notes.sorted {
@@ -145,7 +145,7 @@ struct NotationLayoutEngine {
     }
 
     private func quantizedOffset(for measureOffset: Double) -> Double {
-        Double(Int(measureOffset * Self.columnResolution)) / Self.columnResolution
+        (measureOffset * Self.columnResolution).rounded() / Self.columnResolution
     }
 
     private func staffStep(for position: GameplayLayout.NotePosition) -> Int {

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -3,6 +3,18 @@ import Foundation
 
 struct NotationLayoutEngine {
     private static let columnResolution = 960.0
+    private static let topStaffStep = -8
+    private static let bottomStaffStep = 0
+
+    private struct VoiceCollisionColumn: Hashable {
+        let measureIndex: Int
+        let quantizedColumn: Int
+    }
+
+    private struct NoteHeadDraft {
+        let noteHead: RenderedNoteHead
+        let collisionColumn: VoiceCollisionColumn
+    }
 
     func layout(input: NotationLayoutInput) -> NotationLayout {
         let normalizedNotes = input.notes.sorted {
@@ -12,6 +24,7 @@ struct NotationLayoutEngine {
         let totalMeasures = max(1, (normalizedNotes.map(\.measureNumber).max() ?? 1))
         let measures = buildMeasures(totalMeasures: totalMeasures, notes: normalizedNotes, input: input)
         let noteHeads = buildNoteHeads(notes: normalizedNotes, measures: measures, input: input)
+        let ledgerLines = buildLedgerLines(noteHeads: noteHeads, style: input.style)
         let measureBars = buildMeasureBars(measures: measures)
         let beatLookup = Dictionary(uniqueKeysWithValues: noteHeads.map { ($0.id, $0.position) })
         let totalHeight = GameplayLayout.totalHeight(
@@ -25,7 +38,7 @@ struct NotationLayoutEngine {
             noteHeads: noteHeads,
             stems: [],
             beams: [],
-            ledgerLines: [],
+            ledgerLines: ledgerLines,
             measureBars: measureBars,
             beatLookup: beatLookup,
             totalHeight: totalHeight
@@ -99,11 +112,12 @@ struct NotationLayoutEngine {
     ) -> [RenderedNoteHead] {
         var nextID: UInt64 = 0
         let measuresByIndex = Dictionary(uniqueKeysWithValues: measures.map { ($0.measureIndex, $0) })
+        var drafts: [NoteHeadDraft] = []
 
-        return notes.compactMap { note in
-            guard let drumType = DrumType.from(noteType: note.noteType) else { return nil }
+        for note in notes {
+            guard let drumType = DrumType.from(noteType: note.noteType) else { continue }
             let measureIndex = MeasureUtils.toZeroBasedIndex(note.measureNumber)
-            guard let measure = measuresByIndex[measureIndex] else { return nil }
+            guard let measure = measuresByIndex[measureIndex] else { continue }
             let beatGap = beatGap(for: measure, input: input)
             let beatPosition = quantizedOffset(for: note.measureOffset) * Double(input.timeSignature.beatsPerMeasure)
             let x = measure.xOffset + GameplayLayout.barLineWidth + GameplayLayout.uniformSpacing
@@ -111,23 +125,72 @@ struct NotationLayoutEngine {
             let y = GameplayLayout.StaffLinePosition.line1.absoluteY(for: measure.row)
                 + drumType.notePosition.yOffset
             let id = nextID
+            let voice = NotationVoice.voice(for: drumType)
             nextID += 1
 
+            drafts.append(
+                NoteHeadDraft(
+                    noteHead: RenderedNoteHead(
+                        id: id,
+                        sourceNoteID: ObjectIdentifier(note),
+                        drumType: drumType,
+                        voice: voice,
+                        timePosition: MeasureUtils.timePosition(
+                            measureNumber: note.measureNumber,
+                            measureOffset: note.measureOffset
+                        ),
+                        measureIndex: measureIndex,
+                        row: measure.row,
+                        position: CGPoint(x: x, y: y),
+                        staffStep: staffStep(for: drumType.notePosition),
+                        stemDirection: .up,
+                        interval: note.interval
+                    ),
+                    collisionColumn: VoiceCollisionColumn(
+                        measureIndex: measureIndex,
+                        quantizedColumn: quantizedColumn(for: note.measureOffset)
+                    )
+                )
+            )
+        }
+
+        return applyVoiceCollisionOffsets(to: drafts, style: input.style)
+    }
+
+    private func applyVoiceCollisionOffsets(
+        to drafts: [NoteHeadDraft],
+        style: NotationLayoutStyle
+    ) -> [RenderedNoteHead] {
+        let collisionColumns = Set(
+            Dictionary(grouping: drafts, by: \.collisionColumn).compactMap { column, drafts in
+                Set(drafts.map(\.noteHead.voice)).count > 1 ? column : nil
+            }
+        )
+
+        return drafts.map { draft in
+            let noteHead = draft.noteHead
+            guard collisionColumns.contains(draft.collisionColumn) else {
+                return noteHead
+            }
+
+            let xOffset = noteHead.voice == .upper
+                ? style.voiceCollisionOffset
+                : -style.voiceCollisionOffset
             return RenderedNoteHead(
-                id: id,
-                sourceNoteID: ObjectIdentifier(note),
-                drumType: drumType,
-                voice: NotationVoice.voice(for: drumType),
-                timePosition: MeasureUtils.timePosition(
-                    measureNumber: note.measureNumber,
-                    measureOffset: note.measureOffset
+                id: noteHead.id,
+                sourceNoteID: noteHead.sourceNoteID,
+                drumType: noteHead.drumType,
+                voice: noteHead.voice,
+                timePosition: noteHead.timePosition,
+                measureIndex: noteHead.measureIndex,
+                row: noteHead.row,
+                position: CGPoint(
+                    x: noteHead.position.x + xOffset,
+                    y: noteHead.position.y
                 ),
-                measureIndex: measureIndex,
-                row: measure.row,
-                position: CGPoint(x: x, y: y),
-                staffStep: staffStep(for: drumType.notePosition),
-                stemDirection: .up,
-                interval: note.interval
+                staffStep: noteHead.staffStep,
+                stemDirection: noteHead.stemDirection,
+                interval: noteHead.interval
             )
         }
     }
@@ -148,8 +211,42 @@ struct NotationLayoutEngine {
         (measureOffset * Self.columnResolution).rounded() / Self.columnResolution
     }
 
+    private func quantizedColumn(for measureOffset: Double) -> Int {
+        Int((measureOffset * Self.columnResolution).rounded())
+    }
+
     private func staffStep(for position: GameplayLayout.NotePosition) -> Int {
         Int((position.yOffset / (GameplayLayout.staffLineSpacing / 2)).rounded())
+    }
+
+    private func buildLedgerLines(
+        noteHeads: [RenderedNoteHead],
+        style: NotationLayoutStyle
+    ) -> [RenderedLedgerLine] {
+        noteHeads.flatMap { noteHead in
+            ledgerSteps(for: noteHead.staffStep).map { step in
+                let y = GameplayLayout.StaffLinePosition.line1.absoluteY(for: noteHead.row)
+                    + CGFloat(step) * (style.staffLineSpacing / 2)
+                let overhang = style.noteHeadWidth / 2 + style.ledgerLineOverhang
+
+                return RenderedLedgerLine(
+                    id: "ledger_\(noteHead.id)_\(step)",
+                    row: noteHead.row,
+                    start: CGPoint(x: noteHead.position.x - overhang, y: y),
+                    end: CGPoint(x: noteHead.position.x + overhang, y: y)
+                )
+            }
+        }
+    }
+
+    private func ledgerSteps(for staffStep: Int) -> [Int] {
+        if staffStep < Self.topStaffStep {
+            return stride(from: Self.topStaffStep - 2, through: staffStep, by: -2).map { $0 }
+        }
+        if staffStep > Self.bottomStaffStep {
+            return stride(from: Self.bottomStaffStep + 2, through: staffStep, by: 2).map { $0 }
+        }
+        return []
     }
 
     private func buildMeasureBars(measures: [RenderedMeasure]) -> [RenderedMeasureBar] {

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -319,9 +319,13 @@ struct NotationLayoutEngine {
         beams: [RenderedBeam],
         style: NotationLayoutStyle
     ) -> [RenderedStem] {
-        // Group beams by the first noteHeadID for quick lookup.
-        let beamsByNoteHeadID = Dictionary(grouping: beams) { beam in
-            beam.noteHeadIDs.first
+        // Index beams under every noteHeadID so non-leading notes in a beam run
+        // can also look up their beam geometry.
+        var beamsByNoteHeadID: [UInt64: [RenderedBeam]] = [:]
+        for beam in beams {
+            for noteHeadID in beam.noteHeadIDs {
+                beamsByNoteHeadID[noteHeadID, default: []].append(beam)
+            }
         }
 
         return noteHeads
@@ -371,7 +375,7 @@ struct NotationLayoutEngine {
         // The beam spans from start.x to end.x. Find the Y at noteHead's X by linear interpolation.
         let startX = beam.start.x
         let endX = beam.end.x
-        let stemX = noteHead.position.x
+        let stemX = stemStart(for: noteHead, style: style).x
 
         // Check if stem X is within beam span.
         guard stemX >= min(startX, endX) && stemX <= max(startX, endX) else {

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -573,11 +573,22 @@ private extension NotationLayoutEngine {
                 ))
             }
 
-            // End barline: single barline at every measure end
+            // End barline: align with next same-row measure's start so the shared
+            // boundary sits at the following measure's xOffset rather than leaving
+            // a measureSpacing-wide gap between the drawn bar and the next measure.
+            let nextOnSameRow = measures.count > index + 1
+                && measures[index + 1].row == measure.row
+            let endX: CGFloat
+            if nextOnSameRow {
+                endX = measures[index + 1].xOffset
+            } else {
+                endX = measure.xOffset + measure.width
+            }
+
             bars.append(RenderedMeasureBar(
                 id: "bar_\(measure.measureIndex)_end",
                 row: measure.row,
-                x: measure.xOffset + measure.width,
+                x: endX,
                 isFinal: isLastOverall
             ))
         }

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -33,6 +33,7 @@ struct NotationLayoutEngine {
         let noteHeads = buildNoteHeads(notes: normalizedNotes, measures: measures, input: input)
         let stems = buildStems(noteHeads: noteHeads, style: input.style)
         let beams = buildBeams(noteHeads: noteHeads, style: input.style)
+        let flags = buildFlags(noteHeads: noteHeads, beams: beams, style: input.style)
         let ledgerLines = buildLedgerLines(noteHeads: noteHeads, style: input.style)
         let measureBars = buildMeasureBars(measures: measures)
         let beatLookup = Dictionary(uniqueKeysWithValues: noteHeads.map { ($0.id, $0.position) })
@@ -51,6 +52,7 @@ struct NotationLayoutEngine {
             noteHeads: noteHeads,
             stems: stems,
             beams: beams,
+            flags: flags,
             ledgerLines: ledgerLines,
             measureBars: measureBars,
             beatLookup: beatLookup,
@@ -450,6 +452,40 @@ private extension NotationLayoutEngine {
         return segments
     }
 
+    private func buildFlags(
+        noteHeads: [RenderedNoteHead],
+        beams: [RenderedBeam],
+        style: NotationLayoutStyle
+    ) -> [RenderedFlag] {
+        let beamedNoteHeadIDs = Set(beams.filter { $0.level == 0 }.flatMap(\.noteHeadIDs))
+
+        return noteHeads
+            .filter { $0.interval.needsFlag && !beamedNoteHeadIDs.contains($0.id) }
+            .flatMap { noteHead -> [RenderedFlag] in
+                let stemBottom = stemStart(for: noteHead, style: style)
+                let flagOrigin = CGPoint(
+                    x: stemBottom.x + GameplayLayout.flagXOffset,
+                    y: noteHead.stemDirection == .up
+                        ? stemBottom.y - style.stemLength
+                        : stemBottom.y + style.stemLength
+                )
+
+                return (0..<noteHead.interval.flagCount).map { flagIndex in
+                    let yOffset = noteHead.stemDirection == .up
+                        ? CGFloat(flagIndex) * GameplayLayout.flagVerticalSpacing
+                        : -CGFloat(flagIndex) * GameplayLayout.flagVerticalSpacing
+
+                    return RenderedFlag(
+                        id: "flag_\(noteHead.id)_\(flagIndex)",
+                        noteHeadID: noteHead.id,
+                        stemDirection: noteHead.stemDirection,
+                        flagIndex: flagIndex,
+                        origin: CGPoint(x: flagOrigin.x, y: flagOrigin.y + yOffset)
+                    )
+                }
+            }
+    }
+
     private func hasPositiveBeamSpan(
         from firstHead: RenderedNoteHead,
         to lastHead: RenderedNoteHead,
@@ -521,21 +557,31 @@ private extension NotationLayoutEngine {
     }
 
     private func buildMeasureBars(measures: [RenderedMeasure]) -> [RenderedMeasureBar] {
-        measures.flatMap { measure in
-            [
-                RenderedMeasureBar(
+        var bars: [RenderedMeasureBar] = []
+
+        for (index, measure) in measures.enumerated() {
+            let isFirstInRow = index == 0 || measures[index - 1].row != measure.row
+            let isLastOverall = measure.measureIndex == measures.last?.measureIndex
+
+            // Start barline: only at row beginnings
+            if isFirstInRow {
+                bars.append(RenderedMeasureBar(
                     id: "bar_\(measure.measureIndex)",
                     row: measure.row,
                     x: measure.xOffset,
                     isFinal: false
-                ),
-                RenderedMeasureBar(
-                    id: "bar_\(measure.measureIndex)_end",
-                    row: measure.row,
-                    x: measure.xOffset + measure.width,
-                    isFinal: measure.measureIndex == measures.last?.measureIndex
-                )
-            ]
+                ))
+            }
+
+            // End barline: single barline at every measure end
+            bars.append(RenderedMeasureBar(
+                id: "bar_\(measure.measureIndex)_end",
+                row: measure.row,
+                x: measure.xOffset + measure.width,
+                isFinal: isLastOverall
+            ))
         }
+
+        return bars
     }
 }

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -36,7 +36,7 @@ struct NotationLayoutEngine {
         let flags = buildFlags(noteHeads: noteHeads, beams: beams, style: input.style)
         let ledgerLines = buildLedgerLines(noteHeads: noteHeads, style: input.style)
         let measureBars = buildMeasureBars(measures: measures)
-        let beatLookup = Dictionary(uniqueKeysWithValues: noteHeads.map { ($0.id, $0.position) })
+        let noteHeadPositionsByID = Dictionary(uniqueKeysWithValues: noteHeads.map { ($0.id, $0.position) })
         let noteHeadIDsByTimePosition = Dictionary(
             grouping: noteHeads,
             by: { NotationLayout.timePositionKey($0.timePosition) }
@@ -55,7 +55,7 @@ struct NotationLayoutEngine {
             flags: flags,
             ledgerLines: ledgerLines,
             measureBars: measureBars,
-            beatLookup: beatLookup,
+            noteHeadPositionsByID: noteHeadPositionsByID,
             noteHeadIDsByTimePosition: noteHeadIDsByTimePosition,
             totalHeight: totalHeight
         )

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -167,10 +167,15 @@ struct NotationLayoutEngine {
 
         for note in notes {
             guard let drumType = DrumType.from(noteType: note.noteType) else { continue }
-            let measureIndex = MeasureUtils.toZeroBasedIndex(note.measureNumber)
-            guard let measure = measuresByIndex[measureIndex] else { continue }
+            let timePos = MeasureUtils.timePosition(
+                measureNumber: note.measureNumber,
+                measureOffset: note.measureOffset
+            )
+            let normalizedMeasureIndex = MeasureUtils.measureIndex(from: timePos)
+            let normalizedOffset = timePos - Double(normalizedMeasureIndex)
+            guard let measure = measuresByIndex[normalizedMeasureIndex] else { continue }
             let beatGap = beatGap(for: measure, input: input)
-            let beatPosition = quantizedOffset(for: note.measureOffset) * Double(input.timeSignature.beatsPerMeasure)
+            let beatPosition = quantizedOffset(for: normalizedOffset) * Double(input.timeSignature.beatsPerMeasure)
             let x = measure.xOffset + GameplayLayout.barLineWidth + GameplayLayout.uniformSpacing
                 + CGFloat(beatPosition) * beatGap
             let y = GameplayLayout.StaffLinePosition.line1.absoluteY(for: measure.row)
@@ -187,11 +192,8 @@ struct NotationLayoutEngine {
                         sourceNoteID: ObjectIdentifier(note),
                         drumType: drumType,
                         voice: voice,
-                        timePosition: MeasureUtils.timePosition(
-                            measureNumber: note.measureNumber,
-                            measureOffset: note.measureOffset
-                        ),
-                        measureIndex: measureIndex,
+                        timePosition: timePos,
+                        measureIndex: normalizedMeasureIndex,
                         row: measure.row,
                         position: CGPoint(x: x, y: y),
                         staffStep: staffStep(for: drumType.notePosition),
@@ -199,8 +201,8 @@ struct NotationLayoutEngine {
                         interval: note.interval
                     ),
                     collisionColumn: VoiceCollisionColumn(
-                        measureIndex: measureIndex,
-                        quantizedColumn: quantizedColumn(for: note.measureOffset)
+                        measureIndex: normalizedMeasureIndex,
+                        quantizedColumn: quantizedColumn(for: normalizedOffset)
                     )
                 )
             )

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -1,6 +1,7 @@
 import CoreGraphics
 import Foundation
 
+/// Core layout engine - handles measure construction and note head placement.
 struct NotationLayoutEngine {
     private static let columnResolution = 960.0
     private static let topStaffStep = -8
@@ -16,7 +17,7 @@ struct NotationLayoutEngine {
         let collisionColumn: VoiceCollisionColumn
     }
 
-    private struct BeamGroupKey: Hashable {
+    struct BeamGroupKey: Hashable {
         let measureIndex: Int
         let row: Int
         let voice: NotationVoice
@@ -28,8 +29,6 @@ struct NotationLayoutEngine {
             MeasureUtils.timePosition(measureNumber: $0.measureNumber, measureOffset: $0.measureOffset)
             < MeasureUtils.timePosition(measureNumber: $1.measureNumber, measureOffset: $1.measureOffset)
         }
-        // Derive total measures from normalized positions so notes with
-        // measureOffset >= 1.0 (which roll into the next measure) are allocated correctly.
         let maxNormalizedMeasureIndex = sortedNotes.map { note in
             MeasureUtils.measureIndex(from: MeasureUtils.timePosition(
                 measureNumber: note.measureNumber, measureOffset: note.measureOffset
@@ -38,8 +37,9 @@ struct NotationLayoutEngine {
         let totalMeasures = max(input.minimumMeasureCount, maxNormalizedMeasureIndex + 1, 1)
         let measures = buildMeasures(totalMeasures: totalMeasures, notes: sortedNotes, input: input)
         let noteHeads = buildNoteHeads(notes: sortedNotes, measures: measures, input: input)
-        let stems = buildStems(noteHeads: noteHeads, style: input.style)
+        // Build beams first so stems can extend to beam lines when notes are beamed.
         let beams = buildBeams(noteHeads: noteHeads, style: input.style)
+        let stems = buildStems(noteHeads: noteHeads, beams: beams, style: input.style)
         let flags = buildFlags(noteHeads: noteHeads, beams: beams, style: input.style)
         let ledgerLines = buildLedgerLines(noteHeads: noteHeads, style: input.style)
         let measureBars = buildMeasureBars(measures: measures)
@@ -67,6 +67,8 @@ struct NotationLayoutEngine {
             totalHeight: totalHeight
         )
     }
+
+    // MARK: - Measure Building
 
     private func buildMeasures(
         totalMeasures: Int,
@@ -98,7 +100,7 @@ struct NotationLayoutEngine {
         return result
     }
 
-    private func measureWidth(
+    func measureWidth(
         measureIndex: Int,
         notes: [Note],
         input: NotationLayoutInput
@@ -144,7 +146,7 @@ struct NotationLayoutEngine {
         return style.minimumNoteColumnGap + 2 * style.voiceCollisionOffset
     }
 
-    private func containsCrossVoiceCollision(measureIndex: Int, notes: [Note]) -> Bool {
+    func containsCrossVoiceCollision(measureIndex: Int, notes: [Note]) -> Bool {
         Dictionary(
             grouping: notes.filter { normalizedMeasureIndex(for: $0) == measureIndex },
             by: { quantizedColumn(for: normalizedOffset(for: $0)) }
@@ -161,6 +163,8 @@ struct NotationLayoutEngine {
             return voices.count > 1
         }
     }
+
+    // MARK: - Note Head Building
 
     private func buildNoteHeads(
         notes: [Note],
@@ -255,6 +259,8 @@ struct NotationLayoutEngine {
         }
     }
 
+    // MARK: - Helpers
+
     private func beatGap(for measure: RenderedMeasure, input: NotationLayoutInput) -> CGFloat {
         let drawableWidth = measure.width - GameplayLayout.barLineWidth - GameplayLayout.uniformSpacing
         return drawableWidth / CGFloat(input.timeSignature.beatsPerMeasure)
@@ -271,14 +277,12 @@ struct NotationLayoutEngine {
         (measureOffset * Self.columnResolution).rounded() / Self.columnResolution
     }
 
-    /// Zero-based measure index after normalizing measureOffset >= 1.0 into the next measure.
     private func normalizedMeasureIndex(for note: Note) -> Int {
         MeasureUtils.measureIndex(from: MeasureUtils.timePosition(
             measureNumber: note.measureNumber, measureOffset: note.measureOffset
         ))
     }
 
-    /// Offset within the normalized measure (always in [0, 1)).
     private func normalizedOffset(for note: Note) -> Double {
         let timePos = MeasureUtils.timePosition(
             measureNumber: note.measureNumber, measureOffset: note.measureOffset
@@ -293,42 +297,51 @@ struct NotationLayoutEngine {
     private func staffStep(for position: GameplayLayout.NotePosition) -> Int {
         Int((position.yOffset / (GameplayLayout.staffLineSpacing / 2)).rounded())
     }
-}
 
-private extension NotationLayoutEngine {
     private func stemDirection(for drumType: DrumType, voice: NotationVoice) -> StemDirection {
         guard voice == .upper else { return .down }
 
         switch drumType.notePosition {
         case .aboveLine9, .aboveLine8, .aboveLine7, .aboveLine6, .aboveLine5, .line5:
             return .down
-        case .spaceBetween4And5,
-             .line4,
-             .spaceBetween3And4,
-             .line3,
-             .spaceBetween2And3,
-             .line2,
-             .spaceBetween1And2,
-             .line1,
-             .spaceBetweenLine1AndBelow,
-             .belowLine1,
-             .belowLine2,
-             .belowLine3,
-             .belowLine4,
-             .belowLine5,
-             .belowLine6:
+        case .spaceBetween4And5, .line4, .spaceBetween3And4, .line3,
+             .spaceBetween2And3, .line2, .spaceBetween1And2, .line1,
+             .spaceBetweenLine1AndBelow, .belowLine1, .belowLine2,
+             .belowLine3, .belowLine4, .belowLine5, .belowLine6:
             return .up
         }
     }
 
+    // MARK: - Rendering Primitives (delegated to fileprivate extension)
+
     private func buildStems(
         noteHeads: [RenderedNoteHead],
+        beams: [RenderedBeam],
         style: NotationLayoutStyle
     ) -> [RenderedStem] {
-        noteHeads
+        // Group beams by the first noteHeadID for quick lookup.
+        let beamsByNoteHeadID = Dictionary(grouping: beams) { beam in
+            beam.noteHeadIDs.first
+        }
+
+        return noteHeads
             .filter { $0.interval.needsStem }
             .map { noteHead in
                 let start = stemStart(for: noteHead, style: style)
+                // Check if this noteHead belongs to beams. If so, compute stem end from beam geometry.
+                // Use the first matching beam for stem end calculation.
+                if let beamsForNote = beamsByNoteHeadID[noteHead.id],
+                   let firstBeam = beamsForNote.first,
+                   let beamY = beamEndY(for: noteHead, beam: firstBeam, style: style) {
+                    return RenderedStem(
+                        id: "stem_\(noteHead.id)",
+                        noteHeadIDs: [noteHead.id],
+                        direction: noteHead.stemDirection,
+                        start: start,
+                        end: CGPoint(x: start.x, y: beamY)
+                    )
+                }
+                // Not beamed - use fixed stem length.
                 let endY = switch noteHead.stemDirection {
                 case .up:
                     start.y - style.stemLength
@@ -346,6 +359,34 @@ private extension NotationLayoutEngine {
             }
     }
 
+    /// Computes stem end Y from beam geometry if noteHead is beamed.
+    private func beamEndY(
+        for noteHead: RenderedNoteHead,
+        beam: RenderedBeam,
+        style: NotationLayoutStyle
+    ) -> Double? {
+        // Only extend to beam if beam has multiple note heads.
+        guard beam.noteHeadIDs.count > 1 else { return nil }
+
+        // The beam spans from start.x to end.x. Find the Y at noteHead's X by linear interpolation.
+        let startX = beam.start.x
+        let endX = beam.end.x
+        let stemX = noteHead.position.x
+
+        // Check if stem X is within beam span.
+        guard stemX >= min(startX, endX) && stemX <= max(startX, endX) else {
+            return nil
+        }
+
+        // Linear interpolation for Y at stemX.
+        let t = (stemX - startX) / (endX - startX)
+        let beamY = beam.start.y + t * (beam.end.y - beam.start.y)
+
+        // For upward stems, beam is above notehead so stem extends to beam Y.
+        // For downward stems, beam is below notehead so stem extends to beam Y.
+        return beamY
+    }
+
     private func buildBeams(
         noteHeads: [RenderedNoteHead],
         style: NotationLayoutStyle
@@ -361,7 +402,7 @@ private extension NotationLayoutEngine {
 
         return groupedHeads.values
             .flatMap { heads in
-                beamRuns(from: heads).flatMap { run in
+                beamRuns(from: Array(heads)).flatMap { run in
                     beams(for: run, style: style)
                 }
             }
@@ -373,8 +414,110 @@ private extension NotationLayoutEngine {
                     return $0.start.x < $1.start.x
                 }
                 return $0.level < $1.level
+            }
+    }
+
+    private func buildFlags(
+        noteHeads: [RenderedNoteHead],
+        beams: [RenderedBeam],
+        style: NotationLayoutStyle
+    ) -> [RenderedFlag] {
+        var coveredLevelsByNoteHead: [UInt64: Int] = [:]
+        for beam in beams {
+            for noteHeadID in beam.noteHeadIDs {
+                let current = coveredLevelsByNoteHead[noteHeadID] ?? 0
+                coveredLevelsByNoteHead[noteHeadID] = max(current, beam.level + 1)
+            }
+        }
+
+        return noteHeads
+            .filter { $0.interval.needsFlag }
+            .flatMap { noteHead -> [RenderedFlag] in
+                let coveredLevels = coveredLevelsByNoteHead[noteHead.id] ?? 0
+                let totalFlags = noteHead.interval.flagCount
+                guard coveredLevels < totalFlags else { return [] }
+
+                let stemBottom = stemStart(for: noteHead, style: style)
+                let flagOrigin = CGPoint(
+                    x: stemBottom.x + GameplayLayout.flagXOffset,
+                    y: noteHead.stemDirection == .up
+                        ? stemBottom.y - style.stemLength
+                        : stemBottom.y + style.stemLength
+                )
+
+                return (coveredLevels..<totalFlags).map { flagIndex in
+                    let yOffset = noteHead.stemDirection == .up
+                        ? CGFloat(flagIndex) * GameplayLayout.flagVerticalSpacing
+                        : -CGFloat(flagIndex) * GameplayLayout.flagVerticalSpacing
+
+                    return RenderedFlag(
+                        id: "flag_\(noteHead.id)_\(flagIndex)",
+                        noteHeadID: noteHead.id,
+                        stemDirection: noteHead.stemDirection,
+                        flagIndex: flagIndex,
+                        origin: CGPoint(x: flagOrigin.x, y: flagOrigin.y + yOffset)
+                    )
+                }
+            }
+    }
+
+    private func buildLedgerLines(
+        noteHeads: [RenderedNoteHead],
+        style: NotationLayoutStyle
+    ) -> [RenderedLedgerLine] {
+        noteHeads.flatMap { noteHead in
+            ledgerSteps(for: noteHead.staffStep).map { step in
+                let y = GameplayLayout.StaffLinePosition.line1.absoluteY(for: noteHead.row)
+                    + CGFloat(step) * (style.staffLineSpacing / 2)
+                let overhang = style.noteHeadWidth / 2 + style.ledgerLineOverhang
+
+                return RenderedLedgerLine(
+                    id: "ledger_\(noteHead.id)_\(step)",
+                    row: noteHead.row,
+                    start: CGPoint(x: noteHead.position.x - overhang, y: y),
+                    end: CGPoint(x: noteHead.position.x + overhang, y: y)
+                )
+            }
         }
     }
+
+    func buildMeasureBars(measures: [RenderedMeasure]) -> [RenderedMeasureBar] {
+        var bars: [RenderedMeasureBar] = []
+
+        for (index, measure) in measures.enumerated() {
+            let isFirstInRow = index == 0 || measures[index - 1].row != measure.row
+            let isLastOverall = measure.measureIndex == measures.last?.measureIndex
+
+            if isFirstInRow {
+                bars.append(RenderedMeasureBar(
+                    id: "bar_\(measure.measureIndex)",
+                    row: measure.row,
+                    x: measure.xOffset,
+                    isFinal: false
+                ))
+            }
+
+            let nextOnSameRow = measures.count > index + 1
+                && measures[index + 1].row == measure.row
+            let endX: CGFloat
+            if nextOnSameRow {
+                endX = measures[index + 1].xOffset
+            } else {
+                endX = measure.xOffset + measure.width
+            }
+
+            bars.append(RenderedMeasureBar(
+                id: "bar_\(measure.measureIndex)_end",
+                row: measure.row,
+                x: endX,
+                isFinal: isLastOverall
+            ))
+        }
+
+        return bars
+    }
+
+    // MARK: - Beam Helpers
 
     private func beamRuns(from noteHeads: [RenderedNoteHead]) -> [[RenderedNoteHead]] {
         let sortedHeads = noteHeads.sorted {
@@ -426,7 +569,9 @@ private extension NotationLayoutEngine {
 
         return (0..<maxFlagCount).flatMap { level in
             beamSegments(for: noteHeads, level: level).compactMap { levelHeads in
-                guard let firstHead = levelHeads.first, let lastHead = levelHeads.last, levelHeads.count >= 2 else {
+                guard let firstHead = levelHeads.first,
+                      let lastHead = levelHeads.last,
+                      levelHeads.count >= 2 else {
                     return nil
                 }
 
@@ -475,55 +620,6 @@ private extension NotationLayoutEngine {
         return segments
     }
 
-    private func buildFlags(
-        noteHeads: [RenderedNoteHead],
-        beams: [RenderedBeam],
-        style: NotationLayoutStyle
-    ) -> [RenderedFlag] {
-        // Count how many beam levels each notehead is covered by.
-        // A notehead in a level-0 beam has 1 covered level, level-0 and level-1
-        // beams means 2 covered levels, etc.  Flags should only be emitted for
-        // levels NOT already represented by beams.
-        var coveredLevelsByNoteHead: [UInt64: Int] = [:]
-        for beam in beams {
-            for noteHeadID in beam.noteHeadIDs {
-                let current = coveredLevelsByNoteHead[noteHeadID] ?? 0
-                coveredLevelsByNoteHead[noteHeadID] = max(current, beam.level + 1)
-            }
-        }
-
-        return noteHeads
-            .filter { $0.interval.needsFlag }
-            .flatMap { noteHead -> [RenderedFlag] in
-                let coveredLevels = coveredLevelsByNoteHead[noteHead.id] ?? 0
-                let totalFlags = noteHead.interval.flagCount
-                // Emit flags only for levels not already represented by beams
-                guard coveredLevels < totalFlags else { return [] }
-
-                let stemBottom = stemStart(for: noteHead, style: style)
-                let flagOrigin = CGPoint(
-                    x: stemBottom.x + GameplayLayout.flagXOffset,
-                    y: noteHead.stemDirection == .up
-                        ? stemBottom.y - style.stemLength
-                        : stemBottom.y + style.stemLength
-                )
-
-                return (coveredLevels..<totalFlags).map { flagIndex in
-                    let yOffset = noteHead.stemDirection == .up
-                        ? CGFloat(flagIndex) * GameplayLayout.flagVerticalSpacing
-                        : -CGFloat(flagIndex) * GameplayLayout.flagVerticalSpacing
-
-                    return RenderedFlag(
-                        id: "flag_\(noteHead.id)_\(flagIndex)",
-                        noteHeadID: noteHead.id,
-                        stemDirection: noteHead.stemDirection,
-                        flagIndex: flagIndex,
-                        origin: CGPoint(x: flagOrigin.x, y: flagOrigin.y + yOffset)
-                    )
-                }
-            }
-    }
-
     private func hasPositiveBeamSpan(
         from firstHead: RenderedNoteHead,
         to lastHead: RenderedNoteHead,
@@ -564,26 +660,6 @@ private extension NotationLayoutEngine {
         return CGPoint(x: start.x, y: noteHead.position.y + yOffset)
     }
 
-    private func buildLedgerLines(
-        noteHeads: [RenderedNoteHead],
-        style: NotationLayoutStyle
-    ) -> [RenderedLedgerLine] {
-        noteHeads.flatMap { noteHead in
-            ledgerSteps(for: noteHead.staffStep).map { step in
-                let y = GameplayLayout.StaffLinePosition.line1.absoluteY(for: noteHead.row)
-                    + CGFloat(step) * (style.staffLineSpacing / 2)
-                let overhang = style.noteHeadWidth / 2 + style.ledgerLineOverhang
-
-                return RenderedLedgerLine(
-                    id: "ledger_\(noteHead.id)_\(step)",
-                    row: noteHead.row,
-                    start: CGPoint(x: noteHead.position.x - overhang, y: y),
-                    end: CGPoint(x: noteHead.position.x + overhang, y: y)
-                )
-            }
-        }
-    }
-
     private func ledgerSteps(for staffStep: Int) -> [Int] {
         if staffStep < Self.topStaffStep {
             return stride(from: Self.topStaffStep - 2, through: staffStep, by: -2).map { $0 }
@@ -592,45 +668,5 @@ private extension NotationLayoutEngine {
             return stride(from: Self.bottomStaffStep + 2, through: staffStep, by: 2).map { $0 }
         }
         return []
-    }
-
-    private func buildMeasureBars(measures: [RenderedMeasure]) -> [RenderedMeasureBar] {
-        var bars: [RenderedMeasureBar] = []
-
-        for (index, measure) in measures.enumerated() {
-            let isFirstInRow = index == 0 || measures[index - 1].row != measure.row
-            let isLastOverall = measure.measureIndex == measures.last?.measureIndex
-
-            // Start barline: only at row beginnings
-            if isFirstInRow {
-                bars.append(RenderedMeasureBar(
-                    id: "bar_\(measure.measureIndex)",
-                    row: measure.row,
-                    x: measure.xOffset,
-                    isFinal: false
-                ))
-            }
-
-            // End barline: align with next same-row measure's start so the shared
-            // boundary sits at the following measure's xOffset rather than leaving
-            // a measureSpacing-wide gap between the drawn bar and the next measure.
-            let nextOnSameRow = measures.count > index + 1
-                && measures[index + 1].row == measure.row
-            let endX: CGFloat
-            if nextOnSameRow {
-                endX = measures[index + 1].xOffset
-            } else {
-                endX = measure.xOffset + measure.width
-            }
-
-            bars.append(RenderedMeasureBar(
-                id: "bar_\(measure.measureIndex)_end",
-                row: measure.row,
-                x: endX,
-                isFinal: isLastOverall
-            ))
-        }
-
-        return bars
     }
 }

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -2,6 +2,8 @@ import CoreGraphics
 import Foundation
 
 struct NotationLayoutEngine {
+    private static let columnResolution = 1000.0
+
     func layout(input: NotationLayoutInput) -> NotationLayout {
         let normalizedNotes = input.notes.sorted {
             MeasureUtils.timePosition(measureNumber: $0.measureNumber, measureOffset: $0.measureOffset)
@@ -66,13 +68,11 @@ struct NotationLayoutEngine {
         input: NotationLayoutInput
     ) -> CGFloat {
         let measureNumber = MeasureUtils.toOneBasedNumber(measureIndex)
-        let offsets = Set(notes
-            .filter { $0.measureNumber == measureNumber }
-            .map(\.measureOffset))
-            .sorted()
+        let offsets = columnOffsets(for: measureNumber, notes: notes)
+        let legacyWidth = GameplayLayout.measureWidth(for: input.timeSignature)
 
         guard offsets.count > 1 else {
-            return GameplayLayout.measureWidth(for: input.timeSignature)
+            return legacyWidth
         }
 
         let smallestGap = zip(offsets.dropFirst(), offsets)
@@ -85,10 +85,11 @@ struct NotationLayoutEngine {
             input.style.minimumQuarterBeatGap,
             minimumBeatGap
         )
-        return GameplayLayout.barLineWidth
-            + input.style.measurePadding
+        let adaptiveWidth = GameplayLayout.barLineWidth
+            + GameplayLayout.uniformSpacing
             + CGFloat(input.timeSignature.beatsPerMeasure) * beatGap
-            + input.style.measurePadding
+
+        return max(legacyWidth, adaptiveWidth)
     }
 
     private func buildNoteHeads(
@@ -104,8 +105,9 @@ struct NotationLayoutEngine {
             let measureIndex = MeasureUtils.toZeroBasedIndex(note.measureNumber)
             guard let measure = measuresByIndex[measureIndex] else { return nil }
             let beatGap = beatGap(for: measure, input: input)
-            let x = measure.xOffset + GameplayLayout.barLineWidth + input.style.measurePadding
-                + CGFloat(note.measureOffset * Double(input.timeSignature.beatsPerMeasure)) * beatGap
+            let beatPosition = quantizedOffset(for: note.measureOffset) * Double(input.timeSignature.beatsPerMeasure)
+            let x = measure.xOffset + GameplayLayout.barLineWidth + GameplayLayout.uniformSpacing
+                + CGFloat(beatPosition) * beatGap
             let y = GameplayLayout.StaffLinePosition.line1.absoluteY(for: measure.row)
                 + drumType.notePosition.yOffset
             let id = nextID
@@ -131,8 +133,19 @@ struct NotationLayoutEngine {
     }
 
     private func beatGap(for measure: RenderedMeasure, input: NotationLayoutInput) -> CGFloat {
-        let drawableWidth = measure.width - GameplayLayout.barLineWidth - input.style.measurePadding * 2
+        let drawableWidth = measure.width - GameplayLayout.barLineWidth - GameplayLayout.uniformSpacing
         return drawableWidth / CGFloat(input.timeSignature.beatsPerMeasure)
+    }
+
+    private func columnOffsets(for measureNumber: Int, notes: [Note]) -> [Double] {
+        Set(notes
+            .filter { $0.measureNumber == measureNumber }
+            .map { quantizedOffset(for: $0.measureOffset) })
+            .sorted()
+    }
+
+    private func quantizedOffset(for measureOffset: Double) -> Double {
+        Double(Int(measureOffset * Self.columnResolution)) / Self.columnResolution
     }
 
     private func staffStep(for position: GameplayLayout.NotePosition) -> Int {

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -66,9 +66,9 @@ struct NotationLayoutEngine {
         input: NotationLayoutInput
     ) -> CGFloat {
         let measureNumber = MeasureUtils.toOneBasedNumber(measureIndex)
-        let offsets = notes
+        let offsets = Set(notes
             .filter { $0.measureNumber == measureNumber }
-            .map(\.measureOffset)
+            .map(\.measureOffset))
             .sorted()
 
         guard offsets.count > 1 else {
@@ -78,9 +78,12 @@ struct NotationLayoutEngine {
         let smallestGap = zip(offsets.dropFirst(), offsets)
             .map { pair in pair.0 - pair.1 }
             .min() ?? 0.25
+        let minimumBeatGap = input.style.minimumNoteColumnGap / CGFloat(
+            max(smallestGap * Double(input.timeSignature.beatsPerMeasure), 0.001)
+        )
         let beatGap = max(
             input.style.minimumQuarterBeatGap,
-            input.style.minimumNoteColumnGap / CGFloat(max(smallestGap * Double(input.timeSignature.beatsPerMeasure), 0.001))
+            minimumBeatGap
         )
         return GameplayLayout.barLineWidth
             + input.style.measurePadding

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -333,10 +333,14 @@ struct NotationLayoutEngine {
             .map { noteHead in
                 let start = stemStart(for: noteHead, style: style)
                 // Check if this noteHead belongs to beams. If so, compute stem end from beam geometry.
-                // Use the first matching beam for stem end calculation.
+                // Pick the beam farthest in the stem direction so the stem extends through all levels.
+                // Beams are sorted by Y ascending: up-stems need .first (lowest Y = outermost),
+                // down-stems need .last (highest Y = outermost).
                 if let beamsForNote = beamsByNoteHeadID[noteHead.id],
-                   let firstBeam = beamsForNote.first,
-                   let beamY = beamEndY(for: noteHead, beam: firstBeam, style: style) {
+                   let outermostBeam = noteHead.stemDirection == .up
+                       ? beamsForNote.first
+                       : beamsForNote.last,
+                   let beamY = beamEndY(for: noteHead, beam: outermostBeam, style: style) {
                     return RenderedStem(
                         id: "stem_\(noteHead.id)",
                         noteHeadIDs: [noteHead.id],

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -28,7 +28,7 @@ struct NotationLayoutEngine {
             MeasureUtils.timePosition(measureNumber: $0.measureNumber, measureOffset: $0.measureOffset)
             < MeasureUtils.timePosition(measureNumber: $1.measureNumber, measureOffset: $1.measureOffset)
         }
-        let totalMeasures = max(1, (normalizedNotes.map(\.measureNumber).max() ?? 1))
+        let totalMeasures = max(input.minimumMeasureCount, (normalizedNotes.map(\.measureNumber).max() ?? 1), 1)
         let measures = buildMeasures(totalMeasures: totalMeasures, notes: normalizedNotes, input: input)
         let noteHeads = buildNoteHeads(notes: normalizedNotes, measures: measures, input: input)
         let stems = buildStems(noteHeads: noteHeads, style: input.style)

--- a/Virgo/layout/NotationLayoutEngine.swift
+++ b/Virgo/layout/NotationLayoutEngine.swift
@@ -36,6 +36,10 @@ struct NotationLayoutEngine {
         let ledgerLines = buildLedgerLines(noteHeads: noteHeads, style: input.style)
         let measureBars = buildMeasureBars(measures: measures)
         let beatLookup = Dictionary(uniqueKeysWithValues: noteHeads.map { ($0.id, $0.position) })
+        let noteHeadIDsByTimePosition = Dictionary(
+            grouping: noteHeads,
+            by: { NotationLayout.timePositionKey($0.timePosition) }
+        ).mapValues { Set($0.map(\.id)) }
         let totalHeight = GameplayLayout.totalHeight(
             for: measures.map {
                 GameplayLayout.MeasurePosition(row: $0.row, xOffset: $0.xOffset, measureIndex: $0.measureIndex)
@@ -50,6 +54,7 @@ struct NotationLayoutEngine {
             ledgerLines: ledgerLines,
             measureBars: measureBars,
             beatLookup: beatLookup,
+            noteHeadIDsByTimePosition: noteHeadIDsByTimePosition,
             totalHeight: totalHeight
         )
     }

--- a/Virgo/utilities/BeamGroupingLogic.swift
+++ b/Virgo/utilities/BeamGroupingLogic.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// Legacy notation renderer retained for compatibility tests while gameplay uses NotationLayoutEngine.
+
 // MARK: - Beam Grouping Helper
 struct BeamGroupingHelper {
     static func calculateBeamGroups(from beats: [DrumBeat]) -> [BeamGroup] {

--- a/Virgo/utilities/NotePositionKey.swift
+++ b/Virgo/utilities/NotePositionKey.swift
@@ -21,6 +21,22 @@ struct NotePositionKey: Hashable, Equatable {
         self.measureNumber = measureNumber
         self.measureOffset = measureOffset
     }
+
+    /// Returns a canonical key where `measureOffset >= 1.0` is rolled into the next measure.
+    ///
+    /// A note at `(measureNumber: 1, measureOffset: 1.0)` and another at
+    /// `(measureNumber: 2, measureOffset: 0.0)` represent the same musical instant.
+    /// Both normalize to `(measureNumber: 2, measureOffset: 0.0)`.
+    func normalized() -> NotePositionKey {
+        guard measureOffset >= 1.0 else { return self }
+        let timePosition = Double(measureNumber - 1) + measureOffset
+        let normalizedIndex = Int(timePosition)
+        let normalizedOffset = timePosition - Double(normalizedIndex)
+        return NotePositionKey(
+            measureNumber: MeasureUtils.toOneBasedNumber(normalizedIndex),
+            measureOffset: normalizedOffset
+        )
+    }
     
     // MARK: - Hashable
     

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -1149,16 +1149,43 @@ final class GameplayViewModel {
             currentTimePosition = Double(measureIdx) + measureOffset
         }
 
-        // Binary search for the last beat at or near the current position.
-        // The metronome only fires at quarter-note intervals, so sub-beat notes
-        // (eighths, sixteenths) are never exactly at the playhead.  Using a
-        // small look-ahead plus a wider look-behind catches those notes.
+        // Two-step search: prefer beats at/before the playhead, then fall back to
+        // a small look-ahead.  The metronome only fires at quarter-note intervals,
+        // so sub-beat notes (eighths, sixteenths) are never exactly at the playhead.
+        // Using look-ahead catches those, but we must not let a future note steal
+        // the active-beat slot from a note the playhead is currently on.
         let lookAhead = 0.05
         let maxLookBehind = 1.0 / Double(track.timeSignature.beatsPerMeasure)
 
+        // Step 1: find the last beat at or before the playhead.
         var left = 0
         var right = cachedDrumBeats.count - 1
         var result = -1
+
+        while left <= right {
+            let mid = (left + right) / 2
+            if cachedDrumBeats[mid].timePosition <= currentTimePosition {
+                result = mid
+                left = mid + 1
+            } else {
+                right = mid - 1
+            }
+        }
+
+        if result >= 0 {
+            let beat = cachedDrumBeats[result]
+            if currentTimePosition - beat.timePosition <= maxLookBehind {
+                activeBeatId = beat.id
+                updateActiveNotation(forBeatID: beat.id, fallbackTimePosition: currentTimePosition)
+                return
+            }
+        }
+
+        // Step 2: no beat at/before playhead — try a small look-ahead for
+        // sub-beat notes that the playhead is about to reach.
+        left = 0
+        right = cachedDrumBeats.count - 1
+        result = -1
 
         while left <= right {
             let mid = (left + right) / 2

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -117,6 +117,10 @@ final class GameplayViewModel {
     // MARK: - Visual State
     /// Currently active beat ID for highlighting
     var activeBeatId: UInt64?
+    var activeNotationNoteHeadIDs: Set<UInt64> {
+        guard let activeBeatId else { return [] }
+        return Set(cachedNotationNoteHeadIDsByBeatID[activeBeatId] ?? [])
+    }
     /// Current purple bar position (x, y)
     var purpleBarPosition: (x: Double, y: Double)?
     /// Cached static staff lines view (uses AnyView for type erasure)

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -1124,6 +1124,10 @@ final class GameplayViewModel {
         // even between quarter-note boundaries.
         updatePurpleBarPosition(elapsedTime: elapsedTime)
 
+        // Playback progress updates on EVERY tick so the progress bar and time
+        // label move smoothly rather than stepping at quarter-note boundaries.
+        playbackProgress = min(elapsedTime / cachedTrackDuration, 1.0)
+
         if discreteTotalBeats != lastDiscreteBeat {
             lastDiscreteBeat = discreteTotalBeats
 
@@ -1135,7 +1139,6 @@ final class GameplayViewModel {
             currentBeatPosition = beatPosition
             currentBeat = findClosestBeatIndex(measureIndex: measureIndex, beatPosition: beatPosition)
             totalBeatsElapsed = discreteTotalBeats
-            playbackProgress = min(elapsedTime / cachedTrackDuration, 1.0)
 
             scanForMissedNotes(upToTimePosition: playheadTimePosition)
 

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -105,13 +105,13 @@ final class GameplayViewModel {
     private(set) var measurePositionMap: [Int: GameplayLayout.MeasurePosition] = [:]
     /// Pre-cached beat positions for performance
     private(set) var cachedBeatPositions: [UInt64: (x: Double, y: Double)] = [:]
-    /// Pre-computed notation layout for future gameplay rendering migration
+    /// Pre-computed notation layout that drives rendering when notes are present
     private(set) var cachedNotationLayout = NotationLayout.empty
     /// Fast lookup map from rendered note-head ID to rendered position
     private(set) var cachedNotationNoteHeadPositions: [UInt64: (x: Double, y: Double)] = [:]
     /// Maps legacy DrumBeat IDs to all rendered note heads at the same musical time.
     private(set) var cachedNotationNoteHeadIDsByBeatID: [UInt64: [UInt64]] = [:]
-    /// Duration-based measure count shared with the legacy sheet layout.
+    /// Duration-based measure count shared with both legacy sheet layout and notation layout.
     private var cachedLayoutMeasureCount = 1
     /// Preserves the legacy grouping key that produced each DrumBeat ID.
     private var cachedDrumBeatIDByNotePositionKey: [NotePositionKey: UInt64] = [:]
@@ -120,7 +120,8 @@ final class GameplayViewModel {
     /// Currently active beat ID for highlighting
     var activeBeatId: UInt64? {
         didSet {
-            // Always clear active note heads when beat changes (self-enforcing invariant)
+            guard oldValue != activeBeatId else { return }
+            // Clear active note heads when beat changes (self-enforcing invariant)
             activeNotationNoteHeadIDs = []
         }
     }
@@ -1069,7 +1070,7 @@ final class GameplayViewModel {
             withTimeInterval: 1.0 / 30.0,
             repeats: true
         ) { [weak self] _ in
-            Task { @MainActor [weak self] in
+            MainActor.assumeIsolated {
                 self?.updateContinuousVisualsTick()
             }
         }
@@ -1111,7 +1112,7 @@ final class GameplayViewModel {
         // Continuous playhead position — always computed so sub-beat notes
         // (eighths, sixteenths) can be matched regardless of when the metronome fires.
         let beatsPerMeasure = track.timeSignature.beatsPerMeasure
-        let continuousMeasureFraction = totalBeatsElapsedFloat / Double(beatsPerMeasure)
+        let continuousMeasureFraction = max(0, totalBeatsElapsedFloat / Double(beatsPerMeasure))
         let continuousMeasureIdx = Int(continuousMeasureFraction)
         let continuousOffset = continuousMeasureFraction - Double(continuousMeasureIdx)
         let playheadTimePosition = Double(continuousMeasureIdx) + continuousOffset
@@ -1189,7 +1190,7 @@ final class GameplayViewModel {
             let secondsPerBeat = 60.0 / effectiveBPM()
             let totalBeats = elapsedTime / secondsPerBeat
             let beatsPerMeasure = Double(track.timeSignature.beatsPerMeasure)
-            let continuousMeasureFraction = totalBeats / beatsPerMeasure
+            let continuousMeasureFraction = max(0, totalBeats / beatsPerMeasure)
             let measureIdx = Int(continuousMeasureFraction)
             let measureOffset = continuousMeasureFraction - Double(measureIdx)
             currentTimePosition = Double(measureIdx) + measureOffset
@@ -1313,7 +1314,7 @@ final class GameplayViewModel {
         let secondsPerBeat = 60.0 / effectiveBPM()
         let totalBeatsElapsed = elapsedTime / secondsPerBeat
         let beatsPerMeasure = track.timeSignature.beatsPerMeasure
-        let continuousMeasureFraction = totalBeatsElapsed / Double(beatsPerMeasure)
+        let continuousMeasureFraction = max(0, totalBeatsElapsed / Double(beatsPerMeasure))
         let measureIndex = Int(continuousMeasureFraction)
         let beatWithinMeasure = totalBeatsElapsed - Double(measureIndex * beatsPerMeasure)
 
@@ -1545,8 +1546,19 @@ final class GameplayViewModel {
         }
 
         if cachedNotes.count != cachedNotationLayout.noteHeads.count, !cachedNotes.isEmpty {
+            let renderedSourceIDs = Set(cachedNotationLayout.noteHeads.map { $0.sourceNoteID })
+            let droppedNotes = cachedNotes.filter { !renderedSourceIDs.contains(ObjectIdentifier($0)) }
+            let droppedReasons = droppedNotes.prefix(5).map { note in
+                let drumType = DrumType.from(noteType: note.noteType)
+                let measureIdx = MeasureUtils.measureIndex(from: MeasureUtils.timePosition(
+                    measureNumber: note.measureNumber, measureOffset: note.measureOffset
+                ))
+                return "noteType=\(note.noteType)(\(drumType?.description ?? "unknown")), " +
+                        "measure=\(note.measureNumber)(idx=\(measureIdx))"
+            }
             Logger.warning(
-                "Layout engine dropped notes: \(cachedNotes.count) input → \(cachedNotationLayout.noteHeads.count) noteHeads"
+                "Layout engine dropped \(droppedNotes.count) note(s): \(droppedReasons.joined(separator: "; "))"
+                    + (droppedNotes.count > 5 ? " … and \(droppedNotes.count - 5) more" : "")
             )
         }
 
@@ -1555,14 +1567,18 @@ final class GameplayViewModel {
                 (noteHeadID, (x: Double(position.x), y: Double(position.y)))
             }
         )
-        let notePositionKeyBySourceNoteID = Dictionary(
-            uniqueKeysWithValues: cachedNotes.map { note in
-                (
-                    ObjectIdentifier(note),
-                    NotePositionKey(measureNumber: note.measureNumber, measureOffset: note.measureOffset).normalized()
+        var notePositionKeyBySourceNoteID: [ObjectIdentifier: NotePositionKey] = [:]
+        for note in cachedNotes {
+            let key = ObjectIdentifier(note)
+            let positionKey = NotePositionKey(measureNumber: note.measureNumber, measureOffset: note.measureOffset).normalized()
+            if notePositionKeyBySourceNoteID[key] != nil {
+                Logger.warning(
+                    "Duplicate ObjectIdentifier for Note(measure:\(note.measureNumber), " +
+                    "offset:\(note.measureOffset)) — SwiftData faulting returned identical instance"
                 )
             }
-        )
+            notePositionKeyBySourceNoteID[key] = positionKey
+        }
         var noteHeadIDsByBeatID = Dictionary(uniqueKeysWithValues: cachedDrumBeats.map { ($0.id, [UInt64]()) })
         var desyncCount = 0
         for noteHead in cachedNotationLayout.noteHeads {

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -1083,7 +1083,13 @@ final class GameplayViewModel {
             totalBeatsElapsed = discreteTotalBeats
             playbackProgress = min(elapsedTime / cachedTrackDuration, 1.0)
 
-            let playheadTimePosition = Double(measureIndex) + beatPosition
+            // Use continuous timePosition so off-beat notes (eighths, sixteenths)
+            // can be matched by updateActiveBeat's binary-search + look-behind logic.
+            let continuousMeasureFraction = totalBeatsElapsedFloat / Double(beatsPerMeasure)
+            let continuousMeasureIdx = Int(continuousMeasureFraction)
+            let continuousOffset = continuousMeasureFraction - Double(continuousMeasureIdx)
+            let playheadTimePosition = Double(continuousMeasureIdx) + continuousOffset
+
             updatePurpleBarPosition(elapsedTime: elapsedTime)
             updateActiveBeat(forTimePosition: playheadTimePosition)
             scanForMissedNotes(upToTimePosition: playheadTimePosition)
@@ -1133,20 +1139,44 @@ final class GameplayViewModel {
             }
             // Use effective BPM for visual sync (speed-adjusted)
             let secondsPerBeat = 60.0 / effectiveBPM()
-            let totalBeatsElapsed = elapsedTime / secondsPerBeat
-            let beatsPerMeasure = track.timeSignature.beatsPerMeasure
-            let discreteTotalBeats = Int(totalBeatsElapsed)
-            let measureIndex = discreteTotalBeats / beatsPerMeasure
-            let beatWithinMeasure = Double(discreteTotalBeats % beatsPerMeasure)
-            currentTimePosition = Double(measureIndex) + (beatWithinMeasure / Double(beatsPerMeasure))
+            let totalBeats = elapsedTime / secondsPerBeat
+            let beatsPerMeasure = Double(track.timeSignature.beatsPerMeasure)
+            let continuousMeasureFraction = totalBeats / beatsPerMeasure
+            let measureIdx = Int(continuousMeasureFraction)
+            let measureOffset = continuousMeasureFraction - Double(measureIdx)
+            currentTimePosition = Double(measureIdx) + measureOffset
         }
-        let timeTolerance = 0.05
 
-        for beat in cachedDrumBeats where abs(beat.timePosition - currentTimePosition) < timeTolerance {
-            activeBeatId = beat.id
-            updateActiveNotation(forBeatID: beat.id, fallbackTimePosition: currentTimePosition)
-            return
+        // Binary search for the last beat at or near the current position.
+        // The metronome only fires at quarter-note intervals, so sub-beat notes
+        // (eighths, sixteenths) are never exactly at the playhead.  Using a
+        // small look-ahead plus a wider look-behind catches those notes.
+        let lookAhead = 0.05
+        let maxLookBehind = 1.0 / Double(track.timeSignature.beatsPerMeasure)
+
+        var left = 0
+        var right = cachedDrumBeats.count - 1
+        var result = -1
+
+        while left <= right {
+            let mid = (left + right) / 2
+            if cachedDrumBeats[mid].timePosition <= currentTimePosition + lookAhead {
+                result = mid
+                left = mid + 1
+            } else {
+                right = mid - 1
+            }
         }
+
+        if result >= 0 {
+            let beat = cachedDrumBeats[result]
+            if currentTimePosition - beat.timePosition <= maxLookBehind {
+                activeBeatId = beat.id
+                updateActiveNotation(forBeatID: beat.id, fallbackTimePosition: currentTimePosition)
+                return
+            }
+        }
+
         clearActiveBeat()
     }
 

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -1212,7 +1212,9 @@ final class GameplayViewModel {
 
         // Step 2: no beat at/before playhead — try a small look-ahead for
         // sub-beat notes that the playhead is about to reach.
-        if let index = lastBeatIndex(atOrBefore: currentTimePosition, lookAhead: lookAhead) {
+        // Find the NEAREST upcoming note (first after the playhead), not the
+        // farthest note in the look-ahead window.
+        if let index = firstBeatIndex(atOrAfter: currentTimePosition, within: lookAhead) {
             let beat = cachedDrumBeats[index]
             if currentTimePosition - beat.timePosition <= maxLookBehind {
                 activeBeatId = beat.id
@@ -1246,6 +1248,30 @@ final class GameplayViewModel {
         }
 
         return result >= 0 ? result : nil
+    }
+
+    /// Performs binary search over cachedDrumBeats to find the first beat at or after
+    /// `timePosition` that is also within `maxDistance` of it.
+    /// Used by the look-ahead branch to select the nearest upcoming note.
+    private func firstBeatIndex(atOrAfter timePosition: Double, within maxDistance: Double) -> Int? {
+        guard !cachedDrumBeats.isEmpty else { return nil }
+
+        // Lower-bound binary search: first index where timePosition >= threshold.
+        var left = 0
+        var right = cachedDrumBeats.count
+        while left < right {
+            let mid = (left + right) / 2
+            if cachedDrumBeats[mid].timePosition < timePosition {
+                left = mid + 1
+            } else {
+                right = mid
+            }
+        }
+
+        guard left < cachedDrumBeats.count else { return nil }
+        let candidate = cachedDrumBeats[left]
+        guard candidate.timePosition - timePosition <= maxDistance else { return nil }
+        return left
     }
 
     func updateActiveNotation(forTimePosition timePosition: Double) {

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -111,6 +111,8 @@ final class GameplayViewModel {
     private(set) var cachedNotationNoteHeadPositions: [UInt64: (x: Double, y: Double)] = [:]
     /// Maps legacy DrumBeat IDs to all rendered note heads at the same musical time.
     private(set) var cachedNotationNoteHeadIDsByBeatID: [UInt64: [UInt64]] = [:]
+    /// Preserves the legacy grouping key that produced each DrumBeat ID.
+    private var cachedDrumBeatIDByNotePositionKey: [NotePositionKey: UInt64] = [:]
 
     // MARK: - Visual State
     /// Currently active beat ID for highlighting
@@ -1218,6 +1220,7 @@ final class GameplayViewModel {
     func computeDrumBeats() {
         if cachedNotes.isEmpty {
             cachedDrumBeats = []
+            cachedDrumBeatIDByNotePositionKey = [:]
             nextBeatId = 0  // Reset counter for consistency
             return
         }
@@ -1226,15 +1229,18 @@ final class GameplayViewModel {
             NotePositionKey(measureNumber: note.measureNumber, measureOffset: note.measureOffset)
         }
 
+        cachedDrumBeatIDByNotePositionKey = [:]
         cachedDrumBeats = groupedNotes.map { (positionKey, notes) in
+            let beatID = generateBeatId()
             let timePosition = MeasureUtils.timePosition(
                 measureNumber: positionKey.measureNumber,
                 measureOffset: positionKey.measureOffset
             )
             let drumTypes = notes.compactMap { DrumType.from(noteType: $0.noteType) }
             let interval = notes.first?.interval ?? .quarter
+            cachedDrumBeatIDByNotePositionKey[positionKey] = beatID
             return DrumBeat(
-                id: generateBeatId(),
+                id: beatID,
                 drums: drumTypes,
                 timePosition: timePosition,
                 interval: interval
@@ -1308,16 +1314,23 @@ final class GameplayViewModel {
                 (beatID, (x: Double(position.x), y: Double(position.y)))
             }
         )
-        cachedNotationNoteHeadIDsByBeatID = Dictionary(
-            uniqueKeysWithValues: cachedDrumBeats.map { beat in
-                let noteHeadIDs = cachedNotationLayout.noteHeads
-                    .filter {
-                        abs($0.timePosition - beat.timePosition) <= BeamGroupingConstants.comparisonTolerance
-                    }
-                    .map(\.id)
-                return (beat.id, noteHeadIDs)
+        let notePositionKeyBySourceNoteID = Dictionary(
+            uniqueKeysWithValues: cachedNotes.map { note in
+                (
+                    ObjectIdentifier(note),
+                    NotePositionKey(measureNumber: note.measureNumber, measureOffset: note.measureOffset)
+                )
             }
         )
+        var noteHeadIDsByBeatID = Dictionary(uniqueKeysWithValues: cachedDrumBeats.map { ($0.id, [UInt64]()) })
+        for noteHead in cachedNotationLayout.noteHeads {
+            guard let positionKey = notePositionKeyBySourceNoteID[noteHead.sourceNoteID],
+                  let beatID = cachedDrumBeatIDByNotePositionKey[positionKey] else {
+                continue
+            }
+            noteHeadIDsByBeatID[beatID, default: []].append(noteHead.id)
+        }
+        cachedNotationNoteHeadIDsByBeatID = noteHeadIDsByBeatID
     }
 
     func cacheBeatPositions() {

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -1287,9 +1287,9 @@ final class GameplayViewModel {
         let secondsPerBeat = 60.0 / effectiveBPM()
         let totalBeatsElapsed = elapsedTime / secondsPerBeat
         let beatsPerMeasure = track.timeSignature.beatsPerMeasure
-        let discreteTotalBeats = Int(totalBeatsElapsed)
-        let measureIndex = discreteTotalBeats / beatsPerMeasure
-        let beatWithinMeasure = Double(discreteTotalBeats % beatsPerMeasure)
+        let continuousMeasureFraction = totalBeatsElapsed / Double(beatsPerMeasure)
+        let measureIndex = Int(continuousMeasureFraction)
+        let beatWithinMeasure = totalBeatsElapsed - Double(measureIndex * beatsPerMeasure)
 
         let isNotationLayoutActive = !cachedNotationLayout.noteHeads.isEmpty
         // Clamp measureIndex to valid range for notation layout lookup

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -1295,13 +1295,18 @@ final class GameplayViewModel {
         let beatWithinMeasure = totalBeatsElapsed - Double(measureIndex * beatsPerMeasure)
 
         let isNotationLayoutActive = !cachedNotationLayout.noteHeads.isEmpty
-        // Clamp measureIndex to valid range for notation layout lookup
-        let clampedMeasureIndex = isNotationLayoutActive && measureIndex >= cachedNotationLayout.measures.count
-            ? cachedNotationLayout.measures.count - 1
-            : measureIndex
+        // Clamp measureIndex to valid range for notation layout lookup.
+        // Also clamp beatWithinMeasure so the purple bar stays at the end
+        // of the final measure instead of jumping back to beat 0.
+        var clampedMeasureIndex = measureIndex
+        var clampedBeatWithinMeasure = beatWithinMeasure
+        if isNotationLayoutActive && measureIndex >= cachedNotationLayout.measures.count {
+            clampedMeasureIndex = cachedNotationLayout.measures.count - 1
+            clampedBeatWithinMeasure = Double(beatsPerMeasure)
+        }
         if let notationPosition = calculateNotationPurpleBarPosition(
             measureIndex: clampedMeasureIndex,
-            beatWithinMeasure: beatWithinMeasure
+            beatWithinMeasure: clampedBeatWithinMeasure
         ) {
             return notationPosition
         }
@@ -1409,7 +1414,7 @@ final class GameplayViewModel {
         }
 
         let groupedNotes = Dictionary(grouping: cachedNotes) { note in
-            NotePositionKey(measureNumber: note.measureNumber, measureOffset: note.measureOffset)
+            NotePositionKey(measureNumber: note.measureNumber, measureOffset: note.measureOffset).normalized()
         }
 
         cachedDrumBeatIDByNotePositionKey = [:]
@@ -1531,7 +1536,7 @@ final class GameplayViewModel {
             uniqueKeysWithValues: cachedNotes.map { note in
                 (
                     ObjectIdentifier(note),
-                    NotePositionKey(measureNumber: note.measureNumber, measureOffset: note.measureOffset)
+                    NotePositionKey(measureNumber: note.measureNumber, measureOffset: note.measureOffset).normalized()
                 )
             }
         )

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -1201,7 +1201,10 @@ final class GameplayViewModel {
             return nil
         }
 
-        guard let measurePos = measurePositionMap[measureIndex] ?? measurePositionMap[0] else { return nil }
+        let clampedIndex = measurePositionMap[measureIndex] != nil
+            ? measureIndex
+            : (measurePositionMap.keys.max() ?? 0)
+        guard let measurePos = measurePositionMap[clampedIndex] else { return nil }
         let indicatorX = GameplayLayout.preciseNoteXPosition(
             measurePosition: measurePos,
             beatPosition: beatWithinMeasure,

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -1122,6 +1122,10 @@ final class GameplayViewModel {
         // so that off-beat notes become active at the right moment.
         updateActiveBeat(forTimePosition: playheadTimePosition)
 
+        // Purple-bar update runs on EVERY tick for smooth 30 Hz playhead movement,
+        // even between quarter-note boundaries.
+        updatePurpleBarPosition(elapsedTime: elapsedTime)
+
         if discreteTotalBeats != lastDiscreteBeat {
             lastDiscreteBeat = discreteTotalBeats
 
@@ -1135,7 +1139,6 @@ final class GameplayViewModel {
             totalBeatsElapsed = discreteTotalBeats
             playbackProgress = min(elapsedTime / cachedTrackDuration, 1.0)
 
-            updatePurpleBarPosition(elapsedTime: elapsedTime)
             scanForMissedNotes(upToTimePosition: playheadTimePosition)
 
             // Schedule delayed completion to preserve late-tolerance window for final notes.

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -111,6 +111,8 @@ final class GameplayViewModel {
     private(set) var cachedNotationNoteHeadPositions: [UInt64: (x: Double, y: Double)] = [:]
     /// Maps legacy DrumBeat IDs to all rendered note heads at the same musical time.
     private(set) var cachedNotationNoteHeadIDsByBeatID: [UInt64: [UInt64]] = [:]
+    /// Duration-based measure count shared with the legacy sheet layout.
+    private var cachedLayoutMeasureCount = 1
     /// Preserves the legacy grouping key that produced each DrumBeat ID.
     private var cachedDrumBeatIDByNotePositionKey: [NotePositionKey: UInt64] = [:]
 
@@ -1331,6 +1333,7 @@ final class GameplayViewModel {
         let trackDurationInSeconds = calculateTrackDurationInSeconds(secondsPerMeasure: secondsPerMeasure)
         let totalMeasuresForDuration = Int(ceil(trackDurationInSeconds / secondsPerMeasure))
         let measuresCount = max(1, totalMeasuresForDuration)
+        cachedLayoutMeasureCount = measuresCount
 
         cachedMeasurePositions = GameplayLayout.calculateMeasurePositions(
             totalMeasures: measuresCount,
@@ -1376,7 +1379,11 @@ final class GameplayViewModel {
             return
         }
 
-        let input = NotationLayoutInput(notes: cachedNotes, timeSignature: track.timeSignature)
+        let input = NotationLayoutInput(
+            notes: cachedNotes,
+            timeSignature: track.timeSignature,
+            minimumMeasureCount: cachedLayoutMeasureCount
+        )
         cachedNotationLayout = NotationLayoutEngine().layout(input: input)
         cachedNotationNoteHeadPositions = Dictionary(
             uniqueKeysWithValues: cachedNotationLayout.beatLookup.map { beatID, position in

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -107,8 +107,10 @@ final class GameplayViewModel {
     private(set) var cachedBeatPositions: [UInt64: (x: Double, y: Double)] = [:]
     /// Pre-computed notation layout for future gameplay rendering migration
     private(set) var cachedNotationLayout = NotationLayout.empty
-    /// Fast lookup map from notation beat ID to rendered position
-    private(set) var cachedNotationBeatPositions: [UInt64: (x: Double, y: Double)] = [:]
+    /// Fast lookup map from rendered note-head ID to rendered position
+    private(set) var cachedNotationNoteHeadPositions: [UInt64: (x: Double, y: Double)] = [:]
+    /// Maps legacy DrumBeat IDs to all rendered note heads at the same musical time.
+    private(set) var cachedNotationNoteHeadIDsByBeatID: [UInt64: [UInt64]] = [:]
 
     // MARK: - Visual State
     /// Currently active beat ID for highlighting
@@ -1294,15 +1296,26 @@ final class GameplayViewModel {
     func cacheNotationLayout() {
         guard let track = track else {
             cachedNotationLayout = .empty
-            cachedNotationBeatPositions = [:]
+            cachedNotationNoteHeadPositions = [:]
+            cachedNotationNoteHeadIDsByBeatID = [:]
             return
         }
 
         let input = NotationLayoutInput(notes: cachedNotes, timeSignature: track.timeSignature)
         cachedNotationLayout = NotationLayoutEngine().layout(input: input)
-        cachedNotationBeatPositions = Dictionary(
+        cachedNotationNoteHeadPositions = Dictionary(
             uniqueKeysWithValues: cachedNotationLayout.beatLookup.map { beatID, position in
                 (beatID, (x: Double(position.x), y: Double(position.y)))
+            }
+        )
+        cachedNotationNoteHeadIDsByBeatID = Dictionary(
+            uniqueKeysWithValues: cachedDrumBeats.map { beat in
+                let noteHeadIDs = cachedNotationLayout.noteHeads
+                    .filter {
+                        abs($0.timePosition - beat.timePosition) <= BeamGroupingConstants.comparisonTolerance
+                    }
+                    .map(\.id)
+                return (beat.id, noteHeadIDs)
             }
         )
     }

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -1520,8 +1520,8 @@ final class GameplayViewModel {
         }
 
         cachedNotationNoteHeadPositions = Dictionary(
-            uniqueKeysWithValues: cachedNotationLayout.beatLookup.map { beatID, position in
-                (beatID, (x: Double(position.x), y: Double(position.y)))
+            uniqueKeysWithValues: cachedNotationLayout.noteHeadPositionsByID.map { noteHeadID, position in
+                (noteHeadID, (x: Double(position.x), y: Double(position.y)))
             }
         )
         let notePositionKeyBySourceNoteID = Dictionary(

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -1082,7 +1082,7 @@ final class GameplayViewModel {
             playbackProgress = min(elapsedTime / cachedTrackDuration, 1.0)
 
             let playheadTimePosition = Double(measureIndex) + beatPosition
-            updatePurpleBarPosition()
+            updatePurpleBarPosition(elapsedTime: elapsedTime)
             updateActiveBeat(forTimePosition: playheadTimePosition)
             scanForMissedNotes(upToTimePosition: playheadTimePosition)
 
@@ -1167,24 +1167,36 @@ final class GameplayViewModel {
         activeNotationNoteHeadIDs = []
     }
 
-    func updatePurpleBarPosition() {
-        purpleBarPosition = calculatePurpleBarPosition()
+    func updatePurpleBarPosition(elapsedTime: Double? = nil) {
+        purpleBarPosition = calculatePurpleBarPosition(elapsedTime: elapsedTime)
     }
 
-    func calculatePurpleBarPosition() -> (x: Double, y: Double)? {
+    func calculatePurpleBarPosition(elapsedTime providedElapsedTime: Double? = nil) -> (x: Double, y: Double)? {
         guard let track = track, isPlaying else { return nil }
-        guard let beatProgress = metronome.getCurrentBeatProgress() else { return nil }
+        let elapsedTime: Double
+        if let providedElapsedTime {
+            elapsedTime = providedElapsedTime
+        } else {
+            guard let calculatedElapsedTime = calculateElapsedTime() else { return nil }
+            elapsedTime = calculatedElapsedTime
+        }
 
+        let secondsPerBeat = 60.0 / effectiveBPM()
+        let totalBeatsElapsed = elapsedTime / secondsPerBeat
         let beatsPerMeasure = track.timeSignature.beatsPerMeasure
-        let discreteTotalBeats = Int(beatProgress.totalBeats)
+        let discreteTotalBeats = Int(totalBeatsElapsed)
         let measureIndex = discreteTotalBeats / beatsPerMeasure
         let beatWithinMeasure = Double(discreteTotalBeats % beatsPerMeasure)
 
+        let isNotationLayoutActive = !cachedNotationLayout.noteHeads.isEmpty
         if let notationPosition = calculateNotationPurpleBarPosition(
             measureIndex: measureIndex,
             beatWithinMeasure: beatWithinMeasure
         ) {
             return notationPosition
+        }
+        if isNotationLayoutActive {
+            return nil
         }
 
         guard let measurePos = measurePositionMap[measureIndex] ?? measurePositionMap[0] else { return nil }

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -1292,8 +1292,12 @@ final class GameplayViewModel {
         let beatWithinMeasure = Double(discreteTotalBeats % beatsPerMeasure)
 
         let isNotationLayoutActive = !cachedNotationLayout.noteHeads.isEmpty
+        // Clamp measureIndex to valid range for notation layout lookup
+        let clampedMeasureIndex = isNotationLayoutActive && measureIndex >= cachedNotationLayout.measures.count
+            ? cachedNotationLayout.measures.count - 1
+            : measureIndex
         if let notationPosition = calculateNotationPurpleBarPosition(
-            measureIndex: measureIndex,
+            measureIndex: clampedMeasureIndex,
             beatWithinMeasure: beatWithinMeasure
         ) {
             return notationPosition
@@ -1372,6 +1376,8 @@ final class GameplayViewModel {
         isPlaying = false
         metronome.stop()
         inputManager.stopListening()
+        playbackTimer?.invalidate()
+        playbackTimer = nil
         // Capture final score and snapshot scoreEngine before reset clears them
         let finalScore = scoreEngine.score
         let isNewRecord = highScoreService.saveIfHighScore(finalScore, for: chart.persistentModelID)

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -131,6 +131,8 @@ final class GameplayViewModel {
     var purpleBarPosition: (x: Double, y: Double)?
     /// Cached static staff lines view (uses AnyView for type erasure)
     var staticStaffLinesView: AnyView?
+    /// Cached notation-path staff lines view (width matches notation content width)
+    var notationStaffLinesView: AnyView?
 
     // MARK: - BGM State
     /// Audio player for background music
@@ -1408,6 +1410,7 @@ final class GameplayViewModel {
             cachedNotationLayout = .empty
             cachedNotationNoteHeadPositions = [:]
             cachedNotationNoteHeadIDsByBeatID = [:]
+            notationStaffLinesView = nil
             activeNotationNoteHeadIDs = []
             return
         }
@@ -1418,6 +1421,29 @@ final class GameplayViewModel {
             minimumMeasureCount: cachedLayoutMeasureCount
         )
         cachedNotationLayout = NotationLayoutEngine().layout(input: input)
+
+        if !cachedNotationLayout.noteHeads.isEmpty {
+            let notationMeasurePositions = cachedNotationLayout.measures.map { measure in
+                GameplayLayout.MeasurePosition(
+                    row: measure.row,
+                    xOffset: measure.xOffset,
+                    measureIndex: measure.measureIndex
+                )
+            }
+            let contentWidth = cachedNotationLayout.contentWidth
+            notationStaffLinesView = AnyView(
+                StaffLinesBackgroundView(measurePositions: notationMeasurePositions, width: contentWidth)
+            )
+        } else {
+            notationStaffLinesView = nil
+        }
+
+        if cachedNotes.count != cachedNotationLayout.noteHeads.count, !cachedNotes.isEmpty {
+            Logger.warning(
+                "Layout engine dropped notes: \(cachedNotes.count) input → \(cachedNotationLayout.noteHeads.count) noteHeads"
+            )
+        }
+
         cachedNotationNoteHeadPositions = Dictionary(
             uniqueKeysWithValues: cachedNotationLayout.beatLookup.map { beatID, position in
                 (beatID, (x: Double(position.x), y: Double(position.y)))
@@ -1432,12 +1458,19 @@ final class GameplayViewModel {
             }
         )
         var noteHeadIDsByBeatID = Dictionary(uniqueKeysWithValues: cachedDrumBeats.map { ($0.id, [UInt64]()) })
+        var desyncCount = 0
         for noteHead in cachedNotationLayout.noteHeads {
             guard let positionKey = notePositionKeyBySourceNoteID[noteHead.sourceNoteID],
                   let beatID = cachedDrumBeatIDByNotePositionKey[positionKey] else {
+                desyncCount += 1
                 continue
             }
             noteHeadIDsByBeatID[beatID, default: []].append(noteHead.id)
+        }
+        if desyncCount > 0 {
+            Logger.warning(
+                "NoteHead-to-beatID mapping failed for \(desyncCount)/\(cachedNotationLayout.noteHeads.count) noteHeads"
+            )
         }
         cachedNotationNoteHeadIDsByBeatID = noteHeadIDsByBeatID
     }

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -719,6 +719,10 @@ final class GameplayViewModel {
         // This ensures UI state accurately reflects whether playback actually started
         isPlaying = true
 
+        // Start continuous visual tick (~30 Hz) so sub-beat notes (eighths,
+        // sixteenths) are highlighted between quarter-note metronome callbacks.
+        startVisualTickTimer()
+
         // Synchronize input timeline with the actual scheduled playback start time.
         // The metronome/BGM are scheduled 0.05s in the future (setupTime). The input
         // manager must use the same zero-point so hits are judged relative to what the
@@ -1054,6 +1058,25 @@ final class GameplayViewModel {
 
     // MARK: - Visual Updates
 
+    /// Starts a ~30 Hz timer that continuously updates active-note highlighting
+    /// and purple-bar position between quarter-note metronome callbacks.
+    /// This ensures sub-beat notes (eighths, sixteenths) become active at the
+    /// correct moment rather than only when the next quarter-note boundary fires.
+    /// Skipped in test environments to avoid interfering with the test runner's
+    /// main run loop (matches the pattern used by audio components).
+    private func startVisualTickTimer() {
+        guard !TestEnvironment.isRunningTests else { return }
+        playbackTimer?.invalidate()
+        playbackTimer = Timer.scheduledTimer(
+            withTimeInterval: 1.0 / 30.0,
+            repeats: true
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.updateContinuousVisualsTick()
+            }
+        }
+    }
+
     func updateVisualElementsFromMetronome() {
         guard let track = track, isPlaying else { return }
 
@@ -1066,15 +1089,42 @@ final class GameplayViewModel {
         guard let metronomeTime = metronome.getCurrentPlaybackTime() else { return }
         let elapsedTime = pausedElapsedTime + metronomeTime
 
+        updateContinuousVisuals(elapsedTime: elapsedTime, track: track)
+    }
+
+    /// Called by the continuous visual tick timer (~30 Hz) so that sub-beat notes
+    /// (eighths, sixteenths) are highlighted even though the metronome only fires
+    /// at quarter-note boundaries.
+    private func updateContinuousVisualsTick() {
+        guard let track = track, isPlaying else { return }
+        guard cachedTrackDuration > 0 else { return }
+        guard let metronomeTime = metronome.getCurrentPlaybackTime() else { return }
+        let elapsedTime = pausedElapsedTime + metronomeTime
+        updateContinuousVisuals(elapsedTime: elapsedTime, track: track)
+    }
+
+    /// Shared logic for both the metronome callback and the continuous tick timer.
+    private func updateContinuousVisuals(elapsedTime: Double, track: DrumTrack) {
         // Use effective BPM for visual sync (speed-adjusted)
         let secondsPerBeat = 60.0 / effectiveBPM()
         let totalBeatsElapsedFloat = elapsedTime / secondsPerBeat
         let discreteTotalBeats = Int(totalBeatsElapsedFloat)
 
+        // Continuous playhead position — always computed so sub-beat notes
+        // (eighths, sixteenths) can be matched regardless of when the metronome fires.
+        let beatsPerMeasure = track.timeSignature.beatsPerMeasure
+        let continuousMeasureFraction = totalBeatsElapsedFloat / Double(beatsPerMeasure)
+        let continuousMeasureIdx = Int(continuousMeasureFraction)
+        let continuousOffset = continuousMeasureFraction - Double(continuousMeasureIdx)
+        let playheadTimePosition = Double(continuousMeasureIdx) + continuousOffset
+
+        // Active-note update runs on EVERY tick (not gated by discrete beat)
+        // so that off-beat notes become active at the right moment.
+        updateActiveBeat(forTimePosition: playheadTimePosition)
+
         if discreteTotalBeats != lastDiscreteBeat {
             lastDiscreteBeat = discreteTotalBeats
 
-            let beatsPerMeasure = track.timeSignature.beatsPerMeasure
             let measureIndex = discreteTotalBeats / beatsPerMeasure
             let beatWithinMeasure = discreteTotalBeats % beatsPerMeasure
             let beatPosition = Double(beatWithinMeasure) / Double(beatsPerMeasure)
@@ -1085,15 +1135,7 @@ final class GameplayViewModel {
             totalBeatsElapsed = discreteTotalBeats
             playbackProgress = min(elapsedTime / cachedTrackDuration, 1.0)
 
-            // Use continuous timePosition so off-beat notes (eighths, sixteenths)
-            // can be matched by updateActiveBeat's binary-search + look-behind logic.
-            let continuousMeasureFraction = totalBeatsElapsedFloat / Double(beatsPerMeasure)
-            let continuousMeasureIdx = Int(continuousMeasureFraction)
-            let continuousOffset = continuousMeasureFraction - Double(continuousMeasureIdx)
-            let playheadTimePosition = Double(continuousMeasureIdx) + continuousOffset
-
             updatePurpleBarPosition(elapsedTime: elapsedTime)
-            updateActiveBeat(forTimePosition: playheadTimePosition)
             scanForMissedNotes(upToTimePosition: playheadTimePosition)
 
             // Schedule delayed completion to preserve late-tolerance window for final notes.

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -1066,14 +1066,13 @@ final class GameplayViewModel {
     private func startVisualTickTimer() {
         guard !TestEnvironment.isRunningTests else { return }
         playbackTimer?.invalidate()
-        playbackTimer = Timer.scheduledTimer(
-            withTimeInterval: 1.0 / 30.0,
-            repeats: true
-        ) { [weak self] _ in
+        let timer = Timer(timeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated {
                 self?.updateContinuousVisualsTick()
             }
         }
+        RunLoop.main.add(timer, forMode: .common)
+        playbackTimer = timer
     }
 
     func updateVisualElementsFromMetronome() {

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -105,6 +105,10 @@ final class GameplayViewModel {
     private(set) var measurePositionMap: [Int: GameplayLayout.MeasurePosition] = [:]
     /// Pre-cached beat positions for performance
     private(set) var cachedBeatPositions: [UInt64: (x: Double, y: Double)] = [:]
+    /// Pre-computed notation layout for future gameplay rendering migration
+    private(set) var cachedNotationLayout = NotationLayout.empty
+    /// Fast lookup map from notation beat ID to rendered position
+    private(set) var cachedNotationBeatPositions: [UInt64: (x: Double, y: Double)] = [:]
 
     // MARK: - Visual State
     /// Currently active beat ID for highlighting
@@ -1240,7 +1244,10 @@ final class GameplayViewModel {
     }
 
     func computeCachedLayoutData() {
-        guard let track = track else { return }
+        guard let track = track else {
+            cacheNotationLayout()
+            return
+        }
 
         let secondsPerBeat = 60.0 / track.bpm
         let secondsPerMeasure = secondsPerBeat * Double(track.timeSignature.beatsPerMeasure)
@@ -1280,7 +1287,24 @@ final class GameplayViewModel {
             measurePositionMap[0] = measure0
         }
 
+        cacheNotationLayout()
         cacheBeatPositions()
+    }
+
+    func cacheNotationLayout() {
+        guard let track = track else {
+            cachedNotationLayout = .empty
+            cachedNotationBeatPositions = [:]
+            return
+        }
+
+        let input = NotationLayoutInput(notes: cachedNotes, timeSignature: track.timeSignature)
+        cachedNotationLayout = NotationLayoutEngine().layout(input: input)
+        cachedNotationBeatPositions = Dictionary(
+            uniqueKeysWithValues: cachedNotationLayout.beatLookup.map { beatID, position in
+                (beatID, (x: Double(position.x), y: Double(position.y)))
+            }
+        )
     }
 
     func cacheBeatPositions() {

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -120,12 +120,10 @@ final class GameplayViewModel {
     /// Currently active beat ID for highlighting
     var activeBeatId: UInt64? {
         didSet {
-            if activeBeatId == nil {
-                activeNotationNoteHeadIDs = []
-            }
+            // Always clear active note heads when beat changes (self-enforcing invariant)
+            activeNotationNoteHeadIDs = []
         }
     }
-    /// Rendered notation note heads currently highlighted by the playhead.
     private(set) var activeNotationNoteHeadIDs: Set<UInt64> = []
     /// Current purple bar position (x, y)
     var purpleBarPosition: (x: Double, y: Double)?
@@ -1203,22 +1201,8 @@ final class GameplayViewModel {
         let maxLookBehind = 1.0 / Double(track.timeSignature.beatsPerMeasure)
 
         // Step 1: find the last beat at or before the playhead.
-        var left = 0
-        var right = cachedDrumBeats.count - 1
-        var result = -1
-
-        while left <= right {
-            let mid = (left + right) / 2
-            if cachedDrumBeats[mid].timePosition <= currentTimePosition {
-                result = mid
-                left = mid + 1
-            } else {
-                right = mid - 1
-            }
-        }
-
-        if result >= 0 {
-            let beat = cachedDrumBeats[result]
+        if let index = lastBeatIndex(atOrBefore: currentTimePosition, lookAhead: 0) {
+            let beat = cachedDrumBeats[index]
             if currentTimePosition - beat.timePosition <= maxLookBehind {
                 activeBeatId = beat.id
                 updateActiveNotation(forBeatID: beat.id, fallbackTimePosition: currentTimePosition)
@@ -1228,22 +1212,8 @@ final class GameplayViewModel {
 
         // Step 2: no beat at/before playhead — try a small look-ahead for
         // sub-beat notes that the playhead is about to reach.
-        left = 0
-        right = cachedDrumBeats.count - 1
-        result = -1
-
-        while left <= right {
-            let mid = (left + right) / 2
-            if cachedDrumBeats[mid].timePosition <= currentTimePosition + lookAhead {
-                result = mid
-                left = mid + 1
-            } else {
-                right = mid - 1
-            }
-        }
-
-        if result >= 0 {
-            let beat = cachedDrumBeats[result]
+        if let index = lastBeatIndex(atOrBefore: currentTimePosition, lookAhead: lookAhead) {
+            let beat = cachedDrumBeats[index]
             if currentTimePosition - beat.timePosition <= maxLookBehind {
                 activeBeatId = beat.id
                 updateActiveNotation(forBeatID: beat.id, fallbackTimePosition: currentTimePosition)
@@ -1252,6 +1222,30 @@ final class GameplayViewModel {
         }
 
         clearActiveBeat()
+    }
+
+    /// Performs binary search over cachedDrumBeats to find the last beat at or before
+    /// (timePosition + lookAhead).
+    private func lastBeatIndex(atOrBefore timePosition: Double, lookAhead: Double = 0.0) -> Int? {
+        guard !cachedDrumBeats.isEmpty else { return nil }
+
+        var left = 0
+        var right = cachedDrumBeats.count - 1
+        var result = -1
+
+        let target = timePosition + lookAhead
+
+        while left <= right {
+            let mid = (left + right) / 2
+            if cachedDrumBeats[mid].timePosition <= target {
+                result = mid
+                left = mid + 1
+            } else {
+                right = mid - 1
+            }
+        }
+
+        return result >= 0 ? result : nil
     }
 
     func updateActiveNotation(forTimePosition timePosition: Double) {

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -116,11 +116,15 @@ final class GameplayViewModel {
 
     // MARK: - Visual State
     /// Currently active beat ID for highlighting
-    var activeBeatId: UInt64?
-    var activeNotationNoteHeadIDs: Set<UInt64> {
-        guard let activeBeatId else { return [] }
-        return Set(cachedNotationNoteHeadIDsByBeatID[activeBeatId] ?? [])
+    var activeBeatId: UInt64? {
+        didSet {
+            if activeBeatId == nil {
+                activeNotationNoteHeadIDs = []
+            }
+        }
     }
+    /// Rendered notation note heads currently highlighted by the playhead.
+    private(set) var activeNotationNoteHeadIDs: Set<UInt64> = []
     /// Current purple bar position (x, y)
     var purpleBarPosition: (x: Double, y: Double)?
     /// Cached static staff lines view (uses AnyView for type erasure)
@@ -787,6 +791,7 @@ final class GameplayViewModel {
         playbackStartTime = nil
         bgmPlayer?.pause()
         purpleBarPosition = nil
+        clearActiveBeat()
         Logger.audioPlayback("Paused playback for track: \(track?.title ?? "Unknown")")
     }
 
@@ -885,6 +890,7 @@ final class GameplayViewModel {
         lastDiscreteBeat = -1
         playbackProgress = 0.0
         purpleBarPosition = nil
+        clearActiveBeat()
         lastScheduledPlaybackStartTime = nil
         lastScheduledPlaybackHostTime = nil
         resetScoring()
@@ -1075,10 +1081,9 @@ final class GameplayViewModel {
             totalBeatsElapsed = discreteTotalBeats
             playbackProgress = min(elapsedTime / cachedTrackDuration, 1.0)
 
-            updatePurpleBarPosition()
-            updateActiveBeat()
-
             let playheadTimePosition = Double(measureIndex) + beatPosition
+            updatePurpleBarPosition()
+            updateActiveBeat(forTimePosition: playheadTimePosition)
             scanForMissedNotes(upToTimePosition: playheadTimePosition)
 
             // Schedule delayed completion to preserve late-tolerance window for final notes.
@@ -1109,34 +1114,57 @@ final class GameplayViewModel {
         }
     }
 
-    func updateActiveBeat() {
+    func updateActiveBeat(forTimePosition providedTimePosition: Double? = nil) {
         guard let track = track, isPlaying else {
-            activeBeatId = nil
+            clearActiveBeat()
             return
         }
 
-        guard let elapsedTime = calculateElapsedTime() else {
-            activeBeatId = nil
-            return
+        let currentTimePosition: Double
+
+        if let providedTimePosition {
+            currentTimePosition = providedTimePosition
+        } else {
+            guard let elapsedTime = calculateElapsedTime() else {
+                clearActiveBeat()
+                return
+            }
+            // Use effective BPM for visual sync (speed-adjusted)
+            let secondsPerBeat = 60.0 / effectiveBPM()
+            let totalBeatsElapsed = elapsedTime / secondsPerBeat
+            let beatsPerMeasure = track.timeSignature.beatsPerMeasure
+            let discreteTotalBeats = Int(totalBeatsElapsed)
+            let measureIndex = discreteTotalBeats / beatsPerMeasure
+            let beatWithinMeasure = Double(discreteTotalBeats % beatsPerMeasure)
+            currentTimePosition = Double(measureIndex) + (beatWithinMeasure / Double(beatsPerMeasure))
         }
-
-        // Use effective BPM for visual sync (speed-adjusted)
-        let secondsPerBeat = 60.0 / effectiveBPM()
-        let totalBeatsElapsed = elapsedTime / secondsPerBeat
-        let beatsPerMeasure = track.timeSignature.beatsPerMeasure
-
-        let discreteTotalBeats = Int(totalBeatsElapsed)
-        let measureIndex = discreteTotalBeats / beatsPerMeasure
-        let beatWithinMeasure = Double(discreteTotalBeats % beatsPerMeasure)
-
-        let currentTimePosition = Double(measureIndex) + (beatWithinMeasure / Double(beatsPerMeasure))
         let timeTolerance = 0.05
 
         for beat in cachedDrumBeats where abs(beat.timePosition - currentTimePosition) < timeTolerance {
             activeBeatId = beat.id
+            updateActiveNotation(forBeatID: beat.id, fallbackTimePosition: currentTimePosition)
             return
         }
+        clearActiveBeat()
+    }
+
+    func updateActiveNotation(forTimePosition timePosition: Double) {
+        let key = NotationLayout.timePositionKey(timePosition)
+        activeNotationNoteHeadIDs = cachedNotationLayout.noteHeadIDsByTimePosition[key] ?? []
+    }
+
+    private func updateActiveNotation(forBeatID beatID: UInt64, fallbackTimePosition: Double) {
+        let noteHeadIDs = Set(cachedNotationNoteHeadIDsByBeatID[beatID] ?? [])
+        if noteHeadIDs.isEmpty {
+            updateActiveNotation(forTimePosition: fallbackTimePosition)
+        } else {
+            activeNotationNoteHeadIDs = noteHeadIDs
+        }
+    }
+
+    private func clearActiveBeat() {
         activeBeatId = nil
+        activeNotationNoteHeadIDs = []
     }
 
     func updatePurpleBarPosition() {
@@ -1152,16 +1180,40 @@ final class GameplayViewModel {
         let measureIndex = discreteTotalBeats / beatsPerMeasure
         let beatWithinMeasure = Double(discreteTotalBeats % beatsPerMeasure)
 
-        guard let measurePos = measurePositionMap[measureIndex] ?? measurePositionMap[0] else {
-            return nil
+        if let notationPosition = calculateNotationPurpleBarPosition(
+            measureIndex: measureIndex,
+            beatWithinMeasure: beatWithinMeasure
+        ) {
+            return notationPosition
         }
 
+        guard let measurePos = measurePositionMap[measureIndex] ?? measurePositionMap[0] else { return nil }
         let indicatorX = GameplayLayout.preciseNoteXPosition(
             measurePosition: measurePos,
             beatPosition: beatWithinMeasure,
             timeSignature: track.timeSignature
         )
         let staffCenterY = GameplayLayout.StaffLinePosition.line3.absoluteY(for: measurePos.row)
+
+        return (x: Double(indicatorX), y: Double(staffCenterY))
+    }
+
+    func calculateNotationPurpleBarPosition(
+        measureIndex: Int,
+        beatWithinMeasure: Double
+    ) -> (x: Double, y: Double)? {
+        guard let track = track, !cachedNotationLayout.noteHeads.isEmpty else { return nil }
+        guard let measure = cachedNotationLayout.measures.first(where: { $0.measureIndex == measureIndex }) else {
+            return nil
+        }
+
+        let drawableWidth = measure.width - GameplayLayout.barLineWidth - GameplayLayout.uniformSpacing
+        let beatGap = drawableWidth / CGFloat(track.timeSignature.beatsPerMeasure)
+        let indicatorX = measure.xOffset
+            + GameplayLayout.barLineWidth
+            + GameplayLayout.uniformSpacing
+            + CGFloat(beatWithinMeasure) * beatGap
+        let staffCenterY = GameplayLayout.StaffLinePosition.line3.absoluteY(for: measure.row)
 
         return (x: Double(indicatorX), y: Double(staffCenterY))
     }
@@ -1308,6 +1360,7 @@ final class GameplayViewModel {
             cachedNotationLayout = .empty
             cachedNotationNoteHeadPositions = [:]
             cachedNotationNoteHeadIDsByBeatID = [:]
+            activeNotationNoteHeadIDs = []
             return
         }
 

--- a/Virgo/views/BeamView.swift
+++ b/Virgo/views/BeamView.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+// Legacy notation renderer retained for compatibility tests while gameplay uses NotationLayoutEngine.
+
 // MARK: - Beam Group Models
 struct BeamGroup: Identifiable {
     let id: String

--- a/Virgo/views/DrumBeatView.swift
+++ b/Virgo/views/DrumBeatView.swift
@@ -273,6 +273,7 @@ private struct DrumSymbolView: View {
 // MARK: - Flag View
 struct FlagView: View {
     let flagIndex: Int
+    var stemDirection: StemDirection = .up
 
     var body: some View {
         Path { path in
@@ -287,5 +288,6 @@ struct FlagView: View {
         }
         .fill(Color.white)
         .frame(width: GameplayLayout.flagWidth, height: GameplayLayout.flagHeight)
+        .rotationEffect(stemDirection == .down ? .degrees(180) : .zero)
     }
 }

--- a/Virgo/views/DrumBeatView.swift
+++ b/Virgo/views/DrumBeatView.swift
@@ -286,7 +286,7 @@ struct FlagView: View {
                           control2: CGPoint(x: GameplayLayout.flagCurveEndControl2X, y: GameplayLayout.flagCurveEndControl2Y))
             path.closeSubpath()
         }
-        .fill(Color.white)
+        .fill(.foreground)
         .frame(width: GameplayLayout.flagWidth, height: GameplayLayout.flagHeight)
         .rotationEffect(stemDirection == .down ? .degrees(180) : .zero)
     }

--- a/Virgo/views/DrumBeatView.swift
+++ b/Virgo/views/DrumBeatView.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+// Legacy notation renderer retained for compatibility tests while gameplay uses NotationLayoutEngine.
+
 // MARK: - Supporting Models
 struct DrumBeat {
     let id: UInt64

--- a/Virgo/views/GameplayView.swift
+++ b/Virgo/views/GameplayView.swift
@@ -143,10 +143,12 @@ struct GameplayView: View {
 // MARK: - Stable Staff Lines Background View
 struct StaffLinesBackgroundView: View {
     let measurePositions: [GameplayLayout.MeasurePosition]
+    let width: CGFloat
     private let rows: [Int]
 
-    init(measurePositions: [GameplayLayout.MeasurePosition]) {
+    init(measurePositions: [GameplayLayout.MeasurePosition], width: CGFloat = GameplayLayout.maxRowWidth) {
         self.measurePositions = measurePositions
+        self.width = width
         self.rows = Array(Set(measurePositions.map { $0.row })).sorted()
     }
 
@@ -156,10 +158,10 @@ struct StaffLinesBackgroundView: View {
                 ZStack {
                     ForEach(0..<GameplayLayout.staffLineCount, id: \.self) { lineIndex in
                         Rectangle()
-                            .frame(width: GameplayLayout.maxRowWidth, height: 1)
+                            .frame(width: width, height: 1)
                             .foregroundColor(.gray.opacity(0.5))
                             .position(
-                                x: GameplayLayout.maxRowWidth / 2,
+                                x: width / 2,
                                 y: GameplayLayout.StaffLinePosition(rawValue: lineIndex)?.absoluteY(for: row) ?? 0
                             )
                     }

--- a/Virgo/views/NotationPrimitiveViews.swift
+++ b/Virgo/views/NotationPrimitiveViews.swift
@@ -93,6 +93,11 @@ struct NotationMeasureBarView: View {
         let centerY = GameplayLayout.StaffLinePosition.line3.absoluteY(for: measureBar.row)
 
         if measureBar.isFinal {
+            // Compute total double-bar width: thin bar + spacing + thick bar.
+            let totalWidth = GameplayLayout.doubleBarLineWidths.thin
+                + GameplayLayout.doubleBarLineSpacing
+                + GameplayLayout.doubleBarLineWidths.thick
+            // Position HStack so its trailing edge (thick bar) aligns at measureBar.x.
             HStack(spacing: GameplayLayout.doubleBarLineSpacing) {
                 Rectangle()
                     .frame(width: GameplayLayout.doubleBarLineWidths.thin, height: GameplayLayout.staffHeight)
@@ -101,7 +106,7 @@ struct NotationMeasureBarView: View {
                     .frame(width: GameplayLayout.doubleBarLineWidths.thick, height: GameplayLayout.staffHeight)
                     .foregroundColor(.white)
             }
-            .position(x: measureBar.x, y: centerY)
+            .position(x: measureBar.x - totalWidth / 2, y: centerY)
         } else {
             Rectangle()
                 .frame(width: GameplayLayout.barLineWidth, height: GameplayLayout.staffHeight)

--- a/Virgo/views/NotationPrimitiveViews.swift
+++ b/Virgo/views/NotationPrimitiveViews.swift
@@ -62,10 +62,27 @@ struct NotationFlagView: View {
     let flag: RenderedFlag
     let isActive: Bool
 
+    /// Computes the corrected center so the flag path origin (0,0) lands on the
+    /// stem-tip attachment point stored in `flag.origin`.
+    /// `.position()` centres the flagWidth × flagHeight frame, so we shift by
+    /// half the frame to align the top-left corner with the stem tip.
+    /// For stem-down the view is rotated 180°, which mirrors the attachment to
+    /// the opposite corner, so the correction direction flips.
+    private var adjustedCenter: CGPoint {
+        let halfW = GameplayLayout.flagWidth / 2
+        let halfH = GameplayLayout.flagHeight / 2
+        switch flag.stemDirection {
+        case .up:
+            return CGPoint(x: flag.origin.x + halfW, y: flag.origin.y + halfH)
+        case .down:
+            return CGPoint(x: flag.origin.x - halfW, y: flag.origin.y - halfH)
+        }
+    }
+
     var body: some View {
         FlagView(flagIndex: flag.flagIndex, stemDirection: flag.stemDirection)
             .foregroundColor(isActive ? .yellow : .white)
-            .position(flag.origin)
+            .position(adjustedCenter)
     }
 }
 

--- a/Virgo/views/NotationPrimitiveViews.swift
+++ b/Virgo/views/NotationPrimitiveViews.swift
@@ -1,0 +1,84 @@
+//
+//  NotationPrimitiveViews.swift
+//  Virgo
+//
+//  Created by Codex on 1/5/2026.
+//
+
+import SwiftUI
+
+struct NotationNoteHeadView: View {
+    let noteHead: RenderedNoteHead
+    let isActive: Bool
+
+    var body: some View {
+        Text(noteHead.drumType.symbol)
+            .font(.system(size: GameplayLayout.drumSymbolFontSize, weight: .bold))
+            .foregroundColor(isActive ? .yellow : .white)
+            .frame(width: GameplayLayout.beatColumnWidth, height: GameplayLayout.drumSymbolFontSize)
+            .position(noteHead.position)
+    }
+}
+
+struct NotationStemView: View {
+    let stem: RenderedStem
+    let isActive: Bool
+
+    var body: some View {
+        Path { path in
+            path.move(to: stem.start)
+            path.addLine(to: stem.end)
+        }
+        .stroke(isActive ? Color.yellow : Color.white, lineWidth: GameplayLayout.stemWidth)
+    }
+}
+
+struct NotationBeamView: View {
+    let beam: RenderedBeam
+    let isActive: Bool
+
+    var body: some View {
+        Path { path in
+            path.move(to: beam.start)
+            path.addLine(to: beam.end)
+        }
+        .stroke(isActive ? Color.yellow : Color.white, lineWidth: beam.thickness)
+    }
+}
+
+struct NotationLedgerLineView: View {
+    let ledgerLine: RenderedLedgerLine
+
+    var body: some View {
+        Path { path in
+            path.move(to: ledgerLine.start)
+            path.addLine(to: ledgerLine.end)
+        }
+        .stroke(Color.white, lineWidth: GameplayLayout.barLineWidth)
+    }
+}
+
+struct NotationMeasureBarView: View {
+    let measureBar: RenderedMeasureBar
+
+    var body: some View {
+        let centerY = GameplayLayout.StaffLinePosition.line3.absoluteY(for: measureBar.row)
+
+        if measureBar.isFinal {
+            HStack(spacing: GameplayLayout.doubleBarLineSpacing) {
+                Rectangle()
+                    .frame(width: GameplayLayout.doubleBarLineWidths.thin, height: GameplayLayout.staffHeight)
+                    .foregroundColor(.white)
+                Rectangle()
+                    .frame(width: GameplayLayout.doubleBarLineWidths.thick, height: GameplayLayout.staffHeight)
+                    .foregroundColor(.white)
+            }
+            .position(x: measureBar.x, y: centerY)
+        } else {
+            Rectangle()
+                .frame(width: GameplayLayout.barLineWidth, height: GameplayLayout.staffHeight)
+                .foregroundColor(.white.opacity(0.8))
+                .position(x: measureBar.x, y: centerY)
+        }
+    }
+}

--- a/Virgo/views/NotationPrimitiveViews.swift
+++ b/Virgo/views/NotationPrimitiveViews.swift
@@ -58,6 +58,17 @@ struct NotationLedgerLineView: View {
     }
 }
 
+struct NotationFlagView: View {
+    let flag: RenderedFlag
+    let isActive: Bool
+
+    var body: some View {
+        FlagView(flagIndex: flag.flagIndex, stemDirection: flag.stemDirection)
+            .foregroundColor(isActive ? .yellow : .white)
+            .position(flag.origin)
+    }
+}
+
 struct NotationMeasureBarView: View {
     let measureBar: RenderedMeasureBar
 

--- a/Virgo/views/subviews/GameplaySheetMusicView.swift
+++ b/Virgo/views/subviews/GameplaySheetMusicView.swift
@@ -206,10 +206,8 @@ extension GameplayView {
                 // Then render individual notes
                 ForEach(viewModel.cachedDrumBeats, id: \.id) { beat in
 
-                    // PERFORMANCE FIX: Use pre-cached active beat ID instead of calculating for every beat
                     let isCurrentlyActive = viewModel.activeBeatId == beat.id
 
-                    // PERFORMANCE FIX: Use pre-cached positions to avoid expensive per-frame calculations
                     if let cachedPosition = viewModel.cachedBeatPositions[beat.id] {
                         // Use cached lookup map for O(1) beam group check
                         let isBeamed = viewModel.beatToBeamGroupMap[beat.id] != nil
@@ -234,7 +232,6 @@ extension GameplayView {
 
     func timeBasedBeatProgressionBars(viewModel: GameplayViewModel) -> some View {
         Group {
-            // PERFORMANCE FIX: Use pre-cached purple bar position instead of expensive calculation
             if let position = viewModel.purpleBarPosition {
                 Rectangle()
                     .frame(width: GameplayLayout.beatColumnWidth, height: GameplayLayout.staffHeight)

--- a/Virgo/views/subviews/GameplaySheetMusicView.swift
+++ b/Virgo/views/subviews/GameplaySheetMusicView.swift
@@ -34,10 +34,7 @@ extension GameplayView {
 
                         drumNotationView(measurePositions: measurePositions, viewModel: viewModel)
 
-                        timeBasedBeatProgressionBars(
-                            measurePositions: viewModel.cachedMeasurePositions,
-                            viewModel: viewModel
-                        )
+                        timeBasedBeatProgressionBars(viewModel: viewModel)
                     }
                 }
                 .frame(width: contentWidth, height: contentHeight)
@@ -222,10 +219,7 @@ extension GameplayView {
         }
     }
 
-    func timeBasedBeatProgressionBars(
-        measurePositions: [GameplayLayout.MeasurePosition],
-        viewModel: GameplayViewModel
-    ) -> some View {
+    func timeBasedBeatProgressionBars(viewModel: GameplayViewModel) -> some View {
         Group {
             // PERFORMANCE FIX: Use pre-cached purple bar position instead of expensive calculation
             if let position = viewModel.purpleBarPosition {

--- a/Virgo/views/subviews/GameplaySheetMusicView.swift
+++ b/Virgo/views/subviews/GameplaySheetMusicView.swift
@@ -168,6 +168,13 @@ extension GameplayView {
                     NotationBeamView(beam: beam, isActive: isActive)
                 }
 
+                ForEach(notationLayout.flags) { flag in
+                    NotationFlagView(
+                        flag: flag,
+                        isActive: activeNotationNoteHeadIDs.contains(flag.noteHeadID)
+                    )
+                }
+
                 ForEach(notationLayout.stems) { stem in
                     let isActive = stem.noteHeadIDs.contains { activeNotationNoteHeadIDs.contains($0) }
                     NotationStemView(stem: stem, isActive: isActive)

--- a/Virgo/views/subviews/GameplaySheetMusicView.swift
+++ b/Virgo/views/subviews/GameplaySheetMusicView.swift
@@ -93,78 +93,112 @@ extension GameplayView {
     }
 
     func barLinesView(measurePositions: [GameplayLayout.MeasurePosition], viewModel: GameplayViewModel) -> some View {
-        ZStack {
-            // Regular bar lines
-            ForEach(measurePositions, id: \.measureIndex) { position in
-                // Use the same Y positioning as staff lines - center of the staff for this row
-                let centerY = GameplayLayout.StaffLinePosition.line3.absoluteY(for: position.row) // Middle staff line
+        let notationMeasureBars = viewModel.cachedNotationLayout.measureBars
 
-                Rectangle()
-                    .frame(width: GameplayLayout.barLineWidth, height: GameplayLayout.staffHeight)
-                    .foregroundColor(.white.opacity(0.8))
+        ZStack {
+            if !notationMeasureBars.isEmpty {
+                ForEach(notationMeasureBars) { measureBar in
+                    NotationMeasureBarView(measureBar: measureBar)
+                }
+            } else {
+                // Regular bar lines
+                ForEach(measurePositions, id: \.measureIndex) { position in
+                    // Use the same Y positioning as staff lines - center of the staff for this row
+                    let centerY = GameplayLayout.StaffLinePosition.line3.absoluteY(for: position.row) // Middle staff line
+
+                    Rectangle()
+                        .frame(width: GameplayLayout.barLineWidth, height: GameplayLayout.staffHeight)
+                        .foregroundColor(.white.opacity(0.8))
+                        .position(
+                            x: position.xOffset,
+                            y: centerY
+                        )
+                }
+
+                // Double bar line at the very end
+                if let lastPosition = measurePositions.last {
+                    let measureWidth = GameplayLayout.measureWidth(for: viewModel.track?.timeSignature ?? TimeSignature.fourFour)
+                    let endX = lastPosition.xOffset + measureWidth
+                    let centerY = GameplayLayout.StaffLinePosition.line3.absoluteY(for: lastPosition.row) // Middle staff line
+
+                    HStack(spacing: GameplayLayout.doubleBarLineSpacing) {
+                        Rectangle()
+                            .frame(width: GameplayLayout.doubleBarLineWidths.thin, height: GameplayLayout.staffHeight)
+                            .foregroundColor(.white)
+                        Rectangle()
+                            .frame(width: GameplayLayout.doubleBarLineWidths.thick, height: GameplayLayout.staffHeight)
+                            .foregroundColor(.white)
+                    }
                     .position(
-                        x: position.xOffset,
+                        x: endX,
                         y: centerY
                     )
-            }
-
-            // Double bar line at the very end
-            if let lastPosition = measurePositions.last {
-                let measureWidth = GameplayLayout.measureWidth(for: viewModel.track?.timeSignature ?? TimeSignature.fourFour)
-                let endX = lastPosition.xOffset + measureWidth
-                let centerY = GameplayLayout.StaffLinePosition.line3.absoluteY(for: lastPosition.row) // Middle staff line
-
-                HStack(spacing: GameplayLayout.doubleBarLineSpacing) {
-                    Rectangle()
-                        .frame(width: GameplayLayout.doubleBarLineWidths.thin, height: GameplayLayout.staffHeight)
-                        .foregroundColor(.white)
-                    Rectangle()
-                        .frame(width: GameplayLayout.doubleBarLineWidths.thick, height: GameplayLayout.staffHeight)
-                        .foregroundColor(.white)
                 }
-                .position(
-                    x: endX,
-                    y: centerY
-                )
             }
         }
     }
 
     func drumNotationView(measurePositions: [GameplayLayout.MeasurePosition], viewModel: GameplayViewModel) -> some View {
+        let notationLayout = viewModel.cachedNotationLayout
+        let activeNotationNoteHeadIDs = viewModel.activeNotationNoteHeadIDs
+
         return ZStack {
-            // Render beams first (behind notes)
-            ForEach(viewModel.cachedBeamGroups, id: \.id) { beamGroup in
-                BeamGroupView(
-                    beamGroup: beamGroup,
-                    measurePositions: measurePositions,
-                    timeSignature: viewModel.track?.timeSignature ?? TimeSignature.fourFour,
-                    isActive: false // Keep disabled for performance
-                )
-            }
+            if !notationLayout.noteHeads.isEmpty {
+                ForEach(notationLayout.ledgerLines) { ledgerLine in
+                    NotationLedgerLineView(ledgerLine: ledgerLine)
+                }
 
-            // Then render individual notes
-            ForEach(viewModel.cachedDrumBeats, id: \.id) { beat in
+                ForEach(notationLayout.beams) { beam in
+                    let isActive = beam.noteHeadIDs.contains { activeNotationNoteHeadIDs.contains($0) }
+                    NotationBeamView(beam: beam, isActive: isActive)
+                }
 
-                // PERFORMANCE FIX: Use pre-cached active beat ID instead of calculating for every beat
-                let isCurrentlyActive = viewModel.activeBeatId == beat.id
+                ForEach(notationLayout.stems) { stem in
+                    let isActive = stem.noteHeadIDs.contains { activeNotationNoteHeadIDs.contains($0) }
+                    NotationStemView(stem: stem, isActive: isActive)
+                }
 
-                // PERFORMANCE FIX: Use pre-cached positions to avoid expensive per-frame calculations
-                if let cachedPosition = viewModel.cachedBeatPositions[beat.id] {
-                    // Use cached lookup map for O(1) beam group check
-                    let isBeamed = viewModel.beatToBeamGroupMap[beat.id] != nil
-                    let measureIndex = MeasureUtils.measureIndex(from: beat.timePosition)
-                    let row = viewModel.measurePositionMap[measureIndex]?.row ?? 0
-
-                    DrumBeatView(
-                        beat: beat,
-                        isActive: isCurrentlyActive,
-                        row: row,
-                        isBeamed: isBeamed
+                ForEach(notationLayout.noteHeads) { noteHead in
+                    NotationNoteHeadView(
+                        noteHead: noteHead,
+                        isActive: activeNotationNoteHeadIDs.contains(noteHead.id)
                     )
-                    .position(
-                        x: cachedPosition.x,
-                        y: cachedPosition.y
+                }
+            } else {
+                // Render beams first (behind notes)
+                ForEach(viewModel.cachedBeamGroups, id: \.id) { beamGroup in
+                    BeamGroupView(
+                        beamGroup: beamGroup,
+                        measurePositions: measurePositions,
+                        timeSignature: viewModel.track?.timeSignature ?? TimeSignature.fourFour,
+                        isActive: false // Keep disabled for performance
                     )
+                }
+
+                // Then render individual notes
+                ForEach(viewModel.cachedDrumBeats, id: \.id) { beat in
+
+                    // PERFORMANCE FIX: Use pre-cached active beat ID instead of calculating for every beat
+                    let isCurrentlyActive = viewModel.activeBeatId == beat.id
+
+                    // PERFORMANCE FIX: Use pre-cached positions to avoid expensive per-frame calculations
+                    if let cachedPosition = viewModel.cachedBeatPositions[beat.id] {
+                        // Use cached lookup map for O(1) beam group check
+                        let isBeamed = viewModel.beatToBeamGroupMap[beat.id] != nil
+                        let measureIndex = MeasureUtils.measureIndex(from: beat.timePosition)
+                        let row = viewModel.measurePositionMap[measureIndex]?.row ?? 0
+
+                        DrumBeatView(
+                            beat: beat,
+                            isActive: isCurrentlyActive,
+                            row: row,
+                            isBeamed: isBeamed
+                        )
+                        .position(
+                            x: cachedPosition.x,
+                            y: cachedPosition.y
+                        )
+                    }
                 }
             }
         }

--- a/Virgo/views/subviews/GameplaySheetMusicView.swift
+++ b/Virgo/views/subviews/GameplaySheetMusicView.swift
@@ -19,7 +19,13 @@ extension GameplayView {
             ScrollView([.horizontal, .vertical], showsIndicators: false) {
                 ZStack(alignment: .topLeading) {
                     // Use cached static staff lines view - created only once
-                    if !usesNotationLayout, let staticView = viewModel.staticStaffLinesView {
+                    if usesNotationLayout {
+                        if let cachedNotationView = viewModel.notationStaffLinesView {
+                            cachedNotationView
+                        } else {
+                            staffLinesView(measurePositions: measurePositions, width: contentWidth)
+                        }
+                    } else if let staticView = viewModel.staticStaffLinesView {
                         staticView
                     } else {
                         // Fallback: render dynamic staff lines when static view is not available
@@ -278,16 +284,6 @@ extension GameplayView {
     }
 
     func notationContentWidth(for notationLayout: NotationLayout) -> CGFloat {
-        let primitiveMaxX = [
-            notationLayout.noteHeads.map(\.position.x),
-            notationLayout.measureBars.map(\.x),
-            notationLayout.beams.flatMap { [$0.start.x, $0.end.x] },
-            notationLayout.ledgerLines.flatMap { [$0.start.x, $0.end.x] },
-            notationLayout.stems.flatMap { [$0.start.x, $0.end.x] }
-        ]
-        .flatMap { $0 }
-        .max() ?? GameplayLayout.maxRowWidth
-
-        return max(GameplayLayout.maxRowWidth, primitiveMaxX + GameplayLayout.uniformSpacing)
+        notationLayout.contentWidth
     }
 }

--- a/Virgo/views/subviews/GameplaySheetMusicView.swift
+++ b/Virgo/views/subviews/GameplaySheetMusicView.swift
@@ -105,7 +105,7 @@ extension GameplayView {
         let notationMeasureBars = viewModel.cachedNotationLayout.measureBars
         let usesNotationLayout = usesNotationLayout(viewModel: viewModel)
 
-        ZStack {
+        return ZStack {
             if usesNotationLayout {
                 ForEach(notationMeasureBars) { measureBar in
                     NotationMeasureBarView(measureBar: measureBar)

--- a/Virgo/views/subviews/GameplaySheetMusicView.swift
+++ b/Virgo/views/subviews/GameplaySheetMusicView.swift
@@ -11,30 +11,36 @@ extension GameplayView {
     @ViewBuilder
     func sheetMusicView(geometry: GeometryProxy) -> some View {
         if let viewModel = viewModel {
-            let totalHeight = GameplayLayout.totalHeight(for: viewModel.cachedMeasurePositions)
+            let usesNotationLayout = usesNotationLayout(viewModel: viewModel)
+            let measurePositions = sheetMeasurePositions(viewModel: viewModel)
+            let contentWidth = sheetContentWidth(viewModel: viewModel)
+            let contentHeight = sheetContentHeight(viewModel: viewModel)
 
             ScrollView([.horizontal, .vertical], showsIndicators: false) {
                 ZStack(alignment: .topLeading) {
                     // Use cached static staff lines view - created only once
-                    if let staticView = viewModel.staticStaffLinesView {
+                    if !usesNotationLayout, let staticView = viewModel.staticStaffLinesView {
                         staticView
                     } else {
                         // Fallback: render dynamic staff lines when static view is not available
-                        staffLinesView(measurePositions: viewModel.cachedMeasurePositions)
+                        staffLinesView(measurePositions: measurePositions, width: contentWidth)
                     }
 
                     // Dynamic content
                     ZStack(alignment: .topLeading) {
-                        barLinesView(measurePositions: viewModel.cachedMeasurePositions, viewModel: viewModel)
+                        barLinesView(measurePositions: measurePositions, viewModel: viewModel)
 
-                        clefsAndTimeSignaturesView(measurePositions: viewModel.cachedMeasurePositions, viewModel: viewModel)
+                        clefsAndTimeSignaturesView(measurePositions: measurePositions, viewModel: viewModel)
 
-                        drumNotationView(measurePositions: viewModel.cachedMeasurePositions, viewModel: viewModel)
+                        drumNotationView(measurePositions: measurePositions, viewModel: viewModel)
 
-                        timeBasedBeatProgressionBars(measurePositions: viewModel.cachedMeasurePositions, viewModel: viewModel)
+                        timeBasedBeatProgressionBars(
+                            measurePositions: viewModel.cachedMeasurePositions,
+                            viewModel: viewModel
+                        )
                     }
                 }
-                .frame(width: GameplayLayout.maxRowWidth, height: totalHeight)
+                .frame(width: contentWidth, height: contentHeight)
             }
             .background(Color.gray.opacity(0.1))
         } else {
@@ -43,7 +49,10 @@ extension GameplayView {
         }
     }
 
-    func staffLinesView(measurePositions: [GameplayLayout.MeasurePosition]) -> some View {
+    func staffLinesView(
+        measurePositions: [GameplayLayout.MeasurePosition],
+        width: CGFloat = GameplayLayout.maxRowWidth
+    ) -> some View {
         let rows = Set(measurePositions.map { $0.row })
 
         return ZStack {
@@ -51,10 +60,10 @@ extension GameplayView {
                 ZStack {
                     ForEach(0..<GameplayLayout.staffLineCount, id: \.self) { lineIndex in
                         Rectangle()
-                            .frame(width: GameplayLayout.maxRowWidth, height: 1) // Full width to cover clef area
+                            .frame(width: width, height: 1) // Full width to cover clef area
                             .foregroundColor(.gray.opacity(0.5))
                             .position(
-                                x: GameplayLayout.maxRowWidth / 2, // Center in full width
+                                x: width / 2, // Center in full width
                                 y: GameplayLayout.StaffLinePosition(rawValue: lineIndex)?.absoluteY(for: row) ?? 0
                             )
                     }
@@ -64,7 +73,10 @@ extension GameplayView {
         }
     }
 
-    func clefsAndTimeSignaturesView(measurePositions: [GameplayLayout.MeasurePosition], viewModel: GameplayViewModel) -> some View {
+    func clefsAndTimeSignaturesView(
+        measurePositions: [GameplayLayout.MeasurePosition],
+        viewModel: GameplayViewModel
+    ) -> some View {
         let rows = Set(measurePositions.map { $0.row })
 
         return ZStack {
@@ -94,9 +106,10 @@ extension GameplayView {
 
     func barLinesView(measurePositions: [GameplayLayout.MeasurePosition], viewModel: GameplayViewModel) -> some View {
         let notationMeasureBars = viewModel.cachedNotationLayout.measureBars
+        let usesNotationLayout = usesNotationLayout(viewModel: viewModel)
 
         ZStack {
-            if !notationMeasureBars.isEmpty {
+            if usesNotationLayout {
                 ForEach(notationMeasureBars) { measureBar in
                     NotationMeasureBarView(measureBar: measureBar)
                 }
@@ -104,7 +117,7 @@ extension GameplayView {
                 // Regular bar lines
                 ForEach(measurePositions, id: \.measureIndex) { position in
                     // Use the same Y positioning as staff lines - center of the staff for this row
-                    let centerY = GameplayLayout.StaffLinePosition.line3.absoluteY(for: position.row) // Middle staff line
+                    let centerY = GameplayLayout.StaffLinePosition.line3.absoluteY(for: position.row)
 
                     Rectangle()
                         .frame(width: GameplayLayout.barLineWidth, height: GameplayLayout.staffHeight)
@@ -117,9 +130,11 @@ extension GameplayView {
 
                 // Double bar line at the very end
                 if let lastPosition = measurePositions.last {
-                    let measureWidth = GameplayLayout.measureWidth(for: viewModel.track?.timeSignature ?? TimeSignature.fourFour)
+                    let measureWidth = GameplayLayout.measureWidth(
+                        for: viewModel.track?.timeSignature ?? TimeSignature.fourFour
+                    )
                     let endX = lastPosition.xOffset + measureWidth
-                    let centerY = GameplayLayout.StaffLinePosition.line3.absoluteY(for: lastPosition.row) // Middle staff line
+                    let centerY = GameplayLayout.StaffLinePosition.line3.absoluteY(for: lastPosition.row)
 
                     HStack(spacing: GameplayLayout.doubleBarLineSpacing) {
                         Rectangle()
@@ -138,7 +153,10 @@ extension GameplayView {
         }
     }
 
-    func drumNotationView(measurePositions: [GameplayLayout.MeasurePosition], viewModel: GameplayViewModel) -> some View {
+    func drumNotationView(
+        measurePositions: [GameplayLayout.MeasurePosition],
+        viewModel: GameplayViewModel
+    ) -> some View {
         let notationLayout = viewModel.cachedNotationLayout
         let activeNotationNoteHeadIDs = viewModel.activeNotationNoteHeadIDs
 
@@ -204,7 +222,10 @@ extension GameplayView {
         }
     }
 
-    func timeBasedBeatProgressionBars(measurePositions: [GameplayLayout.MeasurePosition], viewModel: GameplayViewModel) -> some View {
+    func timeBasedBeatProgressionBars(
+        measurePositions: [GameplayLayout.MeasurePosition],
+        viewModel: GameplayViewModel
+    ) -> some View {
         Group {
             // PERFORMANCE FIX: Use pre-cached purple bar position instead of expensive calculation
             if let position = viewModel.purpleBarPosition {
@@ -215,5 +236,57 @@ extension GameplayView {
                     .position(x: position.x, y: position.y)
             }
         }
+    }
+
+    func usesNotationLayout(viewModel: GameplayViewModel) -> Bool {
+        !viewModel.cachedNotationLayout.noteHeads.isEmpty
+    }
+
+    func sheetMeasurePositions(viewModel: GameplayViewModel) -> [GameplayLayout.MeasurePosition] {
+        guard usesNotationLayout(viewModel: viewModel) else {
+            return viewModel.cachedMeasurePositions
+        }
+
+        return measurePositions(from: viewModel.cachedNotationLayout)
+    }
+
+    func sheetContentHeight(viewModel: GameplayViewModel) -> CGFloat {
+        guard usesNotationLayout(viewModel: viewModel) else {
+            return GameplayLayout.totalHeight(for: viewModel.cachedMeasurePositions)
+        }
+
+        return viewModel.cachedNotationLayout.totalHeight
+    }
+
+    func sheetContentWidth(viewModel: GameplayViewModel) -> CGFloat {
+        guard usesNotationLayout(viewModel: viewModel) else {
+            return GameplayLayout.maxRowWidth
+        }
+
+        return notationContentWidth(for: viewModel.cachedNotationLayout)
+    }
+
+    func measurePositions(from notationLayout: NotationLayout) -> [GameplayLayout.MeasurePosition] {
+        notationLayout.measures.map { measure in
+            GameplayLayout.MeasurePosition(
+                row: measure.row,
+                xOffset: measure.xOffset,
+                measureIndex: measure.measureIndex
+            )
+        }
+    }
+
+    func notationContentWidth(for notationLayout: NotationLayout) -> CGFloat {
+        let primitiveMaxX = [
+            notationLayout.noteHeads.map(\.position.x),
+            notationLayout.measureBars.map(\.x),
+            notationLayout.beams.flatMap { [$0.start.x, $0.end.x] },
+            notationLayout.ledgerLines.flatMap { [$0.start.x, $0.end.x] },
+            notationLayout.stems.flatMap { [$0.start.x, $0.end.x] }
+        ]
+        .flatMap { $0 }
+        .max() ?? GameplayLayout.maxRowWidth
+
+        return max(GameplayLayout.maxRowWidth, primitiveMaxX + GameplayLayout.uniformSpacing)
     }
 }

--- a/VirgoTests/GameplayRenderCoverageTests.swift
+++ b/VirgoTests/GameplayRenderCoverageTests.swift
@@ -125,6 +125,21 @@ struct GameplayRenderCoverageTests {
         }
     }
 
+    @Test("StaffLinesBackgroundView accepts custom width parameter")
+    func testStaffLinesBackgroundView_customWidth() async throws {
+        try await TestSetup.withTestSetup {
+            let positions = GameplayLayout.calculateMeasurePositions(
+                totalMeasures: 1, timeSignature: .fourFour
+            )
+            let customWidth: CGFloat = 500
+            let view = StaffLinesBackgroundView(measurePositions: positions, width: customWidth)
+            SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 1280, height: 900)
+            )
+        }
+    }
+
     // MARK: - BeamGroupView
 
     /// Renders a `BeamGroupView` whose `beats` are eighth notes in the same measure.

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -159,6 +159,89 @@ struct GameplayViewModelTests {
         #expect(viewModel.cachedNotationNoteHeadIDsByBeatID[beat.id]?.count == 2)
     }
 
+    @Test func testNotationActiveLookupFindsAllNoteheadsAtCurrentTime() async throws {
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
+        )
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .bass, measureNumber: 1, measureOffset: 0.0)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+
+        viewModel.updateActiveNotation(forTimePosition: 0)
+
+        #expect(viewModel.activeNotationNoteHeadIDs.count == 2)
+    }
+
+    @Test func testNotationActiveLookupUsesExactMicrosecondTimePositions() async throws {
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
+        )
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .bass, measureNumber: 1, measureOffset: 0.0004)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+
+        viewModel.updateActiveNotation(forTimePosition: 0)
+        let firstPositionIDs = viewModel.activeNotationNoteHeadIDs
+        viewModel.updateActiveNotation(forTimePosition: 0.0004)
+        let secondPositionIDs = viewModel.activeNotationNoteHeadIDs
+
+        #expect(firstPositionIDs.count == 1)
+        #expect(secondPositionIDs.count == 1)
+        #expect(firstPositionIDs.isDisjoint(with: secondPositionIDs))
+    }
+
+    @Test func testUpdateActiveBeatUsesBeatBridgeForNearIdenticalNotationHeadIDs() async throws {
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
+        )
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .bass, measureNumber: 1, measureOffset: 0.0004)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+        let beat = try #require(viewModel.cachedDrumBeats.first)
+        viewModel.isPlaying = true
+
+        viewModel.updateActiveBeat(forTimePosition: 0)
+
+        #expect(viewModel.activeBeatId == beat.id)
+        #expect(viewModel.activeNotationNoteHeadIDs.count == 2)
+    }
+
+    @Test func testPausePlaybackClearsActiveNotationNoteheads() async throws {
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+        viewModel.updateActiveNotation(forTimePosition: 0)
+        viewModel.isPlaying = true
+
+        viewModel.pausePlayback()
+
+        #expect(viewModel.activeNotationNoteHeadIDs.isEmpty)
+    }
+
     @Test func testNotationLayoutCachesClearWithoutTrack() async throws {
         let chart = Chart(difficulty: .easy)
         let metronome = createTestMetronome()
@@ -179,6 +262,7 @@ struct GameplayViewModelTests {
         #expect(NotationLayout.empty.ledgerLines.isEmpty)
         #expect(NotationLayout.empty.measureBars.isEmpty)
         #expect(NotationLayout.empty.beatLookup.isEmpty)
+        #expect(NotationLayout.empty.noteHeadIDsByTimePosition.isEmpty)
         #expect(NotationLayout.empty.totalHeight == 0)
     }
 
@@ -1461,6 +1545,37 @@ struct GameplayViewModelTests {
         let position = viewModel.calculatePurpleBarPosition()
 
         #expect(position == nil)
+    }
+
+    @Test func testNotationPurpleBarPositionUsesRenderedMeasureWidth() async throws {
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
+        )
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .bass, measureNumber: 1, measureOffset: 0.01)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+
+        let measure = try #require(viewModel.cachedNotationLayout.measures.first)
+        let position = try #require(
+            viewModel.calculateNotationPurpleBarPosition(measureIndex: 0, beatWithinMeasure: 1.0)
+        )
+        let beatGap = (measure.width - GameplayLayout.barLineWidth - GameplayLayout.uniformSpacing) / 4
+        let expectedX = measure.xOffset + GameplayLayout.barLineWidth + GameplayLayout.uniformSpacing + beatGap
+        let legacyPosition = try #require(viewModel.measurePositionMap[0])
+        let legacyX = GameplayLayout.preciseNoteXPosition(
+            measurePosition: legacyPosition,
+            beatPosition: 1.0,
+            timeSignature: .fourFour
+        )
+
+        #expect(abs(position.x - Double(expectedX)) < 0.001)
+        #expect(abs(position.x - Double(legacyX)) > 0.001)
     }
 
     // MARK: - Input Manager Tests

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -1656,6 +1656,36 @@ struct GameplayViewModelTests {
         #expect(viewModel.calculatePurpleBarPosition(elapsedTime: 2.0) != nil)
     }
 
+    @Test func testPurpleBarUsesFractionalBeatForSubBeatPosition() async throws {
+        // At BPM 120, 4/4 time: secondsPerBeat = 0.5
+        // elapsedTime = 0.125s → totalBeatsElapsed = 0.25
+        // This is a 16th note (offset 0.0625 in 4/4). The purple bar should be at
+        // beatWithinMeasure = 0.25 (quarter of a beat), NOT at beat 0.
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0.0625)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+        viewModel.isPlaying = true
+
+        let position = try #require(
+            viewModel.calculatePurpleBarPosition(elapsedTime: 0.125)
+        )
+        let measure = try #require(viewModel.cachedNotationLayout.measures.first)
+        let beatGap = (measure.width - GameplayLayout.barLineWidth - GameplayLayout.uniformSpacing) / 4
+        // beatWithinMeasure should be 0.25, so x = base + 0.25 * beatGap
+        let expectedX = measure.xOffset
+            + GameplayLayout.barLineWidth
+            + GameplayLayout.uniformSpacing
+            + 0.25 * beatGap
+
+        #expect(abs(position.x - Double(expectedX)) < 0.5)
+    }
+
     // MARK: - Input Manager Tests
 
     @Test func testInputManagerConfiguration() async throws {

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -2752,6 +2752,56 @@ struct GameplayViewModelTests {
         let sixteenthBeat = viewModel.cachedDrumBeats.first { $0.timePosition == 0.0625 }
         #expect(viewModel.activeBeatId == sixteenthBeat?.id)
     }
+
+    @Test("beat at playhead is preferred over future look-ahead candidate")
+    func beatAtPlayheadPreferredOverFutureLookAhead() async throws {
+        // Regression test: when two beats are within the 0.05 look-ahead window,
+        // the beat at the playhead must be selected, not the future one.
+        // Place an eighth at offset 0.25 (timePosition 0.25) and a thirty-second
+        // at offset 0.28125 (timePosition 0.28125).  The 0.03125 gap is < 0.05.
+        // At playhead 0.25, the eighth should win — not the thirty-second.
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0.25)
+        )
+        chart.notes.append(
+            Note(interval: .thirtysecond, noteType: .snare, measureNumber: 1, measureOffset: 0.28125)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+        viewModel.isPlaying = true
+
+        viewModel.updateActiveBeat(forTimePosition: 0.25)
+        let eighthBeat = viewModel.cachedDrumBeats.first { $0.timePosition == 0.25 }
+        let thirtysecondBeat = viewModel.cachedDrumBeats.first { $0.timePosition == 0.28125 }
+        #expect(viewModel.activeBeatId == eighthBeat?.id)
+        #expect(viewModel.activeBeatId != thirtysecondBeat?.id)
+    }
+
+    @Test("future beat within look-ahead is selected when no beat at playhead")
+    func futureBeatWithinLookAheadSelectedWhenNoBeatAtPlayhead() async throws {
+        // Ensures look-ahead still works when no beat is at/before the playhead.
+        // Place a thirty-second at offset 0.28125 (timePosition 0.28125).
+        // At playhead 0.25, there is no beat at/before 0.25, but 0.28125 is
+        // within the 0.05 look-ahead window, so it should be selected.
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .thirtysecond, noteType: .snare, measureNumber: 1, measureOffset: 0.28125)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+        viewModel.isPlaying = true
+
+        viewModel.updateActiveBeat(forTimePosition: 0.25)
+        let futureBeat = viewModel.cachedDrumBeats.first { $0.timePosition == 0.28125 }
+        #expect(viewModel.activeBeatId == futureBeat?.id)
+    }
 }
 
 @MainActor

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -440,6 +440,41 @@ struct GameplayViewModelTests {
         viewModel.cleanup()
     }
 
+    @Test("purple bar position updates on every tick, not only on discrete beat boundaries")
+    func testPurpleBarUpdatesOnEveryTick() async throws {
+        let chart = createTestChart(noteCount: 8)
+        let metronome = createTestMetronome()
+
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+        viewModel.isPlaying = true
+
+        // Call updatePurpleBarPosition with two different elapsed times
+        // that fall within the same beat (same discreteTotalBeats value).
+        // At 120 BPM: secondsPerBeat = 0.5. Beat 0 covers 0..<0.5s, beat 1 covers 0.5..<1.0s.
+        viewModel.updatePurpleBarPosition(elapsedTime: 0.1)
+        let positionAt01 = viewModel.purpleBarPosition
+
+        viewModel.updatePurpleBarPosition(elapsedTime: 0.3)
+        let positionAt03 = viewModel.purpleBarPosition
+
+        // Both times fall within beat 0 (discreteTotalBeats == 0), so discrete-beat-gated
+        // logic would NOT fire for the second call. If the purple bar only updated on
+        // discrete beat boundaries, both positions would be identical. They must differ
+        // because the purple bar should track continuous elapsed time.
+        #expect(positionAt01 != nil, "Purple bar must produce a position at elapsedTime 0.1s")
+        #expect(positionAt03 != nil, "Purple bar must produce a position at elapsedTime 0.3s")
+        // Purple bar must advance between ticks within the same beat —
+        // position at 0.1s should differ from 0.3s
+        if let pos1 = positionAt01, let pos3 = positionAt03 {
+            #expect(abs(pos1.x - pos3.x) > 0.0001 || abs(pos1.y - pos3.y) > 0.0001,
+                   "Purple bar must advance between sub-beat ticks (0.1s vs 0.3s)")
+        }
+
+        viewModel.cleanup()
+    }
+
     @Test func testRemainingBGMOffsetAccountsForPausedElapsedTime() async throws {
         let chart = createTestChart(noteCount: 8)
         let metronome = createTestMetronome()

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -2623,6 +2623,106 @@ struct GameplayViewModelTests {
 
         viewModel.cleanup()
     }
+
+    // MARK: - Off-beat Note Highlighting Tests
+
+    @Test("eighth note at sub-beat offset becomes active when playhead passes it")
+    func eighthNoteAtSubBeatOffsetBecomesActive() async throws {
+        // In 4/4, an eighth at offset 0.125 has timePosition 0.125.
+        // The metronome fires at quarter-note positions (0.0, 0.25, ...).
+        // When playhead reaches 0.25, the eighth at 0.125 should be
+        // highlighted via look-behind matching.
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0.125)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+        viewModel.isPlaying = true
+
+        // At quarter-beat 1 (timePosition 0.25), the eighth at 0.125 should be found
+        viewModel.updateActiveBeat(forTimePosition: 0.25)
+
+        let eighthBeat = try #require(viewModel.cachedDrumBeats.first)
+        #expect(viewModel.activeBeatId == eighthBeat.id)
+    }
+
+    @Test("sixteenth note at sub-beat offset becomes active when playhead passes it")
+    func sixteenthNoteAtSubBeatOffsetBecomesActive() async throws {
+        // A sixteenth at offset 0.0625 has timePosition 0.0625.
+        // When playhead reaches 0.25, it should be highlighted via look-behind.
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0.0625)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+        viewModel.isPlaying = true
+
+        viewModel.updateActiveBeat(forTimePosition: 0.25)
+
+        let sixteenthBeat = try #require(viewModel.cachedDrumBeats.first)
+        #expect(viewModel.activeBeatId == sixteenthBeat.id)
+    }
+
+    @Test("beat too far behind playhead is not highlighted")
+    func beatTooFarBehindPlayheadIsNotHighlighted() async throws {
+        // Place a note in measure 1 at offset 0.0, then advance the playhead
+        // past one full quarter-beat beyond it — the note should no longer be
+        // active once the look-behind window has expired.
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+        viewModel.isPlaying = true
+
+        // At timePosition 0.0 → the quarter note should be active
+        viewModel.updateActiveBeat(forTimePosition: 0.0)
+        let quarterBeat = try #require(viewModel.cachedDrumBeats.first)
+        #expect(viewModel.activeBeatId == quarterBeat.id)
+
+        // At timePosition 0.5 (two quarter-beats ahead) → beyond maxLookBehind
+        viewModel.updateActiveBeat(forTimePosition: 0.5)
+        #expect(viewModel.activeBeatId == nil)
+    }
+
+    @Test("closest beat to playhead is selected when multiple beats are in range")
+    func closestBeatToPlayheadIsSelectedWhenMultipleBeatsInRange() async throws {
+        // Place a quarter at 0.0 and a sixteenth at 0.0625.
+        // At playhead 0.25, the sixteenth (0.0625) is closer to the quarter at 0.25
+        // that would be found via look-behind. Actually the sixteenth IS the last
+        // beat at or before 0.25 + lookAhead, so it should be selected.
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
+        )
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0.0625)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+        viewModel.isPlaying = true
+
+        // At playhead 0.1, the last beat at or before 0.1 + 0.05 = 0.15
+        // is the sixteenth at 0.0625 (not the quarter at 0.0)
+        viewModel.updateActiveBeat(forTimePosition: 0.1)
+        let sixteenthBeat = viewModel.cachedDrumBeats.first { $0.timePosition == 0.0625 }
+        #expect(viewModel.activeBeatId == sixteenthBeat?.id)
+    }
 }
 
 @MainActor

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -2993,6 +2993,47 @@ struct GameplayViewModelTests {
         let subBeatNote = viewModel.cachedDrumBeats.first { abs($0.timePosition - 0.0625) < 0.001 }
         #expect(viewModel.activeBeatId == subBeatNote?.id)
     }
+
+    // MARK: - activeBeatId.didSet Gating Tests
+
+    @Test("Setting activeBeatId to the same value preserves activeNotationNoteHeadIDs")
+    func testActiveBeatIdSameValueDoesNotClearNoteHeads() async throws {
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
+        )
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .bass, measureNumber: 1, measureOffset: 0.0)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+
+        // First call to updateActiveNotation populates activeNotationNoteHeadIDs
+        viewModel.updateActiveNotation(forTimePosition: 0)
+        let firstIDs = viewModel.activeNotationNoteHeadIDs
+        #expect(!firstIDs.isEmpty,
+                "Expected activeNotationNoteHeadIDs to be populated for simultaneous notes at offset 0")
+
+        // Setting activeBeatId to a different value clears note heads (old behavior)
+        viewModel.activeBeatId = 9999
+        #expect(viewModel.activeNotationNoteHeadIDs.isEmpty,
+                "Setting activeBeatId to a different value should clear activeNotationNoteHeadIDs")
+
+        // Re-populate via updateActiveNotation
+        viewModel.activeBeatId = nil
+        viewModel.updateActiveNotation(forTimePosition: 0)
+        let repopulatedIDs = viewModel.activeNotationNoteHeadIDs
+        #expect(!repopulatedIDs.isEmpty)
+
+        // Setting activeBeatId to the SAME value should NOT clear activeNotationNoteHeadIDs
+        let currentBeatId = viewModel.activeBeatId
+        viewModel.activeBeatId = currentBeatId
+        #expect(!viewModel.activeNotationNoteHeadIDs.isEmpty,
+                "Setting activeBeatId to the same value should not clear activeNotationNoteHeadIDs")
+    }
 }
 
 @MainActor

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -2802,6 +2802,33 @@ struct GameplayViewModelTests {
         let futureBeat = viewModel.cachedDrumBeats.first { $0.timePosition == 0.28125 }
         #expect(viewModel.activeBeatId == futureBeat?.id)
     }
+
+    @Test("continuous visual tick updates active beat at sub-beat positions between quarter boundaries")
+    func continuousVisualTickUpdatesActiveBeatBetweenQuarters() async throws {
+        // Regression: before the continuous tick was added, updateActiveBeat was
+        // only called inside the discreteTotalBeats gate, so sub-beat notes were
+        // never highlighted at the correct moment.  Now updateContinuousVisualsTick
+        // calls updateActiveBeat on every tick regardless of the beat gate.
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
+        )
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .bass, measureNumber: 1, measureOffset: 0.0625)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+        viewModel.isPlaying = true
+
+        // At timePosition 0.0625 (sub-beat, between quarter boundaries),
+        // the sixteenth at 0.0625 should be active — not just the one at 0.0.
+        viewModel.updateActiveBeat(forTimePosition: 0.0625)
+        let subBeatNote = viewModel.cachedDrumBeats.first { abs($0.timePosition - 0.0625) < 0.001 }
+        #expect(viewModel.activeBeatId == subBeatNote?.id)
+    }
 }
 
 @MainActor

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -259,6 +259,7 @@ struct GameplayViewModelTests {
         #expect(NotationLayout.empty.noteHeads.isEmpty)
         #expect(NotationLayout.empty.stems.isEmpty)
         #expect(NotationLayout.empty.beams.isEmpty)
+        #expect(NotationLayout.empty.flags.isEmpty)
         #expect(NotationLayout.empty.ledgerLines.isEmpty)
         #expect(NotationLayout.empty.measureBars.isEmpty)
         #expect(NotationLayout.empty.beatLookup.isEmpty)

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -150,10 +150,25 @@ struct GameplayViewModelTests {
         await viewModel.loadChartData()
         viewModel.setupGameplay(loadPersistedSpeed: false)
 
+        let beat = try #require(viewModel.cachedDrumBeats.first)
+
+        #expect(viewModel.cachedDrumBeats.count == 1)
         #expect(viewModel.cachedNotationLayout.noteHeads.count == 2)
         #expect(!viewModel.cachedNotationLayout.stems.isEmpty)
-        #expect(!viewModel.cachedNotationBeatPositions.isEmpty)
-        #expect(viewModel.cachedNotationBeatPositions.count == viewModel.cachedNotationLayout.beatLookup.count)
+        #expect(viewModel.cachedNotationNoteHeadPositions.count == viewModel.cachedNotationLayout.noteHeads.count)
+        #expect(viewModel.cachedNotationNoteHeadIDsByBeatID[beat.id]?.count == 2)
+    }
+
+    @Test func testNotationLayoutCachesClearWithoutTrack() async throws {
+        let chart = Chart(difficulty: .easy)
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        viewModel.computeCachedLayoutData()
+
+        #expect(viewModel.cachedNotationLayout.noteHeads.isEmpty)
+        #expect(viewModel.cachedNotationNoteHeadPositions.isEmpty)
+        #expect(viewModel.cachedNotationNoteHeadIDsByBeatID.isEmpty)
     }
 
     @Test func testEmptyNotationLayoutHasNoRenderedContent() {

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -1635,7 +1635,10 @@ struct GameplayViewModelTests {
         #expect(abs(position.y - expectedPosition.y) < 0.001)
     }
 
-    @Test func testNotationPurpleBarPositionDoesNotFallbackToLegacyWhenMeasureMissing() async throws {
+    @Test func testNotationPurpleBarPositionClampsAtEndOfTrack() async throws {
+        // Creates a chart with one measure (measureIndex 0) at BPM 120 (4 beats per measure)
+        // At elapsedTime = 2.0 seconds: 2 * 120 / 60 = 4 beats, measureIndex = 4 / 4 = 1
+        // This is one past the last measure, so the position should clamp to the last measure
         let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
         chart.notes.append(
             Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
@@ -1647,8 +1650,10 @@ struct GameplayViewModelTests {
         viewModel.setupGameplay(loadPersistedSpeed: false)
         viewModel.isPlaying = true
 
+        // calculateNotationPurpleBarPosition directly returns nil when measure doesn't exist
         #expect(viewModel.calculateNotationPurpleBarPosition(measureIndex: 1, beatWithinMeasure: 0.0) == nil)
-        #expect(viewModel.calculatePurpleBarPosition(elapsedTime: 2.0) == nil)
+        // But calculatePurpleBarPosition clamps to the last valid measure at track end
+        #expect(viewModel.calculatePurpleBarPosition(elapsedTime: 2.0) != nil)
     }
 
     // MARK: - Input Manager Tests

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -291,7 +291,7 @@ struct GameplayViewModelTests {
         #expect(NotationLayout.empty.flags.isEmpty)
         #expect(NotationLayout.empty.ledgerLines.isEmpty)
         #expect(NotationLayout.empty.measureBars.isEmpty)
-        #expect(NotationLayout.empty.beatLookup.isEmpty)
+        #expect(NotationLayout.empty.noteHeadPositionsByID.isEmpty)
         #expect(NotationLayout.empty.noteHeadIDsByTimePosition.isEmpty)
         #expect(NotationLayout.empty.totalHeight == 0)
     }

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -135,6 +135,38 @@ struct GameplayViewModelTests {
         #expect(viewModel.cachedTrackDuration > 0)
     }
 
+    @Test func testSetupGameplayCachesNotationLayout() async throws {
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
+        )
+        chart.notes.append(
+            Note(interval: .sixteenth, noteType: .bass, measureNumber: 1, measureOffset: 0.0)
+        )
+        let metronome = createTestMetronome()
+
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+
+        #expect(viewModel.cachedNotationLayout.noteHeads.count == 2)
+        #expect(!viewModel.cachedNotationLayout.stems.isEmpty)
+        #expect(!viewModel.cachedNotationBeatPositions.isEmpty)
+        #expect(viewModel.cachedNotationBeatPositions.count == viewModel.cachedNotationLayout.beatLookup.count)
+    }
+
+    @Test func testEmptyNotationLayoutHasNoRenderedContent() {
+        #expect(NotationLayout.empty.measures.isEmpty)
+        #expect(NotationLayout.empty.noteHeads.isEmpty)
+        #expect(NotationLayout.empty.stems.isEmpty)
+        #expect(NotationLayout.empty.beams.isEmpty)
+        #expect(NotationLayout.empty.ledgerLines.isEmpty)
+        #expect(NotationLayout.empty.measureBars.isEmpty)
+        #expect(NotationLayout.empty.beatLookup.isEmpty)
+        #expect(NotationLayout.empty.totalHeight == 0)
+    }
+
     @Test func testSetupGameplayWithoutLoadingData() async throws {
         let chart = createTestChart()
         let metronome = createTestMetronome()

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -1578,6 +1578,49 @@ struct GameplayViewModelTests {
         #expect(abs(position.x - Double(legacyX)) > 0.001)
     }
 
+    @Test func testPurpleBarPositionUsesResumedElapsedTime() async throws {
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
+        )
+        chart.notes.append(
+            Note(interval: .quarter, noteType: .bass, measureNumber: 2, measureOffset: 0.0)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+        viewModel.isPlaying = true
+        viewModel.pausedElapsedTime = 2.0
+
+        let position = try #require(
+            viewModel.calculatePurpleBarPosition(elapsedTime: viewModel.pausedElapsedTime)
+        )
+        let expectedPosition = try #require(
+            viewModel.calculateNotationPurpleBarPosition(measureIndex: 1, beatWithinMeasure: 0.0)
+        )
+
+        #expect(abs(position.x - expectedPosition.x) < 0.001)
+        #expect(abs(position.y - expectedPosition.y) < 0.001)
+    }
+
+    @Test func testNotationPurpleBarPositionDoesNotFallbackToLegacyWhenMeasureMissing() async throws {
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+        viewModel.isPlaying = true
+
+        #expect(viewModel.calculateNotationPurpleBarPosition(measureIndex: 1, beatWithinMeasure: 0.0) == nil)
+        #expect(viewModel.calculatePurpleBarPosition(elapsedTime: 2.0) == nil)
+    }
+
     // MARK: - Input Manager Tests
 
     @Test func testInputManagerConfiguration() async throws {

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -141,7 +141,7 @@ struct GameplayViewModelTests {
             Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
         )
         chart.notes.append(
-            Note(interval: .sixteenth, noteType: .bass, measureNumber: 1, measureOffset: 0.0)
+            Note(interval: .sixteenth, noteType: .bass, measureNumber: 1, measureOffset: 0.0004)
         )
         let metronome = createTestMetronome()
 

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -2937,6 +2937,35 @@ struct GameplayViewModelTests {
         #expect(viewModel.activeBeatId == futureBeat?.id)
     }
 
+    @Test("nearest upcoming beat is selected when multiple beats are in look-ahead window")
+    func nearestUpcomingBeatSelectedWhenMultipleBeatsInLookAhead() async throws {
+        // Regression: when multiple future notes fall inside the 0.05 look-ahead
+        // window after a rest, the look-ahead branch should select the NEAREST
+        // upcoming note, not the farthest one.
+        // Place two notes just ahead of playhead 0.25: at 0.26 and 0.29.
+        // Both are within look-ahead [0.25, 0.30], but 0.26 is nearer.
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .thirtysecond, noteType: .snare, measureNumber: 1, measureOffset: 0.26)
+        )
+        chart.notes.append(
+            Note(interval: .thirtysecond, noteType: .hiHat, measureNumber: 1, measureOffset: 0.29)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+        viewModel.isPlaying = true
+
+        viewModel.updateActiveBeat(forTimePosition: 0.25)
+        let nearerBeat = viewModel.cachedDrumBeats.first { abs($0.timePosition - 0.26) < 0.001 }
+        let fartherBeat = viewModel.cachedDrumBeats.first { abs($0.timePosition - 0.29) < 0.001 }
+        #expect(viewModel.activeBeatId == nearerBeat?.id,
+                "Should select the nearer upcoming beat (0.26), not the farther one (0.29)")
+        #expect(viewModel.activeBeatId != fartherBeat?.id)
+    }
+
     @Test("continuous visual tick updates active beat at sub-beat positions between quarter boundaries")
     func continuousVisualTickUpdatesActiveBeatBetweenQuarters() async throws {
         // Regression: before the continuous tick was added, updateActiveBeat was

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -255,6 +255,34 @@ struct GameplayViewModelTests {
         #expect(viewModel.notationStaffLinesView == nil)
     }
 
+    @Test func testNotesAtSameMusicalInstantEncodedDifferentlyShareBeatID() async throws {
+        // Note A: (measureNumber: 1, measureOffset: 1.0) → timePosition 1.0
+        // Note B: (measureNumber: 2, measureOffset: 0.0) → timePosition 1.0
+        // Both represent the same musical instant and should map to the same DrumBeat.
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 1.0)
+        )
+        chart.notes.append(
+            Note(interval: .quarter, noteType: .bass, measureNumber: 2, measureOffset: 0.0)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+
+        // Normalization merges both notes into a single DrumBeat
+        #expect(viewModel.cachedDrumBeats.count == 1,
+                "Notes at the same timePosition should be grouped into one DrumBeat")
+
+        let beat = try #require(viewModel.cachedDrumBeats.first)
+        // Both noteHeads should map to the same beatID via the bridge
+        let noteHeadIDs = viewModel.cachedNotationNoteHeadIDsByBeatID[beat.id]
+        #expect(noteHeadIDs?.count == 2,
+                "Both noteHeads should be linked to the single beatID")
+    }
+
     @Test func testNotationStaffLinesViewCachedWhenLayoutHasNotes() async throws {
         let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
         chart.notes.append(
@@ -1689,6 +1717,42 @@ struct GameplayViewModelTests {
         #expect(viewModel.calculateNotationPurpleBarPosition(measureIndex: 1, beatWithinMeasure: 0.0) == nil)
         // But calculatePurpleBarPosition clamps to the last valid measure at track end
         #expect(viewModel.calculatePurpleBarPosition(elapsedTime: 2.0) != nil)
+    }
+
+    @Test func testPurpleBarClampsToEndOfFinalMeasure() async throws {
+        // One measure, 4/4 at BPM 120. At elapsedTime = 2.0s:
+        // totalBeatsElapsed = 4.0, measureIndex = 1 (past last measure).
+        // The bar should be at the END of measure 0 (beatWithinMeasure = 4.0),
+        // NOT at the start (beatWithinMeasure = 0.0).
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+        viewModel.isPlaying = true
+
+        let clampedPosition = try #require(
+            viewModel.calculatePurpleBarPosition(elapsedTime: 2.0)
+        )
+        let measure = try #require(viewModel.cachedNotationLayout.measures.first)
+        // beatWithinMeasure clamped to 4.0 → bar at the rightmost edge
+        let drawableWidth = measure.width - GameplayLayout.barLineWidth - GameplayLayout.uniformSpacing
+        let expectedX = measure.xOffset
+            + GameplayLayout.barLineWidth
+            + GameplayLayout.uniformSpacing
+            + drawableWidth
+
+        #expect(abs(clampedPosition.x - Double(expectedX)) < 0.5)
+
+        // Verify it's NOT at the start of the measure (beat 0)
+        let startX = measure.xOffset
+            + GameplayLayout.barLineWidth
+            + GameplayLayout.uniformSpacing
+        #expect(abs(clampedPosition.x - Double(startX)) > 1.0)
     }
 
     @Test func testPurpleBarUsesFractionalBeatForSubBeatPosition() async throws {

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -252,6 +252,35 @@ struct GameplayViewModelTests {
         #expect(viewModel.cachedNotationLayout.noteHeads.isEmpty)
         #expect(viewModel.cachedNotationNoteHeadPositions.isEmpty)
         #expect(viewModel.cachedNotationNoteHeadIDsByBeatID.isEmpty)
+        #expect(viewModel.notationStaffLinesView == nil)
+    }
+
+    @Test func testNotationStaffLinesViewCachedWhenLayoutHasNotes() async throws {
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        chart.notes.append(
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0.0)
+        )
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+
+        #expect(viewModel.notationStaffLinesView != nil,
+               "notationStaffLinesView should be cached when layout has noteHeads")
+    }
+
+    @Test func testNotationStaffLinesViewNilWhenNoNotes() async throws {
+        let chart = Chart(difficulty: .medium, timeSignature: .fourFour)
+        let metronome = createTestMetronome()
+        let viewModel = GameplayViewModel(chart: chart, metronome: metronome)
+
+        await viewModel.loadChartData()
+        viewModel.setupGameplay(loadPersistedSpeed: false)
+
+        #expect(viewModel.cachedNotationLayout.noteHeads.isEmpty)
+        #expect(viewModel.notationStaffLinesView == nil,
+               "notationStaffLinesView should be nil when layout has no noteHeads")
     }
 
     @Test func testEmptyNotationLayoutHasNoRenderedContent() {

--- a/VirgoTests/GameplayViewModelTests.swift
+++ b/VirgoTests/GameplayViewModelTests.swift
@@ -2959,6 +2959,7 @@ struct GameplayViewModelTests {
 
         // At timePosition 0.0625 (sub-beat, between quarter boundaries),
         // the sixteenth at 0.0625 should be active — not just the one at 0.0.
+        // This simulates what happens inside updateContinuousVisualsTick.
         viewModel.updateActiveBeat(forTimePosition: 0.0625)
         let subBeatNote = viewModel.cachedDrumBeats.first { abs($0.timePosition - 0.0625) < 0.001 }
         #expect(viewModel.activeBeatId == subBeatNote?.id)

--- a/VirgoTests/InputManagerScheduledStartTests.swift
+++ b/VirgoTests/InputManagerScheduledStartTests.swift
@@ -428,7 +428,7 @@ struct InputManagerScheduledStartTests {
             MIDINoteEvent(sourceID: "source-1", channel: 9, note: 38, velocity: 100, hostTime: 0)
         )
 
-        #expect(result?.matchedNote != nil,
+        #expect(result != nil,
                 "MIDI event with hostTime == 0 should be accepted after effective audio start")
     }
 }

--- a/VirgoTests/InputManagerScheduledStartTests.swift
+++ b/VirgoTests/InputManagerScheduledStartTests.swift
@@ -430,5 +430,9 @@ struct InputManagerScheduledStartTests {
 
         #expect(result != nil,
                 "MIDI event with hostTime == 0 should be accepted after effective audio start")
+        #expect(result?.matchedNote != nil,
+                "Resumed MIDI hit should match the note at the resumed offset")
+        #expect(result?.timingAccuracy != .miss,
+                "Resumed MIDI hit at the exact note position should not be a miss")
     }
 }

--- a/VirgoTests/NotationLayoutDefensiveGuardTests.swift
+++ b/VirgoTests/NotationLayoutDefensiveGuardTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import Virgo
+
+@Suite("Notation Layout Defensive Guard Tests")
+struct NotationLayoutDefensiveGuardTests {
+
+    @Test("beamEndY returns nil for zero-span beam (startX == endX)")
+    func beamEndYReturnsNilForZeroSpanBeam() {
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(
+                notes: [
+                    Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0.0),
+                    Note(interval: .sixteenth, noteType: .bass, measureNumber: 1, measureOffset: 0.0001)
+                ],
+                timeSignature: .fourFour
+            )
+        )
+
+        for beam in layout.beams {
+            #expect(!beam.start.x.isNaN)
+            #expect(!beam.start.y.isNaN)
+            #expect(!beam.end.x.isNaN)
+            #expect(!beam.end.y.isNaN)
+        }
+        for stem in layout.stems {
+            #expect(!stem.start.x.isNaN)
+            #expect(!stem.start.y.isNaN)
+            #expect(!stem.end.x.isNaN)
+            #expect(!stem.end.y.isNaN)
+        }
+    }
+
+}

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -802,14 +802,16 @@ extension NotationLayoutEngineTests {
 
     @Test("contentWidth expands for notes beyond default row width")
     func contentWidthExpandsForDenseNotes() throws {
+        // Use sixteenth (0.0625) spacing for denser notes that exceed default row width.
         let notes = (0..<8).map { i in
-            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: Double(i) * 0.125)
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: Double(i) * 0.0625)
         }
         let layout = NotationLayoutEngine().layout(
             input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
         )
         let lastNoteHead = try #require(layout.noteHeads.max(by: { $0.position.x < $1.position.x }))
         #expect(layout.contentWidth > lastNoteHead.position.x)
+        // Width expands to accommodate dense notes - at minimum equals max row width.
         #expect(layout.contentWidth >= GameplayLayout.maxRowWidth)
     }
 

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -503,6 +503,93 @@ extension NotationLayoutEngineTests {
         #expect(beam.start.y > firstHead.position.y)
     }
 
+    // MARK: - Beamed Stem Rendering Tests
+
+    @Test("all notes in up-stem beam group have stems reaching beam level 0")
+    func allUpStemBeamedNotesReachBeam() throws {
+        let style = NotationLayoutStyle.gameplayDefault
+        let notes = (0..<4).map { index in
+            Note(
+                interval: .eighth,
+                noteType: .snare,
+                measureNumber: 1,
+                measureOffset: Double(index) / 8.0
+            )
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, style: style)
+        )
+        let beam = try #require(layout.beams.first { $0.level == 0 })
+
+        // Every note head in the beam must have a stem whose end Y matches the beam Y at that stem x.
+        for noteHeadID in beam.noteHeadIDs {
+            let noteHead = try #require(layout.noteHeads.first { $0.id == noteHeadID })
+            let stem = try #require(layout.stems.first { $0.noteHeadIDs.contains(noteHeadID) })
+            let stemX = noteHead.position.x + style.stemXInset  // up-stem inset
+            let t = (stemX - beam.start.x) / (beam.end.x - beam.start.x)
+            let expectedY = beam.start.y + t * (beam.end.y - beam.start.y)
+            #expect(abs(stem.end.y - expectedY) < 0.5,
+                    "Stem for noteHead \(noteHeadID) end.y \(stem.end.y) should reach beam Y \(expectedY)")
+        }
+    }
+
+    @Test("all notes in down-stem beam group have stems reaching beam")
+    func allDownStemBeamedNotesReachBeam() throws {
+        let style = NotationLayoutStyle.gameplayDefault
+        let notes = (0..<4).map { index in
+            Note(
+                interval: .eighth,
+                noteType: .crash,
+                measureNumber: 1,
+                measureOffset: Double(index) / 8.0
+            )
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, style: style)
+        )
+        let beam = try #require(layout.beams.first { $0.level == 0 })
+
+        for noteHeadID in beam.noteHeadIDs {
+            let noteHead = try #require(layout.noteHeads.first { $0.id == noteHeadID })
+            let stem = try #require(layout.stems.first { $0.noteHeadIDs.contains(noteHeadID) })
+            let stemX = noteHead.position.x - style.stemXInset  // down-stem inset
+            let t = (stemX - beam.start.x) / (beam.end.x - beam.start.x)
+            let expectedY = beam.start.y + t * (beam.end.y - beam.start.y)
+            #expect(abs(stem.end.y - expectedY) < 0.5,
+                    "Stem for noteHead \(noteHeadID) end.y \(stem.end.y) should reach beam Y \(expectedY)")
+        }
+    }
+
+    @Test("all sixteenth notes in beam group have stems reaching outermost beam level")
+    func allSixteenthBeamedNotesReachBothBeamLevels() throws {
+        let style = NotationLayoutStyle.gameplayDefault
+        let notes = (0..<4).map { index in
+            Note(
+                interval: .sixteenth,
+                noteType: .snare,
+                measureNumber: 1,
+                measureOffset: Double(index) / 16.0
+            )
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, style: style)
+        )
+
+        // Find the outermost beam (highest level = furthest from note heads for up-stems)
+        let outermostBeam = try #require(layout.beams.max { $0.level < $1.level })
+
+        // Every stem must reach the outermost beam at its stem x position
+        for noteHeadID in outermostBeam.noteHeadIDs {
+            let noteHead = try #require(layout.noteHeads.first { $0.id == noteHeadID })
+            let stem = try #require(layout.stems.first { $0.noteHeadIDs.contains(noteHeadID) })
+            let stemX = noteHead.position.x + style.stemXInset
+            let t = (stemX - outermostBeam.start.x) / (outermostBeam.end.x - outermostBeam.start.x)
+            let expectedY = outermostBeam.start.y + t * (outermostBeam.end.y - outermostBeam.start.y)
+            #expect(abs(stem.end.y - expectedY) < 0.5,
+                    "Stem for sixteenth noteHead \(noteHeadID) should reach outermost beam")
+        }
+    }
+
     // MARK: - Flag Rendering Tests
 
     @Test("isolated eighth note produces one flag")

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -1,0 +1,33 @@
+import Testing
+import SwiftUI
+@testable import Virgo
+
+@Suite("Notation Layout Engine Tests")
+struct NotationLayoutEngineTests {
+    @Test("default gameplay style preserves current low-density quarter spacing")
+    func defaultStylePreservesQuarterSpacing() {
+        let style = NotationLayoutStyle.gameplayDefault
+
+        #expect(style.minimumNoteColumnGap == 28)
+        #expect(style.minimumQuarterBeatGap == GameplayLayout.uniformSpacing)
+        #expect(style.noteHeadWidth == GameplayLayout.beatColumnWidth)
+    }
+
+    @Test("drum types map to gameplay voices")
+    func drumTypesMapToGameplayVoices() {
+        #expect(NotationVoice.voice(for: .kick) == .lower)
+        #expect(NotationVoice.voice(for: .hiHatPedal) == .lower)
+        #expect(NotationVoice.voice(for: .snare) == .upper)
+        #expect(NotationVoice.voice(for: .crash) == .upper)
+    }
+
+    @Test("layout input accepts notes and time signature")
+    func layoutInputAcceptsNotesAndTimeSignature() {
+        let note = Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0)
+        let input = NotationLayoutInput(notes: [note], timeSignature: .fourFour)
+
+        #expect(input.notes.count == 1)
+        #expect(input.timeSignature.beatsPerMeasure == 4)
+        #expect(input.style.minimumNoteColumnGap == 28)
+    }
+}

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -622,6 +622,49 @@ extension NotationLayoutEngineTests {
         #expect(finalBars.first?.isFinal == true)
     }
 
+    @Test("internal barline aligns with next same-row measure's xOffset")
+    func internalBarlineAlignsWithNextSameRowMeasureXOffset() throws {
+        let notes = (0..<8).map { index in
+            Note(
+                interval: .quarter,
+                noteType: .snare,
+                measureNumber: 1,
+                measureOffset: Double(index % 4) / 4.0
+            )
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, minimumMeasureCount: 3)
+        )
+
+        let sameRowMeasures = layout.measures.filter { $0.row == 0 }
+        let sameRowBars = layout.measureBars.filter { $0.row == 0 }
+        guard sameRowMeasures.count >= 2 else {
+            Issue.record("Expected at least 2 measures on row 0")
+            return
+        }
+
+        // For each pair of consecutive same-row measures, the end barline of the
+        // earlier measure must sit exactly at the later measure's xOffset — not
+        // at the earlier measure's right edge, which would leave a measureSpacing
+        // gap between the drawn bar and the next measure.
+        for index in 0..<(sameRowMeasures.count - 1) {
+            let current = sameRowMeasures[index]
+            let next = sameRowMeasures[index + 1]
+            let endBar = try #require(
+                sameRowBars.first { $0.id == "bar_\(current.measureIndex)_end" }
+            )
+
+            #expect(abs(endBar.x - next.xOffset) < 0.001)
+        }
+
+        // The last measure's end barline should remain at its right edge
+        let lastMeasure = sameRowMeasures[sameRowMeasures.count - 1]
+        let lastEndBar = try #require(
+            sameRowBars.first { $0.id == "bar_\(lastMeasure.measureIndex)_end" }
+        )
+        #expect(abs(lastEndBar.x - (lastMeasure.xOffset + lastMeasure.width)) < 0.001)
+    }
+
     @Test("measure wrapping to new row gets separate start barline")
     func measureWrappingToNewRowGetsSeparateStartBarline() {
         // Create enough notes/measures to force a row wrap

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -71,6 +71,44 @@ struct NotationLayoutEngineTests {
         #expect(abs((sortedX[1] - sortedX[0]) - GameplayLayout.uniformSpacing) < 0.001)
     }
 
+    @Test("sparse quarter notes preserve legacy measure width and first column")
+    func sparseQuarterNotesPreserveLegacyMeasureWidthAndFirstColumn() {
+        let notes = (0..<4).map { index in
+            Note(
+                interval: .quarter,
+                noteType: .snare,
+                measureNumber: 1,
+                measureOffset: Double(index) / 4.0
+            )
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+        let measure = layout.measures.first
+        let firstX = layout.noteHeads.map(\.position.x).min() ?? 0
+        let expectedFirstX = (measure?.xOffset ?? 0)
+            + GameplayLayout.barLineWidth
+            + GameplayLayout.uniformSpacing
+
+        #expect(measure?.width == GameplayLayout.measureWidth(for: .fourFour))
+        #expect(abs(firstX - expectedFirstX) < 0.001)
+    }
+
+    @Test("near identical simultaneous offsets do not expand simple measure")
+    func nearIdenticalSimultaneousOffsetsDoNotExpandSimpleMeasure() {
+        let notes = [
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0.0),
+            Note(interval: .quarter, noteType: .bass, measureNumber: 1, measureOffset: 0.0004)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+        let uniqueX = Array(Set(layout.noteHeads.map(\.position.x))).sorted()
+
+        #expect(layout.measures.first?.width == GameplayLayout.measureWidth(for: .fourFour))
+        #expect(uniqueX.count == 1)
+    }
+
     @Test("simultaneous quarter notes share columns without expanding measure")
     func simultaneousQuarterNotesShareColumnsWithoutExpandingMeasure() {
         let notes = (0..<4).flatMap { index in

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -70,4 +70,33 @@ struct NotationLayoutEngineTests {
         #expect(sortedX.count == 4)
         #expect(abs((sortedX[1] - sortedX[0]) - GameplayLayout.uniformSpacing) < 0.001)
     }
+
+    @Test("simultaneous quarter notes share columns without expanding measure")
+    func simultaneousQuarterNotesShareColumnsWithoutExpandingMeasure() {
+        let notes = (0..<4).flatMap { index in
+            [
+                Note(
+                    interval: .quarter,
+                    noteType: .snare,
+                    measureNumber: 1,
+                    measureOffset: Double(index) / 4.0
+                ),
+                Note(
+                    interval: .quarter,
+                    noteType: .bass,
+                    measureNumber: 1,
+                    measureOffset: Double(index) / 4.0
+                )
+            ]
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+        let uniqueX = Array(Set(layout.noteHeads.map(\.position.x))).sorted()
+
+        #expect(layout.noteHeads.count == 8)
+        #expect(uniqueX.count == 4)
+        #expect((layout.measures.first?.width ?? 0) <= GameplayLayout.measureWidth(for: .fourFour))
+        #expect(abs((uniqueX[1] - uniqueX[0]) - GameplayLayout.uniformSpacing) < 0.001)
+    }
 }

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -696,4 +696,84 @@ extension NotationLayoutEngineTests {
             #expect(hasStartBar)
         }
     }
+
+    // MARK: - Mixed-Duration Beam Flag Tests
+
+    @Test("sixteenth in mixed sixteenth-eighth beam run produces one flag for uncovered level")
+    func sixteenthInMixedBeamRunProducesFlagForUncoveredLevel() throws {
+        // sixteenth (flagCount=2) + eighth (flagCount=1) in the same beam run.
+        // Level-0 beam covers both notes; level-1 has only the sixteenth
+        // (< 2 notes, so no beam emitted).  The sixteenth needs a flag at
+        // index 1 to represent the uncovered second level.
+        let notes = [
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0),
+            Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0.0625)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+
+        // One level-0 beam spanning both notes
+        let levelZeroBeams = layout.beams.filter { $0.level == 0 }
+        #expect(levelZeroBeams.count == 1)
+        #expect(levelZeroBeams.first?.noteHeadIDs.count == 2)
+
+        // No level-1 beam (only one sixteenth qualifies, < 2 minimum)
+        let levelOneBeams = layout.beams.filter { $0.level == 1 }
+        #expect(levelOneBeams.isEmpty)
+
+        // The sixteenth should have one flag (for the uncovered level 1)
+        // The eighth should have no flags (fully covered by level-0 beam)
+        let sixteenthHead = try #require(layout.noteHeads.first { $0.interval == .sixteenth })
+        let eighthHead = try #require(layout.noteHeads.first { $0.interval == .eighth })
+        let sixteenthFlags = layout.flags.filter { $0.noteHeadID == sixteenthHead.id }
+        let eighthFlags = layout.flags.filter { $0.noteHeadID == eighthHead.id }
+
+        #expect(sixteenthFlags.count == 1)
+        #expect(sixteenthFlags.first?.flagIndex == 1)
+        #expect(eighthFlags.isEmpty)
+    }
+
+    @Test("thirty-second in mixed beam run produces flags for all uncovered levels")
+    func thirtySecondInMixedBeamRunProducesFlagsForAllUncoveredLevels() throws {
+        // thirty-second (flagCount=3) + eighth (flagCount=1).
+        // Level-0 beam covers both; levels 1-2 have only the thirty-second.
+        // Two flags should be emitted for the thirty-second (indices 1 and 2).
+        let notes = [
+            Note(interval: .thirtysecond, noteType: .snare, measureNumber: 1, measureOffset: 0),
+            Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0.03125)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+
+        let thirtySecondHead = try #require(layout.noteHeads.first { $0.interval == .thirtysecond })
+        let eighthHead = try #require(layout.noteHeads.first { $0.interval == .eighth })
+        let thirtySecondFlags = layout.flags.filter { $0.noteHeadID == thirtySecondHead.id }
+        let eighthFlags = layout.flags.filter { $0.noteHeadID == eighthHead.id }
+
+        #expect(thirtySecondFlags.count == 2)
+        let flagIndices = Set(thirtySecondFlags.map(\.flagIndex))
+        #expect(flagIndices == [1, 2])
+        #expect(eighthFlags.isEmpty)
+    }
+
+    @Test("uniform sixteenths in beam run produce no flags")
+    func uniformSixteenthsInBeamRunProduceNoFlags() {
+        // All sixteenths: both level-0 and level-1 beams are emitted, so no flags.
+        let notes = (0..<4).map { index in
+            Note(
+                interval: .sixteenth,
+                noteType: .snare,
+                measureNumber: 1,
+                measureOffset: Double(index) / 16.0
+            )
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+
+        #expect(layout.beams.count == 2)
+        #expect(layout.flags.isEmpty)
+    }
 }

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -13,6 +13,21 @@ struct NotationLayoutEngineTests {
         #expect(style.noteHeadWidth == GameplayLayout.beatColumnWidth)
     }
 
+    @Test("notation layout style omits unused measure padding API")
+    func notationLayoutStyleOmitsUnusedMeasurePaddingAPI() {
+        let labels = Set(Mirror(reflecting: NotationLayoutStyle.gameplayDefault).children.compactMap(\.label))
+
+        #expect(!labels.contains("measurePadding"))
+    }
+
+    @Test("notation layout exposes note head positions by note head ID")
+    func notationLayoutExposesNoteHeadPositionsByNoteHeadID() {
+        let labels = Set(Mirror(reflecting: NotationLayout.empty).children.compactMap(\.label))
+
+        #expect(labels.contains("noteHeadPositionsByID"))
+        #expect(!labels.contains("beatLookup"))
+    }
+
     @Test("drum types map to gameplay voices")
     func drumTypesMapToGameplayVoices() {
         #expect(NotationVoice.voice(for: .kick) == .lower)

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -24,11 +24,23 @@ struct NotationLayoutEngineTests {
     @Test("layout input accepts notes and time signature")
     func layoutInputAcceptsNotesAndTimeSignature() {
         let note = Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0)
-        let input = NotationLayoutInput(notes: [note], timeSignature: .fourFour)
+        let input = NotationLayoutInput(notes: [note], timeSignature: .fourFour, minimumMeasureCount: 3)
 
         #expect(input.notes.count == 1)
         #expect(input.timeSignature.beatsPerMeasure == 4)
+        #expect(input.minimumMeasureCount == 3)
         #expect(input.style.minimumNoteColumnGap == 28)
+    }
+
+    @Test("minimum measure count preserves trailing empty measures")
+    func minimumMeasureCountPreservesTrailingEmptyMeasures() {
+        let note = Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0)
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour, minimumMeasureCount: 4)
+        )
+
+        #expect(layout.measures.map(\.measureIndex) == [0, 1, 2, 3])
+        #expect(layout.measureBars.contains { $0.id == "bar_3_end" && $0.isFinal })
     }
 
     @Test("sixteenth notes expand measure width for readable spacing")

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -590,6 +590,43 @@ extension NotationLayoutEngineTests {
         }
     }
 
+    @Test("down-stem sixteenth notes reach outermost beam level")
+    func downStemSixteenthNotesReachOutermostBeam() throws {
+        let style = NotationLayoutStyle.gameplayDefault
+        let notes = (0..<4).map { index in
+            Note(
+                interval: .sixteenth,
+                noteType: .crash,
+                measureNumber: 1,
+                measureOffset: Double(index) / 16.0
+            )
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, style: style)
+        )
+
+        // Crash notes have down-stems; verify two beam levels exist
+        #expect(layout.beams.count == 2)
+        #expect(Set(layout.beams.map(\.level)) == [0, 1])
+
+        // The outermost beam (level 1) is farthest from the note heads in stem direction.
+        // For down-stems that means it has the highest Y value.
+        let outermostBeam = try #require(layout.beams.max { $0.level < $1.level })
+        #expect(outermostBeam.direction == .down)
+
+        // Every stem must reach the outermost beam at its stem x position
+        for noteHeadID in outermostBeam.noteHeadIDs {
+            let noteHead = try #require(layout.noteHeads.first { $0.id == noteHeadID })
+            let stem = try #require(layout.stems.first { $0.noteHeadIDs.contains(noteHeadID) })
+            let stemX = noteHead.position.x - style.stemXInset  // down-stem inset
+            let t = (stemX - outermostBeam.start.x) / (outermostBeam.end.x - outermostBeam.start.x)
+            let expectedY = outermostBeam.start.y + t * (outermostBeam.end.y - outermostBeam.start.y)
+            let msg = "Down-stem for noteHead \(noteHeadID) end.y \(stem.end.y)" +
+                " should reach outermost beam Y \(expectedY)"
+            #expect(abs(stem.end.y - expectedY) < 0.5, msg)
+        }
+    }
+
     // MARK: - Flag Rendering Tests
 
     @Test("isolated eighth note produces one flag")
@@ -902,83 +939,4 @@ extension NotationLayoutEngineTests {
         #expect(layout.contentWidth >= GameplayLayout.maxRowWidth)
     }
 
-    // MARK: - Offset-1 Normalization Tests
-
-    @Test("note with measureOffset 1.0 renders in next measure")
-    func noteWithOffsetOneRendersInNextMeasure() throws {
-        // A note at measureNumber: 1, measureOffset: 1.0 has timePosition = 0 + 1.0 = 1.0,
-        // which is the start of measure index 1 (measure number 2). The note head must
-        // render in measure 1, not at the end of measure 0.
-        let note = Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 1.0)
-        let layout = NotationLayoutEngine().layout(
-            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour, minimumMeasureCount: 3)
-        )
-        let head = try #require(layout.noteHeads.first)
-
-        #expect(head.measureIndex == 1)
-        #expect(head.timePosition == 1.0)
-        // x position should be at the start of measure 1, not the end of measure 0
-        let measure1 = try #require(layout.measures.first { $0.measureIndex == 1 })
-        let expectedX = measure1.xOffset + GameplayLayout.barLineWidth + GameplayLayout.uniformSpacing
-        #expect(abs(head.position.x - expectedX) < 0.001)
-    }
-
-    @Test("offset-1 note collision column uses normalized measure")
-    func offsetOneNoteCollisionColumnUsesNormalizedMeasure() throws {
-        // Two notes at the same normalized time position (measure 2 offset 0.0) but
-        // expressed differently: one as (measureNumber:2, offset:0) and one as
-        // (measureNumber:1, offset:1.0). They should collide and get voice offsets.
-        let notes = [
-            Note(interval: .quarter, noteType: .snare, measureNumber: 2, measureOffset: 0.0),
-            Note(interval: .quarter, noteType: .bass, measureNumber: 1, measureOffset: 1.0)
-        ]
-        let layout = NotationLayoutEngine().layout(
-            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, minimumMeasureCount: 3)
-        )
-        let snare = try #require(layout.noteHeads.first { $0.drumType == .snare })
-        let kick = try #require(layout.noteHeads.first { $0.drumType == .kick })
-
-        #expect(snare.measureIndex == 1)
-        #expect(kick.measureIndex == 1)
-        // Both should be at the same x when no collision offset applied, or properly
-        // split when voice collision is detected
-        #expect(abs(snare.timePosition - kick.timePosition) < 0.001)
-    }
-
-    @Test("offset-1 note in last measure is not dropped when minimumMeasureCount is tight")
-    func offsetOneNoteInLastMeasureNotDroppedWithTightMeasureCount() throws {
-        // A note at measureNumber: 2, measureOffset: 1.0 normalizes to measure index 2
-        // (start of measure 3). Without normalization, totalMeasures would be just 2
-        // (from raw measureNumber max), and the note would be dropped. With normalization,
-        // totalMeasures must be 3 to accommodate the overflow.
-        let note = Note(interval: .quarter, noteType: .snare, measureNumber: 2, measureOffset: 1.0)
-        let layout = NotationLayoutEngine().layout(
-            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour, minimumMeasureCount: 1)
-        )
-        let head = try #require(layout.noteHeads.first, "Note must not be dropped — measure count must account for normalized position")
-
-        #expect(head.measureIndex == 2)
-        #expect(head.timePosition == 2.0)
-        #expect(layout.measures.count >= 3, "At least 3 measures needed for the normalized position")
-    }
-
-    @Test("column offsets for measure use normalized positions not raw measureNumber")
-    func columnOffsetsUseNormalizedPositions() throws {
-        // A note at (measureNumber:1, offset:1.0) normalizes to measure index 1 offset 0.0.
-        // It should contribute to measure 1's column offsets and width, not measure 0's.
-        let notes = [
-            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 1.0),
-            Note(interval: .sixteenth, noteType: .snare, measureNumber: 2, measureOffset: 0.0625)
-        ]
-        let layout = NotationLayoutEngine().layout(
-            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, minimumMeasureCount: 3)
-        )
-
-        // Both notes should render in measure index 1
-        let measure1Heads = layout.noteHeads.filter { $0.measureIndex == 1 }
-        #expect(measure1Heads.count == 2, "Both notes should render in normalized measure index 1")
-        // The heads should be at different x positions (different offsets)
-        let uniqueX = Set(measure1Heads.map { $0.position.x })
-        #expect(uniqueX.count == 2, "Two different offsets should produce two distinct x positions")
-    }
 }

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -776,4 +776,25 @@ extension NotationLayoutEngineTests {
         #expect(layout.beams.count == 2)
         #expect(layout.flags.isEmpty)
     }
+
+    // MARK: - Content Width
+
+    @Test("contentWidth is at least maxRowWidth for any layout")
+    func contentWidthAtLeastMaxRowWidth() {
+        let layout = NotationLayout.empty
+        #expect(layout.contentWidth == GameplayLayout.maxRowWidth)
+    }
+
+    @Test("contentWidth expands for notes beyond default row width")
+    func contentWidthExpandsForDenseNotes() throws {
+        let notes = (0..<8).map { i in
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: Double(i) * 0.125)
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+        let lastNoteHead = try #require(layout.noteHeads.max(by: { $0.position.x < $1.position.x }))
+        #expect(layout.contentWidth > lastNoteHead.position.x)
+        #expect(layout.contentWidth >= GameplayLayout.maxRowWidth)
+    }
 }

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -110,8 +110,8 @@ struct NotationLayoutEngineTests {
         #expect((uniqueX.last ?? 0) - (uniqueX.first ?? 0) >= 16)
     }
 
-    @Test("near identical offsets across quantization boundary share visual column")
-    func nearIdenticalOffsetsAcrossQuantizationBoundaryShareVisualColumn() {
+    @Test("near identical cross voice offsets split heads without expanding measure")
+    func nearIdenticalCrossVoiceOffsetsSplitHeadsWithoutExpandingMeasure() {
         let notes = [
             Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0.25),
             Note(interval: .quarter, noteType: .bass, measureNumber: 1, measureOffset: 0.24999999999999997)
@@ -124,6 +124,34 @@ struct NotationLayoutEngineTests {
         #expect(layout.measures.first?.width == GameplayLayout.measureWidth(for: .fourFour))
         #expect(uniqueX.count == 2)
         #expect((uniqueX.last ?? 0) - (uniqueX.first ?? 0) >= 16)
+    }
+
+    @Test("dense adjacent cross voice columns preserve readable final gap")
+    func denseAdjacentCrossVoiceColumnsPreserveReadableFinalGap() throws {
+        let style = NotationLayoutStyle.gameplayDefault
+        let notes = [
+            Note(interval: .sixteenth, noteType: .bass, measureNumber: 1, measureOffset: 0.0),
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0.0),
+            Note(interval: .sixteenth, noteType: .bass, measureNumber: 1, measureOffset: 1.0 / 16.0),
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 1.0 / 16.0)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, style: style)
+        )
+        let firstColumnRightmostX = try #require(
+            layout.noteHeads
+                .filter { $0.timePosition == 0.0 }
+                .map(\.position.x)
+                .max()
+        )
+        let secondColumnLeftmostX = try #require(
+            layout.noteHeads
+                .filter { $0.timePosition == 0.0625 }
+                .map(\.position.x)
+                .min()
+        )
+
+        #expect(secondColumnLeftmostX - firstColumnRightmostX >= style.minimumNoteColumnGap)
     }
 
     @Test("simultaneous quarter notes split voices without expanding measure")

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -797,4 +797,47 @@ extension NotationLayoutEngineTests {
         #expect(layout.contentWidth > lastNoteHead.position.x)
         #expect(layout.contentWidth >= GameplayLayout.maxRowWidth)
     }
+
+    // MARK: - Offset-1 Normalization Tests
+
+    @Test("note with measureOffset 1.0 renders in next measure")
+    func noteWithOffsetOneRendersInNextMeasure() throws {
+        // A note at measureNumber: 1, measureOffset: 1.0 has timePosition = 0 + 1.0 = 1.0,
+        // which is the start of measure index 1 (measure number 2). The note head must
+        // render in measure 1, not at the end of measure 0.
+        let note = Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 1.0)
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour, minimumMeasureCount: 3)
+        )
+        let head = try #require(layout.noteHeads.first)
+
+        #expect(head.measureIndex == 1)
+        #expect(head.timePosition == 1.0)
+        // x position should be at the start of measure 1, not the end of measure 0
+        let measure1 = try #require(layout.measures.first { $0.measureIndex == 1 })
+        let expectedX = measure1.xOffset + GameplayLayout.barLineWidth + GameplayLayout.uniformSpacing
+        #expect(abs(head.position.x - expectedX) < 0.001)
+    }
+
+    @Test("offset-1 note collision column uses normalized measure")
+    func offsetOneNoteCollisionColumnUsesNormalizedMeasure() throws {
+        // Two notes at the same normalized time position (measure 2 offset 0.0) but
+        // expressed differently: one as (measureNumber:2, offset:0) and one as
+        // (measureNumber:1, offset:1.0). They should collide and get voice offsets.
+        let notes = [
+            Note(interval: .quarter, noteType: .snare, measureNumber: 2, measureOffset: 0.0),
+            Note(interval: .quarter, noteType: .bass, measureNumber: 1, measureOffset: 1.0)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, minimumMeasureCount: 3)
+        )
+        let snare = try #require(layout.noteHeads.first { $0.drumType == .snare })
+        let kick = try #require(layout.noteHeads.first { $0.drumType == .kick })
+
+        #expect(snare.measureIndex == 1)
+        #expect(kick.measureIndex == 1)
+        // Both should be at the same x when no collision offset applied, or properly
+        // split when voice collision is detected
+        #expect(abs(snare.timePosition - kick.timePosition) < 0.001)
+    }
 }

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -406,4 +406,73 @@ extension NotationLayoutEngineTests {
         #expect(layout.stems.count == 2)
         #expect(layout.beams.isEmpty)
     }
+
+    @Test("non-beamable note between eighths breaks beam run")
+    func nonBeamableNoteBetweenEighthsBreaksBeamRun() {
+        let notes = [
+            Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0),
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0.125),
+            Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0.25)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+
+        #expect(layout.stems.count == 3)
+        #expect(layout.beams.isEmpty)
+    }
+
+    @Test("higher beam level does not span intervening lower duration note")
+    func higherBeamLevelDoesNotSpanInterveningLowerDurationNote() {
+        let notes = [
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0),
+            Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0.0625),
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0.1875)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+        let levelZeroBeams = layout.beams.filter { $0.level == 0 }
+        let levelOneBeams = layout.beams.filter { $0.level == 1 }
+
+        #expect(levelZeroBeams.count == 1)
+        #expect(levelZeroBeams.first?.noteHeadIDs.count == 3)
+        #expect(levelOneBeams.isEmpty)
+    }
+
+    @Test("same time same voice duplicate eighths do not create zero length beam")
+    func sameTimeSameVoiceDuplicateEighthsDoNotCreateZeroLengthBeam() {
+        let notes = [
+            Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0),
+            Note(interval: .eighth, noteType: .highTom, measureNumber: 1, measureOffset: 0)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+
+        #expect(layout.stems.count == 2)
+        #expect(layout.beams.isEmpty)
+    }
+
+    @Test("down stem beams align to down stem x coordinates")
+    func downStemBeamsAlignToDownStemXCoordinates() throws {
+        let style = NotationLayoutStyle.gameplayDefault
+        let notes = [
+            Note(interval: .eighth, noteType: .crash, measureNumber: 1, measureOffset: 0),
+            Note(interval: .eighth, noteType: .crash, measureNumber: 1, measureOffset: 0.125)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, style: style)
+        )
+        let sortedHeads = layout.noteHeads.sorted { $0.timePosition < $1.timePosition }
+        let firstHead = try #require(sortedHeads.first)
+        let lastHead = try #require(sortedHeads.last)
+        let beam = try #require(layout.beams.first)
+
+        #expect(layout.beams.count == 1)
+        #expect(beam.direction == .down)
+        #expect(abs(beam.start.x - (firstHead.position.x - style.stemXInset)) < 0.001)
+        #expect(abs(beam.end.x - (lastHead.position.x - style.stemXInset)) < 0.001)
+        #expect(beam.start.y > firstHead.position.y)
+    }
 }

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -30,4 +30,44 @@ struct NotationLayoutEngineTests {
         #expect(input.timeSignature.beatsPerMeasure == 4)
         #expect(input.style.minimumNoteColumnGap == 28)
     }
+
+    @Test("sixteenth notes expand measure width for readable spacing")
+    func sixteenthNotesExpandMeasureWidthForReadableSpacing() {
+        let notes = (0..<16).map { index in
+            Note(
+                interval: .sixteenth,
+                noteType: .snare,
+                measureNumber: 1,
+                measureOffset: Double(index) / 16.0
+            )
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+        let sortedX = layout.noteHeads.map(\.position.x).sorted()
+
+        for index in 1..<sortedX.count {
+            #expect(sortedX[index] - sortedX[index - 1] >= 28)
+        }
+        #expect(layout.measures.first?.width ?? 0 > GameplayLayout.measureWidth(for: .fourFour))
+    }
+
+    @Test("quarter notes keep existing spacing")
+    func quarterNotesKeepExistingSpacing() {
+        let notes = (0..<4).map { index in
+            Note(
+                interval: .quarter,
+                noteType: .snare,
+                measureNumber: 1,
+                measureOffset: Double(index) / 4.0
+            )
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+        let sortedX = layout.noteHeads.map(\.position.x).sorted()
+
+        #expect(sortedX.count == 4)
+        #expect(abs((sortedX[1] - sortedX[0]) - GameplayLayout.uniformSpacing) < 0.001)
+    }
 }

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -256,3 +256,154 @@ struct NotationLayoutEngineTests {
         #expect(abs(snare.position.x - kick.position.x) >= 16)
     }
 }
+
+extension NotationLayoutEngineTests {
+    @Test("high crash stem points down")
+    func highCrashStemPointsDown() throws {
+        let style = NotationLayoutStyle.gameplayDefault
+        let note = Note(interval: .quarter, noteType: .crash, measureNumber: 1, measureOffset: 0)
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour, style: style)
+        )
+        let crash = try #require(layout.noteHeads.first { $0.drumType == .crash })
+        let stem = try #require(layout.stems.first)
+
+        #expect(crash.stemDirection == .down)
+        #expect(stem.direction == .down)
+        #expect(abs(stem.start.x - (crash.position.x - style.stemXInset)) < 0.001)
+        #expect(stem.end.y > stem.start.y)
+    }
+
+    @Test("snare stem points up")
+    func snareStemPointsUp() throws {
+        let style = NotationLayoutStyle.gameplayDefault
+        let note = Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0)
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour, style: style)
+        )
+        let snare = try #require(layout.noteHeads.first { $0.drumType == .snare })
+        let stem = try #require(layout.stems.first)
+
+        #expect(snare.stemDirection == .up)
+        #expect(stem.direction == .up)
+        #expect(abs(stem.start.x - (snare.position.x + style.stemXInset)) < 0.001)
+        #expect(stem.end.y < stem.start.y)
+    }
+
+    @Test("quarter notes create stems but no beams")
+    func quarterNotesCreateStemsButNoBeams() {
+        let notes = (0..<4).map { index in
+            Note(
+                interval: .quarter,
+                noteType: .snare,
+                measureNumber: 1,
+                measureOffset: Double(index) / 4.0
+            )
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+
+        #expect(layout.stems.count == 4)
+        #expect(layout.beams.isEmpty)
+    }
+
+    @Test("full and half notes do not create stems")
+    func fullAndHalfNotesDoNotCreateStems() {
+        let notes = [
+            Note(interval: .full, noteType: .snare, measureNumber: 1, measureOffset: 0),
+            Note(interval: .half, noteType: .snare, measureNumber: 1, measureOffset: 0.5)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+
+        #expect(layout.stems.isEmpty)
+        #expect(layout.beams.isEmpty)
+    }
+
+    @Test("consecutive sixteenths create two beam levels")
+    func consecutiveSixteenthsCreateTwoBeamLevels() throws {
+        let style = NotationLayoutStyle.gameplayDefault
+        let notes = (0..<4).map { index in
+            Note(
+                interval: .sixteenth,
+                noteType: .snare,
+                measureNumber: 1,
+                measureOffset: Double(index) / 16.0
+            )
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, style: style)
+        )
+        let sortedHeads = layout.noteHeads.sorted { $0.timePosition < $1.timePosition }
+        let firstHead = try #require(sortedHeads.first)
+        let lastHead = try #require(sortedHeads.last)
+
+        #expect(layout.beams.count == 2)
+        #expect(Set(layout.beams.map(\.level)) == [0, 1])
+        #expect(layout.beams.allSatisfy { $0.noteHeadIDs.count == 4 })
+        #expect(layout.beams.allSatisfy { $0.direction == .up })
+        #expect(layout.beams.allSatisfy { abs($0.start.x - (firstHead.position.x + style.stemXInset)) < 0.001 })
+        #expect(layout.beams.allSatisfy { abs($0.end.x - (lastHead.position.x + style.stemXInset)) < 0.001 })
+    }
+
+    @Test("consecutive eighths create one beam level")
+    func consecutiveEighthsCreateOneBeamLevel() throws {
+        let notes = (0..<2).map { index in
+            Note(
+                interval: .eighth,
+                noteType: .snare,
+                measureNumber: 1,
+                measureOffset: Double(index) / 8.0
+            )
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+        let beam = try #require(layout.beams.first)
+
+        #expect(layout.beams.count == 1)
+        #expect(beam.level == 0)
+        #expect(beam.noteHeadIDs.count == 2)
+    }
+
+    @Test("beams do not cross measure boundaries")
+    func beamsDoNotCrossMeasureBoundaries() {
+        let notes = [
+            Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0.875),
+            Note(interval: .eighth, noteType: .snare, measureNumber: 2, measureOffset: 0)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+
+        #expect(layout.stems.count == 2)
+        #expect(layout.beams.isEmpty)
+    }
+
+    @Test("isolated eighth does not create beam")
+    func isolatedEighthDoesNotCreateBeam() {
+        let note = Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0)
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour)
+        )
+
+        #expect(layout.stems.count == 1)
+        #expect(layout.beams.isEmpty)
+    }
+
+    @Test("cross voice notes do not beam together")
+    func crossVoiceNotesDoNotBeamTogether() {
+        let notes = [
+            Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0),
+            Note(interval: .eighth, noteType: .bass, measureNumber: 1, measureOffset: 0.125)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+
+        #expect(layout.stems.count == 2)
+        #expect(layout.beams.isEmpty)
+    }
+}

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -855,4 +855,41 @@ extension NotationLayoutEngineTests {
         // split when voice collision is detected
         #expect(abs(snare.timePosition - kick.timePosition) < 0.001)
     }
+
+    @Test("offset-1 note in last measure is not dropped when minimumMeasureCount is tight")
+    func offsetOneNoteInLastMeasureNotDroppedWithTightMeasureCount() throws {
+        // A note at measureNumber: 2, measureOffset: 1.0 normalizes to measure index 2
+        // (start of measure 3). Without normalization, totalMeasures would be just 2
+        // (from raw measureNumber max), and the note would be dropped. With normalization,
+        // totalMeasures must be 3 to accommodate the overflow.
+        let note = Note(interval: .quarter, noteType: .snare, measureNumber: 2, measureOffset: 1.0)
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour, minimumMeasureCount: 1)
+        )
+        let head = try #require(layout.noteHeads.first, "Note must not be dropped — measure count must account for normalized position")
+
+        #expect(head.measureIndex == 2)
+        #expect(head.timePosition == 2.0)
+        #expect(layout.measures.count >= 3, "At least 3 measures needed for the normalized position")
+    }
+
+    @Test("column offsets for measure use normalized positions not raw measureNumber")
+    func columnOffsetsUseNormalizedPositions() throws {
+        // A note at (measureNumber:1, offset:1.0) normalizes to measure index 1 offset 0.0.
+        // It should contribute to measure 1's column offsets and width, not measure 0's.
+        let notes = [
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 1.0),
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 2, measureOffset: 0.0625)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, minimumMeasureCount: 3)
+        )
+
+        // Both notes should render in measure index 1
+        let measure1Heads = layout.noteHeads.filter { $0.measureIndex == 1 }
+        #expect(measure1Heads.count == 2, "Both notes should render in normalized measure index 1")
+        // The heads should be at different x positions (different offsets)
+        let uniqueX = Set(measure1Heads.map { $0.position.x })
+        #expect(uniqueX.count == 2, "Two different offsets should produce two distinct x positions")
+    }
 }

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -972,4 +972,24 @@ extension NotationLayoutEngineTests {
         #expect(layout.contentWidth >= GameplayLayout.maxRowWidth)
     }
 
+    @Test("notes in different rows get separate stems even at same x position")
+    func notesInDifferentRowsGetSeparateStems() throws {
+        let notes = [
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0),
+            Note(interval: .quarter, noteType: .snare, measureNumber: 4, measureOffset: 0)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, minimumMeasureCount: 5)
+        )
+        let heads = layout.noteHeads.sorted { $0.measureIndex < $1.measureIndex }
+        #expect(heads.count == 2)
+        let first = try #require(heads.first), second = try #require(heads.last)
+        #expect(first.row != second.row)
+        #expect(abs(first.position.x - second.position.x) < 1.0)
+        #expect(layout.stems.count == 2, "Notes in different rows should get separate stems")
+        for stem in layout.stems {
+            #expect(stem.noteHeadIDs.count == 1)
+        }
+    }
+
 }

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -487,4 +487,170 @@ extension NotationLayoutEngineTests {
         #expect(abs(beam.end.x - (lastHead.position.x - style.stemXInset)) < 0.001)
         #expect(beam.start.y > firstHead.position.y)
     }
+
+    // MARK: - Flag Rendering Tests
+
+    @Test("isolated eighth note produces one flag")
+    func isolatedEighthNoteProducesOneFlag() throws {
+        let note = Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0)
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour)
+        )
+
+        #expect(layout.flags.count == 1)
+        let flag = try #require(layout.flags.first)
+        #expect(flag.flagIndex == 0)
+        #expect(flag.stemDirection == .up)
+        #expect(flag.noteHeadID == layout.noteHeads.first?.id)
+    }
+
+    @Test("isolated sixteenth note produces two flags")
+    func isolatedSixteenthNoteProducesTwoFlags() throws {
+        let note = Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0)
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour)
+        )
+
+        #expect(layout.flags.count == 2)
+        let indices = Set(layout.flags.map(\.flagIndex))
+        #expect(indices == [0, 1])
+    }
+
+    @Test("beamed eighth notes produce no flags")
+    func beamedEighthNotesProduceNoFlags() {
+        let notes = (0..<2).map { index in
+            Note(
+                interval: .eighth,
+                noteType: .snare,
+                measureNumber: 1,
+                measureOffset: Double(index) / 8.0
+            )
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+
+        #expect(layout.beams.count == 1)
+        #expect(layout.flags.isEmpty)
+    }
+
+    @Test("quarter notes produce no flags")
+    func quarterNotesProduceNoFlags() {
+        let note = Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0)
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour)
+        )
+
+        #expect(layout.flags.isEmpty)
+    }
+
+    @Test("mixed beamed and isolated notes produce flags only for isolated")
+    func mixedBeamedAndIsolatedNotesProduceFlagsOnlyForIsolated() throws {
+        let notes = [
+            Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0),
+            Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0.125),
+            Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0.5)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+
+        // First two eighths are beamed, last one is isolated
+        #expect(layout.beams.count == 1)
+        #expect(layout.flags.count == 1)
+        let isolatedHead = try #require(layout.noteHeads.first { $0.timePosition == 0.5 })
+        let flag = try #require(layout.flags.first)
+        #expect(flag.noteHeadID == isolatedHead.id)
+    }
+
+    @Test("down stem crash flag has down direction")
+    func downStemCrashFlagHasDownDirection() throws {
+        let note = Note(interval: .eighth, noteType: .crash, measureNumber: 1, measureOffset: 0)
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour)
+        )
+
+        let flag = try #require(layout.flags.first)
+        #expect(flag.stemDirection == .down)
+    }
+
+    // MARK: - Barline Deduplication Tests
+
+    @Test("adjacent measures on same row share single barline")
+    func adjacentMeasuresOnSameRowShareSingleBarline() throws {
+        let notes = (0..<8).map { index in
+            Note(
+                interval: .quarter,
+                noteType: .snare,
+                measureNumber: 1,
+                measureOffset: Double(index % 4) / 4.0
+            )
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, minimumMeasureCount: 3)
+        )
+
+        let sameRowMeasures = layout.measures.filter { $0.row == 0 }
+        guard sameRowMeasures.count >= 2 else {
+            Issue.record("Expected at least 2 measures on row 0")
+            return
+        }
+
+        // Internal boundaries should have exactly one barline, not two
+        let row0Bars = layout.measureBars.filter { $0.row == 0 }
+        let barXPositions = Set(row0Bars.map(\.x))
+
+        // For N measures on a row, we expect: 1 start bar + N end bars = N+1 bars
+        // (start bar for first measure + end bar for each measure)
+        // NOT 2*N bars (start + end for each)
+        let expectedBarCount = sameRowMeasures.count + 1
+        #expect(row0Bars.count == expectedBarCount)
+
+        // No duplicate x positions
+        #expect(barXPositions.count == row0Bars.count)
+    }
+
+    @Test("final measure barline is marked isFinal")
+    func finalMeasureBarlineIsMarkedFinal() {
+        let note = Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0)
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour, minimumMeasureCount: 2)
+        )
+
+        let finalBars = layout.measureBars.filter(\.isFinal)
+        #expect(finalBars.count == 1)
+        #expect(finalBars.first?.isFinal == true)
+    }
+
+    @Test("measure wrapping to new row gets separate start barline")
+    func measureWrappingToNewRowGetsSeparateStartBarline() {
+        // Create enough notes/measures to force a row wrap
+        let notes = (0..<4).map { index in
+            Note(
+                interval: .quarter,
+                noteType: .snare,
+                measureNumber: 1,
+                measureOffset: Double(index) / 4.0
+            )
+        }
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, minimumMeasureCount: 20)
+        )
+
+        let rows = Set(layout.measures.map(\.row))
+        guard rows.count >= 2 else {
+            Issue.record("Expected measures to wrap to multiple rows")
+            return
+        }
+
+        // Each row should have a start barline
+        for row in rows {
+            let rowMeasures = layout.measures.filter { $0.row == row }
+            let rowBars = layout.measureBars.filter { $0.row == row }
+            let hasStartBar = rowBars.contains { bar in
+                abs(bar.x - (rowMeasures.first?.xOffset ?? -1)) < 0.001
+            }
+            #expect(hasStartBar)
+        }
+    }
 }

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -109,6 +109,21 @@ struct NotationLayoutEngineTests {
         #expect(uniqueX.count == 1)
     }
 
+    @Test("near identical offsets across quantization boundary share visual column")
+    func nearIdenticalOffsetsAcrossQuantizationBoundaryShareVisualColumn() {
+        let notes = [
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0.25),
+            Note(interval: .quarter, noteType: .bass, measureNumber: 1, measureOffset: 0.24999999999999997)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+        let uniqueX = Array(Set(layout.noteHeads.map(\.position.x))).sorted()
+
+        #expect(layout.measures.first?.width == GameplayLayout.measureWidth(for: .fourFour))
+        #expect(uniqueX.count == 1)
+    }
+
     @Test("simultaneous quarter notes share columns without expanding measure")
     func simultaneousQuarterNotesShareColumnsWithoutExpandingMeasure() {
         let notes = (0..<4).flatMap { index in

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -621,9 +621,7 @@ extension NotationLayoutEngineTests {
             let stemX = noteHead.position.x - style.stemXInset  // down-stem inset
             let t = (stemX - outermostBeam.start.x) / (outermostBeam.end.x - outermostBeam.start.x)
             let expectedY = outermostBeam.start.y + t * (outermostBeam.end.y - outermostBeam.start.y)
-            let msg = "Down-stem for noteHead \(noteHeadID) end.y \(stem.end.y)" +
-                " should reach outermost beam Y \(expectedY)"
-            #expect(abs(stem.end.y - expectedY) < 0.5, msg)
+            #expect(abs(stem.end.y - expectedY) < 0.5)
         }
     }
 

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -477,8 +477,43 @@ extension NotationLayoutEngineTests {
             input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
         )
 
-        #expect(layout.stems.count == 2)
+        // Same-time, same-voice note heads share a single stem (chord grouping).
+        #expect(layout.stems.count == 1)
+        #expect(layout.stems.first?.noteHeadIDs.count == 2)
         #expect(layout.beams.isEmpty)
+    }
+
+    @Test("same voice chord notes share a single stem")
+    func sameVoiceChordNotesShareSingleStem() throws {
+        // Snare (.line3, up-stem) and highTom (.spaceBetween3And4, up-stem) are both
+        // upper-voice drums with up-stems. When simultaneous, they share one stem.
+        let notes = [
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0),
+            Note(interval: .quarter, noteType: .highTom, measureNumber: 1, measureOffset: 0)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+
+        #expect(layout.stems.count == 1, "Chord notes at the same position should share one stem")
+        let stem = try #require(layout.stems.first)
+        #expect(stem.noteHeadIDs.count == 2, "Shared stem should reference both note head IDs")
+        #expect(stem.direction == .up)
+    }
+
+    @Test("different voice notes at same time get separate stems")
+    func differentVoiceNotesAtSameTimeGetSeparateStems() {
+        // Snare (upper voice) and bass (lower voice) at the same time
+        // should get separate stems due to voice collision offset.
+        let notes = [
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0),
+            Note(interval: .quarter, noteType: .bass, measureNumber: 1, measureOffset: 0)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+
+        #expect(layout.stems.count == 2, "Different-voice notes should get separate stems")
     }
 
     @Test("down stem beams align to down stem x coordinates")

--- a/VirgoTests/NotationLayoutEngineTests.swift
+++ b/VirgoTests/NotationLayoutEngineTests.swift
@@ -106,7 +106,8 @@ struct NotationLayoutEngineTests {
         let uniqueX = Array(Set(layout.noteHeads.map(\.position.x))).sorted()
 
         #expect(layout.measures.first?.width == GameplayLayout.measureWidth(for: .fourFour))
-        #expect(uniqueX.count == 1)
+        #expect(uniqueX.count == 2)
+        #expect((uniqueX.last ?? 0) - (uniqueX.first ?? 0) >= 16)
     }
 
     @Test("near identical offsets across quantization boundary share visual column")
@@ -121,11 +122,12 @@ struct NotationLayoutEngineTests {
         let uniqueX = Array(Set(layout.noteHeads.map(\.position.x))).sorted()
 
         #expect(layout.measures.first?.width == GameplayLayout.measureWidth(for: .fourFour))
-        #expect(uniqueX.count == 1)
+        #expect(uniqueX.count == 2)
+        #expect((uniqueX.last ?? 0) - (uniqueX.first ?? 0) >= 16)
     }
 
-    @Test("simultaneous quarter notes share columns without expanding measure")
-    func simultaneousQuarterNotesShareColumnsWithoutExpandingMeasure() {
+    @Test("simultaneous quarter notes split voices without expanding measure")
+    func simultaneousQuarterNotesSplitVoicesWithoutExpandingMeasure() {
         let notes = (0..<4).flatMap { index in
             [
                 Note(
@@ -148,8 +150,81 @@ struct NotationLayoutEngineTests {
         let uniqueX = Array(Set(layout.noteHeads.map(\.position.x))).sorted()
 
         #expect(layout.noteHeads.count == 8)
-        #expect(uniqueX.count == 4)
+        #expect(uniqueX.count == 8)
         #expect((layout.measures.first?.width ?? 0) <= GameplayLayout.measureWidth(for: .fourFour))
-        #expect(abs((uniqueX[1] - uniqueX[0]) - GameplayLayout.uniformSpacing) < 0.001)
+        #expect(abs((uniqueX[2] - uniqueX[0]) - GameplayLayout.uniformSpacing) < 0.001)
+    }
+
+    @Test("above staff crash emits ledger line")
+    func aboveStaffCrashEmitsLedgerLine() {
+        let note = Note(interval: .quarter, noteType: .crash, measureNumber: 1, measureOffset: 0)
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour)
+        )
+
+        #expect(layout.ledgerLines.count >= 1)
+        #expect(layout.ledgerLines.allSatisfy { $0.end.x > $0.start.x })
+    }
+
+    @Test("below staff kick emits ledger lines")
+    func belowStaffKickEmitsLedgerLines() {
+        let note = Note(interval: .quarter, noteType: .bass, measureNumber: 1, measureOffset: 0)
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour)
+        )
+
+        #expect(layout.ledgerLines.count >= 1)
+        #expect(layout.ledgerLines.allSatisfy { $0.end.x > $0.start.x })
+    }
+
+    @Test("kick and snare at same time get separate voices")
+    func kickAndSnareAtSameTimeGetSeparateVoices() throws {
+        let notes = [
+            Note(interval: .quarter, noteType: .bass, measureNumber: 1, measureOffset: 0.25),
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0.25)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+        let kick = try #require(layout.noteHeads.first { $0.drumType == .kick })
+        let snare = try #require(layout.noteHeads.first { $0.drumType == .snare })
+
+        #expect(kick.voice == .lower)
+        #expect(snare.voice == .upper)
+        #expect(abs(snare.position.x - kick.position.x) >= 16)
+        #expect(kick.position.x < snare.position.x)
+    }
+
+    @Test("same voice simultaneous notes do not split")
+    func sameVoiceSimultaneousNotesDoNotSplit() throws {
+        let notes = [
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0.5),
+            Note(interval: .quarter, noteType: .crash, measureNumber: 1, measureOffset: 0.5)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+        let snare = try #require(layout.noteHeads.first { $0.drumType == .snare })
+        let crash = try #require(layout.noteHeads.first { $0.drumType == .crash })
+
+        #expect(snare.voice == .upper)
+        #expect(crash.voice == .upper)
+        #expect(abs(snare.position.x - crash.position.x) < 0.001)
+    }
+
+    @Test("near identical cross voice offsets split by quantized column")
+    func nearIdenticalCrossVoiceOffsetsSplitByQuantizedColumn() throws {
+        let notes = [
+            Note(interval: .quarter, noteType: .bass, measureNumber: 1, measureOffset: 0.25),
+            Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0.24999999999999997)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+        )
+        let kick = try #require(layout.noteHeads.first { $0.drumType == .kick })
+        let snare = try #require(layout.noteHeads.first { $0.drumType == .snare })
+
+        #expect(kick.position.x < snare.position.x)
+        #expect(abs(snare.position.x - kick.position.x) >= 16)
     }
 }

--- a/VirgoTests/NotationLayoutOffsetNormalizationTests.swift
+++ b/VirgoTests/NotationLayoutOffsetNormalizationTests.swift
@@ -1,0 +1,68 @@
+import Testing
+import SwiftUI
+@testable import Virgo
+
+@Suite("Offset-1 Normalization Tests")
+struct NotationLayoutOffsetNormalizationTests {
+    @Test("note with measureOffset 1.0 renders in next measure")
+    func noteWithOffsetOneRendersInNextMeasure() throws {
+        let note = Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 1.0)
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour, minimumMeasureCount: 3)
+        )
+        let head = try #require(layout.noteHeads.first)
+
+        #expect(head.measureIndex == 1)
+        #expect(head.timePosition == 1.0)
+        let measure1 = try #require(layout.measures.first { $0.measureIndex == 1 })
+        let expectedX = measure1.xOffset + GameplayLayout.barLineWidth + GameplayLayout.uniformSpacing
+        #expect(abs(head.position.x - expectedX) < 0.001)
+    }
+
+    @Test("offset-1 note collision column uses normalized measure")
+    func offsetOneNoteCollisionColumnUsesNormalizedMeasure() throws {
+        let notes = [
+            Note(interval: .quarter, noteType: .snare, measureNumber: 2, measureOffset: 0.0),
+            Note(interval: .quarter, noteType: .bass, measureNumber: 1, measureOffset: 1.0)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, minimumMeasureCount: 3)
+        )
+        let snare = try #require(layout.noteHeads.first { $0.drumType == .snare })
+        let kick = try #require(layout.noteHeads.first { $0.drumType == .kick })
+
+        #expect(snare.measureIndex == 1)
+        #expect(kick.measureIndex == 1)
+        #expect(abs(snare.timePosition - kick.timePosition) < 0.001)
+    }
+
+    @Test("offset-1 note in last measure is not dropped when minimumMeasureCount is tight")
+    func offsetOneNoteInLastMeasureNotDroppedWithTightMeasureCount() throws {
+        let note = Note(interval: .quarter, noteType: .snare, measureNumber: 2, measureOffset: 1.0)
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: [note], timeSignature: .fourFour, minimumMeasureCount: 1)
+        )
+        let msg = "Note must not be dropped — measure count must account for normalized position"
+        let head = try #require(layout.noteHeads.first, msg)
+
+        #expect(head.measureIndex == 2)
+        #expect(head.timePosition == 2.0)
+        #expect(layout.measures.count >= 3, "At least 3 measures needed for the normalized position")
+    }
+
+    @Test("column offsets for measure use normalized positions not raw measureNumber")
+    func columnOffsetsUseNormalizedPositions() throws {
+        let notes = [
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 1.0),
+            Note(interval: .sixteenth, noteType: .snare, measureNumber: 2, measureOffset: 0.0625)
+        ]
+        let layout = NotationLayoutEngine().layout(
+            input: NotationLayoutInput(notes: notes, timeSignature: .fourFour, minimumMeasureCount: 3)
+        )
+
+        let measure1Heads = layout.noteHeads.filter { $0.measureIndex == 1 }
+        #expect(measure1Heads.count == 2, "Both notes should render in normalized measure index 1")
+        let uniqueX = Set(measure1Heads.map { $0.position.x })
+        #expect(uniqueX.count == 2, "Two different offsets should produce two distinct x positions")
+    }
+}

--- a/VirgoTests/NotationLayoutOffsetNormalizationTests.swift
+++ b/VirgoTests/NotationLayoutOffsetNormalizationTests.swift
@@ -43,7 +43,7 @@ struct NotationLayoutOffsetNormalizationTests {
             input: NotationLayoutInput(notes: [note], timeSignature: .fourFour, minimumMeasureCount: 1)
         )
         let msg = "Note must not be dropped — measure count must account for normalized position"
-        let head = try #require(layout.noteHeads.first, msg)
+        let head = try #require(layout.noteHeads.first, "Note must not be dropped — measure count must account for normalized position")
 
         #expect(head.measureIndex == 2)
         #expect(head.timePosition == 2.0)

--- a/VirgoTests/NotePositionTests.swift
+++ b/VirgoTests/NotePositionTests.swift
@@ -118,4 +118,42 @@ struct NotePositionTests {
         key2.hash(into: &hasher2)
         #expect(hasher1.finalize() == hasher2.finalize())
     }
+
+    // MARK: - Normalized Key
+
+    @Test func testNormalizedReturnsSelfWhenOffsetLessThanOne() {
+        let key = NotePositionKey(measureNumber: 3, measureOffset: 0.75)
+        let normalized = key.normalized()
+        #expect(normalized == key)
+    }
+
+    @Test func testNormalizedRollsOffsetOneIntoNextMeasure() {
+        // (measureNumber: 1, measureOffset: 1.0) → timePosition = 1.0 → (2, 0.0)
+        let key = NotePositionKey(measureNumber: 1, measureOffset: 1.0)
+        let normalized = key.normalized()
+        let expected = NotePositionKey(measureNumber: 2, measureOffset: 0.0)
+        #expect(normalized == expected)
+    }
+
+    @Test func testNormalizedSameMusicalInstantDifferentEncodings() {
+        // Both (1, 1.0) and (2, 0.0) represent the same time position
+        let keyA = NotePositionKey(measureNumber: 1, measureOffset: 1.0)
+        let keyB = NotePositionKey(measureNumber: 2, measureOffset: 0.0)
+        #expect(keyA.normalized() == keyB.normalized())
+    }
+
+    @Test func testNormalizedHandlesLargeOffset() {
+        // (measureNumber: 1, measureOffset: 2.5) → timePosition = 0 + 2.5 = 2.5 → measureIndex 2, offset 0.5 → (3, 0.5)
+        let key = NotePositionKey(measureNumber: 1, measureOffset: 2.5)
+        let normalized = key.normalized()
+        let expected = NotePositionKey(measureNumber: 3, measureOffset: 0.5)
+        #expect(normalized == expected)
+    }
+
+    @Test func testNormalizedIdempotent() {
+        let key = NotePositionKey(measureNumber: 1, measureOffset: 1.0)
+        let once = key.normalized()
+        let twice = once.normalized()
+        #expect(once == twice)
+    }
 }

--- a/VirgoTests/SwiftUIRenderingCoverageTests.swift
+++ b/VirgoTests/SwiftUIRenderingCoverageTests.swift
@@ -132,6 +132,32 @@ struct SwiftUIRenderingCoverageTests {
         }
     }
 
+    @Test("Notation primitive note head renders the expected drum symbol")
+    func testNotationPrimitiveViewsRenderExpectedSymbols() async throws {
+        try await TestSetup.withTestSetup {
+            let note = Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0)
+            let noteHead = RenderedNoteHead(
+                id: 42,
+                sourceNoteID: ObjectIdentifier(note),
+                drumType: .snare,
+                voice: .upper,
+                timePosition: 0,
+                measureIndex: 0,
+                row: 0,
+                position: CGPoint(x: 40, y: 40),
+                staffStep: -4,
+                stemDirection: .up,
+                interval: .quarter
+            )
+
+            SwiftUITestUtilities.assertView(
+                NotationNoteHeadView(noteHead: noteHead, isActive: false),
+                containsStrings: [DrumType.snare.symbol],
+                size: CGSize(width: 120, height: 120)
+            )
+        }
+    }
+
     @Test("LibraryView renders empty and populated downloaded-song states")
     func testLibraryViewRenderingStates() async throws {
         try await TestSetup.withTestSetup {

--- a/VirgoTests/SwiftUIRenderingCoverageTests.swift
+++ b/VirgoTests/SwiftUIRenderingCoverageTests.swift
@@ -158,6 +158,66 @@ struct SwiftUIRenderingCoverageTests {
         }
     }
 
+    @Test("Notation flag view renders in both active and inactive states")
+    func testNotationFlagViewRendersInActiveAndInactiveStates() async throws {
+        try await TestSetup.withTestSetup {
+            let flag = RenderedFlag(
+                id: "flag-1",
+                noteHeadID: 42,
+                stemDirection: .up,
+                flagIndex: 0,
+                origin: CGPoint(x: 50, y: 50)
+            )
+
+            // Smoke test: both states should mount and render without errors
+            let inactiveView = NotationFlagView(flag: flag, isActive: false)
+            SwiftUITestUtilities.assertViewWithEnvironment(inactiveView, size: CGSize(width: 120, height: 120))
+
+            let activeView = NotationFlagView(flag: flag, isActive: true)
+            SwiftUITestUtilities.assertViewWithEnvironment(activeView, size: CGSize(width: 120, height: 120))
+        }
+    }
+
+    @Test("Notation stem view renders in both active and inactive states")
+    func testNotationStemViewRendersInBothStates() async throws {
+        try await TestSetup.withTestSetup {
+            let stem = RenderedStem(
+                id: "stem-1",
+                noteHeadIDs: [42],
+                direction: .up,
+                start: CGPoint(x: 50, y: 20),
+                end: CGPoint(x: 50, y: 80)
+            )
+
+            let inactiveView = NotationStemView(stem: stem, isActive: false)
+            SwiftUITestUtilities.assertViewWithEnvironment(inactiveView, size: CGSize(width: 120, height: 120))
+
+            let activeView = NotationStemView(stem: stem, isActive: true)
+            SwiftUITestUtilities.assertViewWithEnvironment(activeView, size: CGSize(width: 120, height: 120))
+        }
+    }
+
+    @Test("Notation beam view renders in both active and inactive states")
+    func testNotationBeamViewRendersInBothStates() async throws {
+        try await TestSetup.withTestSetup {
+            let beam = RenderedBeam(
+                id: "beam-1",
+                noteHeadIDs: [42, 43],
+                direction: .up,
+                level: 0,
+                start: CGPoint(x: 20, y: 30),
+                end: CGPoint(x: 80, y: 30),
+                thickness: 3.0
+            )
+
+            let inactiveView = NotationBeamView(beam: beam, isActive: false)
+            SwiftUITestUtilities.assertViewWithEnvironment(inactiveView, size: CGSize(width: 120, height: 120))
+
+            let activeView = NotationBeamView(beam: beam, isActive: true)
+            SwiftUITestUtilities.assertViewWithEnvironment(activeView, size: CGSize(width: 120, height: 120))
+        }
+    }
+
     @Test("Gameplay sheet sizing uses notation width only when note heads are active")
     func testGameplaySheetSizingUsesNotationWidthOnlyWhenActive() async throws {
         try await TestSetup.withTestSetup {

--- a/VirgoTests/SwiftUIRenderingCoverageTests.swift
+++ b/VirgoTests/SwiftUIRenderingCoverageTests.swift
@@ -158,6 +158,45 @@ struct SwiftUIRenderingCoverageTests {
         }
     }
 
+    @Test("Gameplay sheet sizing uses notation width only when note heads are active")
+    func testGameplaySheetSizingUsesNotationWidthOnlyWhenActive() async throws {
+        try await TestSetup.withTestSetup {
+            let emptyViewModel = GameplayViewModelCoverageTestSupport.makeViewModel(
+                chart: Chart(difficulty: .medium),
+                noteCount: 0
+            )
+            await emptyViewModel.loadChartData()
+            emptyViewModel.setupGameplay()
+
+            let gameplayView = GameplayView(chart: emptyViewModel.chart, metronome: emptyViewModel.metronome)
+            #expect(!gameplayView.usesNotationLayout(viewModel: emptyViewModel))
+            #expect(emptyViewModel.cachedNotationLayout.measureBars.count >= 1)
+            #expect(gameplayView.sheetContentWidth(viewModel: emptyViewModel) == GameplayLayout.maxRowWidth)
+
+            let denseChart = Chart(difficulty: .medium)
+            for index in 0..<32 {
+                denseChart.notes.append(
+                    Note(
+                        interval: .sixteenth,
+                        noteType: .snare,
+                        measureNumber: 1,
+                        measureOffset: Double(index) / 32.0
+                    )
+                )
+            }
+            let denseViewModel = GameplayViewModelCoverageTestSupport.makeViewModel(chart: denseChart)
+            await denseViewModel.loadChartData()
+            denseViewModel.setupGameplay()
+
+            #expect(gameplayView.usesNotationLayout(viewModel: denseViewModel))
+            #expect(gameplayView.sheetContentWidth(viewModel: denseViewModel) > GameplayLayout.maxRowWidth)
+            #expect(
+                gameplayView.sheetContentHeight(viewModel: denseViewModel)
+                    == denseViewModel.cachedNotationLayout.totalHeight
+            )
+        }
+    }
+
     @Test("LibraryView renders empty and populated downloaded-song states")
     func testLibraryViewRenderingStates() async throws {
         try await TestSetup.withTestSetup {

--- a/VirgoTests/SwiftUIRenderingCoverageTests.swift
+++ b/VirgoTests/SwiftUIRenderingCoverageTests.swift
@@ -178,6 +178,54 @@ struct SwiftUIRenderingCoverageTests {
         }
     }
 
+    @Test("Notation flag view renders with stem-down direction")
+    func testNotationFlagViewRendersWithStemDown() async throws {
+        try await TestSetup.withTestSetup {
+            let flag = RenderedFlag(
+                id: "flag-2",
+                noteHeadID: 43,
+                stemDirection: .down,
+                flagIndex: 0,
+                origin: CGPoint(x: 50, y: 70)
+            )
+
+            // Smoke test: stem-down flag should mount and render without errors
+            let view = NotationFlagView(flag: flag, isActive: false)
+            SwiftUITestUtilities.assertViewWithEnvironment(view, size: CGSize(width: 120, height: 120))
+        }
+    }
+
+    @Test("Notation flag position is adjusted for center-based placement")
+    func testNotationFlagPositionAdjustedForCenterPlacement() async throws {
+        try await TestSetup.withTestSetup {
+            // The adjustedCenter property should offset by half the flag frame size
+            // so the path origin (0,0) lands on flag.origin instead of the frame center.
+            let flagUp = RenderedFlag(
+                id: "flag-up",
+                noteHeadID: 42,
+                stemDirection: .up,
+                flagIndex: 0,
+                origin: CGPoint(x: 50, y: 50)
+            )
+            let flagDown = RenderedFlag(
+                id: "flag-down",
+                noteHeadID: 43,
+                stemDirection: .down,
+                flagIndex: 0,
+                origin: CGPoint(x: 50, y: 70)
+            )
+
+            // Both directions should render without error (smoke test for the
+            // corrected positioning logic — the actual position correction is
+            // exercised visually; this ensures no crash/miscompile).
+            let upView = NotationFlagView(flag: flagUp, isActive: true)
+            SwiftUITestUtilities.assertViewWithEnvironment(upView, size: CGSize(width: 120, height: 120))
+
+            let downView = NotationFlagView(flag: flagDown, isActive: true)
+            SwiftUITestUtilities.assertViewWithEnvironment(downView, size: CGSize(width: 120, height: 120))
+        }
+    }
+
     @Test("Notation stem view renders in both active and inactive states")
     func testNotationStemViewRendersInBothStates() async throws {
         try await TestSetup.withTestSetup {

--- a/docs/superpowers/plans/2026-05-01-gameplay-note-rendering.md
+++ b/docs/superpowers/plans/2026-05-01-gameplay-note-rendering.md
@@ -1,0 +1,1351 @@
+# Gameplay Note Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace view-inferred gameplay note geometry with a cached notation layout engine that improves dense-note readability, ledger lines, stem direction, beams, and lower/upper drum voice separation.
+
+**Architecture:** Add a pure layout model in `Virgo/layout/` that turns SwiftData `Note` values into render primitives. `GameplayViewModel` caches the layout during setup, and `GameplaySheetMusicView` paints primitives instead of recalculating notation rules inside views.
+
+**Tech Stack:** SwiftUI, SwiftData model types, Swift Testing, existing Xcode file-system-synchronized groups.
+
+---
+
+## File Structure
+
+- Create `Virgo/layout/NotationLayout.swift`: value types for layout input, style, render primitives, voice, stem direction, and rendered geometry.
+- Create `Virgo/layout/NotationLayoutEngine.swift`: pure engine for adaptive horizontal spacing, row wrapping, voice splitting, ledger lines, stems, and beams.
+- Create `Virgo/views/NotationPrimitiveViews.swift`: small SwiftUI primitive painters for rendered noteheads, stems, beams, ledger lines, and measure bars.
+- Modify `Virgo/viewmodels/GameplayViewModel.swift`: cache `NotationLayout`, expose lookup maps for active beat and progress indicator, and call `NotationLayoutEngine`.
+- Modify `Virgo/views/subviews/GameplaySheetMusicView.swift`: render primitives from cached layout and keep existing staff/clef/time-signature layers.
+- Modify `Virgo/layout/gameplay.swift`: keep existing constants, add only compatibility helpers if needed.
+- Add `VirgoTests/NotationLayoutEngineTests.swift`: pure layout tests using Swift Testing.
+- Existing `DrumBeatView.swift`, `BeamView.swift`, and `BeamGroupingLogic.swift` stay in the tree during migration. Remove or shrink them only after all rendering paths no longer depend on them.
+
+Xcode uses `PBXFileSystemSynchronizedRootGroup`, so new Swift files under `Virgo/` and `VirgoTests/` should be picked up without editing `Virgo.xcodeproj/project.pbxproj`.
+
+---
+
+### Task 1: Add Layout Primitive Model
+
+**Files:**
+- Create: `Virgo/layout/NotationLayout.swift`
+- Create: `VirgoTests/NotationLayoutEngineTests.swift`
+
+- [ ] **Step 1: Write the failing primitive-model tests**
+
+Create `VirgoTests/NotationLayoutEngineTests.swift` with:
+
+```swift
+import Testing
+import SwiftUI
+@testable import Virgo
+
+@Suite("Notation Layout Engine Tests")
+struct NotationLayoutEngineTests {
+    @Test("default gameplay style preserves current low-density quarter spacing")
+    func defaultStylePreservesQuarterSpacing() {
+        let style = NotationLayoutStyle.gameplayDefault
+
+        #expect(style.minimumNoteColumnGap == 28)
+        #expect(style.minimumQuarterBeatGap == GameplayLayout.uniformSpacing)
+        #expect(style.noteHeadWidth == GameplayLayout.beatColumnWidth)
+    }
+
+    @Test("drum types map to gameplay voices")
+    func drumTypesMapToGameplayVoices() {
+        #expect(NotationVoice.voice(for: .kick) == .lower)
+        #expect(NotationVoice.voice(for: .hiHatPedal) == .lower)
+        #expect(NotationVoice.voice(for: .snare) == .upper)
+        #expect(NotationVoice.voice(for: .crash) == .upper)
+    }
+
+    @Test("layout input accepts notes and time signature")
+    func layoutInputAcceptsNotesAndTimeSignature() {
+        let note = Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0)
+        let input = NotationLayoutInput(notes: [note], timeSignature: .fourFour)
+
+        #expect(input.notes.count == 1)
+        #expect(input.timeSignature.beatsPerMeasure == 4)
+        #expect(input.style.minimumNoteColumnGap == 28)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/NotationLayoutEngineTests test
+```
+
+Expected: FAIL because `NotationLayoutStyle`, `NotationVoice`, and `NotationLayoutInput` are undefined.
+
+- [ ] **Step 3: Add the primitive model**
+
+Create `Virgo/layout/NotationLayout.swift`:
+
+```swift
+import CoreGraphics
+import Foundation
+
+struct NotationLayoutInput {
+    let notes: [Note]
+    let timeSignature: TimeSignature
+    let style: NotationLayoutStyle
+
+    init(
+        notes: [Note],
+        timeSignature: TimeSignature,
+        style: NotationLayoutStyle = .gameplayDefault
+    ) {
+        self.notes = notes
+        self.timeSignature = timeSignature
+        self.style = style
+    }
+}
+
+struct NotationLayoutStyle: Equatable {
+    let minimumNoteColumnGap: CGFloat
+    let minimumQuarterBeatGap: CGFloat
+    let measurePadding: CGFloat
+    let rowWidth: CGFloat
+    let staffLineSpacing: CGFloat
+    let noteHeadWidth: CGFloat
+    let noteHeadHeight: CGFloat
+    let stemLength: CGFloat
+    let stemWidth: CGFloat
+    let stemXInset: CGFloat
+    let beamThickness: CGFloat
+    let beamLevelSpacing: CGFloat
+    let ledgerLineOverhang: CGFloat
+    let voiceCollisionOffset: CGFloat
+
+    static let gameplayDefault = NotationLayoutStyle(
+        minimumNoteColumnGap: 28,
+        minimumQuarterBeatGap: GameplayLayout.uniformSpacing,
+        measurePadding: 16,
+        rowWidth: GameplayLayout.maxRowWidth,
+        staffLineSpacing: GameplayLayout.staffLineSpacing,
+        noteHeadWidth: GameplayLayout.beatColumnWidth,
+        noteHeadHeight: GameplayLayout.drumSymbolFontSize,
+        stemLength: GameplayLayout.stemHeight,
+        stemWidth: GameplayLayout.stemWidth,
+        stemXInset: GameplayLayout.stemXOffset,
+        beamThickness: 4,
+        beamLevelSpacing: GameplayLayout.beamLevelSpacing,
+        ledgerLineOverhang: 6,
+        voiceCollisionOffset: 8
+    )
+}
+
+enum NotationVoice: String, Hashable {
+    case upper
+    case lower
+
+    static func voice(for drumType: DrumType) -> NotationVoice {
+        switch drumType {
+        case .kick, .hiHatPedal:
+            return .lower
+        case .crash, .hiHat, .tom1, .snare, .tom2, .tom3, .ride, .cowbell:
+            return .upper
+        }
+    }
+}
+
+enum StemDirection: String, Hashable {
+    case up
+    case down
+}
+
+struct NotationLayout {
+    var measures: [RenderedMeasure]
+    var noteHeads: [RenderedNoteHead]
+    var stems: [RenderedStem]
+    var beams: [RenderedBeam]
+    var ledgerLines: [RenderedLedgerLine]
+    var measureBars: [RenderedMeasureBar]
+    var beatLookup: [UInt64: CGPoint]
+    var totalHeight: CGFloat
+}
+
+struct RenderedMeasure: Identifiable, Hashable {
+    let id: Int
+    let measureIndex: Int
+    let row: Int
+    let xOffset: CGFloat
+    let width: CGFloat
+}
+
+struct RenderedNoteHead: Identifiable, Hashable {
+    let id: UInt64
+    let sourceNoteID: ObjectIdentifier
+    let drumType: DrumType
+    let voice: NotationVoice
+    let timePosition: Double
+    let measureIndex: Int
+    let row: Int
+    let position: CGPoint
+    let staffStep: Int
+    let stemDirection: StemDirection
+    let interval: NoteInterval
+}
+
+struct RenderedStem: Identifiable, Hashable {
+    let id: String
+    let noteHeadIDs: [UInt64]
+    let direction: StemDirection
+    let start: CGPoint
+    let end: CGPoint
+}
+
+struct RenderedBeam: Identifiable, Hashable {
+    let id: String
+    let noteHeadIDs: [UInt64]
+    let direction: StemDirection
+    let level: Int
+    let start: CGPoint
+    let end: CGPoint
+    let thickness: CGFloat
+}
+
+struct RenderedLedgerLine: Identifiable, Hashable {
+    let id: String
+    let row: Int
+    let start: CGPoint
+    let end: CGPoint
+}
+
+struct RenderedMeasureBar: Identifiable, Hashable {
+    let id: String
+    let row: Int
+    let x: CGFloat
+    let isFinal: Bool
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/NotationLayoutEngineTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Virgo/layout/NotationLayout.swift VirgoTests/NotationLayoutEngineTests.swift
+git commit -m "Add notation layout primitives"
+```
+
+---
+
+### Task 2: Implement Adaptive Measure Spacing
+
+**Files:**
+- Create: `Virgo/layout/NotationLayoutEngine.swift`
+- Modify: `VirgoTests/NotationLayoutEngineTests.swift`
+
+- [ ] **Step 1: Add failing spacing tests**
+
+Append these tests inside `NotationLayoutEngineTests`:
+
+```swift
+@Test("sixteenth notes expand measure width for readable spacing")
+func sixteenthNotesExpandMeasureWidthForReadableSpacing() {
+    let notes = (0..<16).map { index in
+        Note(
+            interval: .sixteenth,
+            noteType: .snare,
+            measureNumber: 1,
+            measureOffset: Double(index) / 16.0
+        )
+    }
+    let layout = NotationLayoutEngine().layout(
+        input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+    )
+    let sortedX = layout.noteHeads.map(\.position.x).sorted()
+
+    for index in 1..<sortedX.count {
+        #expect(sortedX[index] - sortedX[index - 1] >= 28)
+    }
+    #expect(layout.measures.first?.width ?? 0 > GameplayLayout.measureWidth(for: .fourFour))
+}
+
+@Test("quarter notes keep existing spacing")
+func quarterNotesKeepExistingSpacing() {
+    let notes = (0..<4).map { index in
+        Note(
+            interval: .quarter,
+            noteType: .snare,
+            measureNumber: 1,
+            measureOffset: Double(index) / 4.0
+        )
+    }
+    let layout = NotationLayoutEngine().layout(
+        input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+    )
+    let sortedX = layout.noteHeads.map(\.position.x).sorted()
+
+    #expect(sortedX.count == 4)
+    #expect(abs((sortedX[1] - sortedX[0]) - GameplayLayout.uniformSpacing) < 0.001)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/NotationLayoutEngineTests test
+```
+
+Expected: FAIL because `NotationLayoutEngine` is undefined.
+
+- [ ] **Step 3: Implement adaptive measure placement**
+
+Create `Virgo/layout/NotationLayoutEngine.swift`:
+
+```swift
+import CoreGraphics
+import Foundation
+
+struct NotationLayoutEngine {
+    func layout(input: NotationLayoutInput) -> NotationLayout {
+        let normalizedNotes = input.notes.sorted {
+            MeasureUtils.timePosition(measureNumber: $0.measureNumber, measureOffset: $0.measureOffset)
+            < MeasureUtils.timePosition(measureNumber: $1.measureNumber, measureOffset: $1.measureOffset)
+        }
+        let totalMeasures = max(1, (normalizedNotes.map(\.measureNumber).max() ?? 1))
+        let measures = buildMeasures(totalMeasures: totalMeasures, notes: normalizedNotes, input: input)
+        let noteHeads = buildNoteHeads(notes: normalizedNotes, measures: measures, input: input)
+        let measureBars = buildMeasureBars(measures: measures)
+        let beatLookup = Dictionary(uniqueKeysWithValues: noteHeads.map { ($0.id, $0.position) })
+        let totalHeight = GameplayLayout.totalHeight(
+            for: measures.map {
+                GameplayLayout.MeasurePosition(row: $0.row, xOffset: $0.xOffset, measureIndex: $0.measureIndex)
+            }
+        )
+
+        return NotationLayout(
+            measures: measures,
+            noteHeads: noteHeads,
+            stems: [],
+            beams: [],
+            ledgerLines: [],
+            measureBars: measureBars,
+            beatLookup: beatLookup,
+            totalHeight: totalHeight
+        )
+    }
+
+    private func buildMeasures(
+        totalMeasures: Int,
+        notes: [Note],
+        input: NotationLayoutInput
+    ) -> [RenderedMeasure] {
+        var result: [RenderedMeasure] = []
+        var currentRow = 0
+        var currentX = GameplayLayout.leftMargin
+
+        for measureIndex in 0..<totalMeasures {
+            let width = measureWidth(measureIndex: measureIndex, notes: notes, input: input)
+            if currentX + width > input.style.rowWidth, measureIndex > 0 {
+                currentRow += 1
+                currentX = GameplayLayout.leftMargin
+            }
+            result.append(
+                RenderedMeasure(
+                    id: measureIndex,
+                    measureIndex: measureIndex,
+                    row: currentRow,
+                    xOffset: currentX,
+                    width: width
+                )
+            )
+            currentX += width + GameplayLayout.measureSpacing
+        }
+
+        return result
+    }
+
+    private func measureWidth(
+        measureIndex: Int,
+        notes: [Note],
+        input: NotationLayoutInput
+    ) -> CGFloat {
+        let measureNumber = MeasureUtils.toOneBasedNumber(measureIndex)
+        let offsets = notes
+            .filter { $0.measureNumber == measureNumber }
+            .map(\.measureOffset)
+            .sorted()
+
+        guard offsets.count > 1 else {
+            return GameplayLayout.measureWidth(for: input.timeSignature)
+        }
+
+        let smallestGap = zip(offsets.dropFirst(), offsets)
+            .map { later, earlier in later - earlier }
+            .min() ?? 0.25
+        let beatGap = max(
+            input.style.minimumQuarterBeatGap,
+            input.style.minimumNoteColumnGap / CGFloat(max(smallestGap * Double(input.timeSignature.beatsPerMeasure), 0.001))
+        )
+        return GameplayLayout.barLineWidth
+            + input.style.measurePadding
+            + CGFloat(input.timeSignature.beatsPerMeasure) * beatGap
+            + input.style.measurePadding
+    }
+
+    private func buildNoteHeads(
+        notes: [Note],
+        measures: [RenderedMeasure],
+        input: NotationLayoutInput
+    ) -> [RenderedNoteHead] {
+        var nextID: UInt64 = 0
+        let measuresByIndex = Dictionary(uniqueKeysWithValues: measures.map { ($0.measureIndex, $0) })
+
+        return notes.compactMap { note in
+            guard let drumType = DrumType.from(noteType: note.noteType) else { return nil }
+            let measureIndex = MeasureUtils.toZeroBasedIndex(note.measureNumber)
+            guard let measure = measuresByIndex[measureIndex] else { return nil }
+            let beatGap = beatGap(for: measure, input: input)
+            let x = measure.xOffset + GameplayLayout.barLineWidth + input.style.measurePadding
+                + CGFloat(note.measureOffset * Double(input.timeSignature.beatsPerMeasure)) * beatGap
+            let y = GameplayLayout.StaffLinePosition.line1.absoluteY(for: measure.row)
+                + drumType.notePosition.yOffset
+            let id = nextID
+            nextID += 1
+
+            return RenderedNoteHead(
+                id: id,
+                sourceNoteID: ObjectIdentifier(note),
+                drumType: drumType,
+                voice: NotationVoice.voice(for: drumType),
+                timePosition: MeasureUtils.timePosition(
+                    measureNumber: note.measureNumber,
+                    measureOffset: note.measureOffset
+                ),
+                measureIndex: measureIndex,
+                row: measure.row,
+                position: CGPoint(x: x, y: y),
+                staffStep: staffStep(for: drumType.notePosition),
+                stemDirection: .up,
+                interval: note.interval
+            )
+        }
+    }
+
+    private func beatGap(for measure: RenderedMeasure, input: NotationLayoutInput) -> CGFloat {
+        let drawableWidth = measure.width - GameplayLayout.barLineWidth - input.style.measurePadding * 2
+        return drawableWidth / CGFloat(input.timeSignature.beatsPerMeasure)
+    }
+
+    private func staffStep(for position: GameplayLayout.NotePosition) -> Int {
+        Int((position.yOffset / (GameplayLayout.staffLineSpacing / 2)).rounded())
+    }
+
+    private func buildMeasureBars(measures: [RenderedMeasure]) -> [RenderedMeasureBar] {
+        measures.flatMap { measure in
+            [
+                RenderedMeasureBar(
+                    id: "bar_\(measure.measureIndex)",
+                    row: measure.row,
+                    x: measure.xOffset,
+                    isFinal: false
+                ),
+                RenderedMeasureBar(
+                    id: "bar_\(measure.measureIndex)_end",
+                    row: measure.row,
+                    x: measure.xOffset + measure.width,
+                    isFinal: measure.measureIndex == measures.last?.measureIndex
+                )
+            ]
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/NotationLayoutEngineTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Virgo/layout/NotationLayoutEngine.swift VirgoTests/NotationLayoutEngineTests.swift
+git commit -m "Add adaptive notation spacing"
+```
+
+---
+
+### Task 3: Add Ledger Lines and Gameplay Voices
+
+**Files:**
+- Modify: `Virgo/layout/NotationLayoutEngine.swift`
+- Modify: `VirgoTests/NotationLayoutEngineTests.swift`
+
+- [ ] **Step 1: Add failing ledger and voice tests**
+
+Append:
+
+```swift
+@Test("above-staff crash emits ledger line")
+func aboveStaffCrashEmitsLedgerLine() {
+    let note = Note(interval: .quarter, noteType: .crash, measureNumber: 1, measureOffset: 0)
+    let layout = NotationLayoutEngine().layout(
+        input: NotationLayoutInput(notes: [note], timeSignature: .fourFour)
+    )
+
+    #expect(layout.ledgerLines.count >= 1)
+    #expect(layout.ledgerLines.allSatisfy { $0.end.x > $0.start.x })
+}
+
+@Test("kick and snare at same time get separate voices and readable x offsets")
+func kickAndSnareAtSameTimeGetSeparateVoices() {
+    let notes = [
+        Note(interval: .eighth, noteType: .bass, measureNumber: 1, measureOffset: 0),
+        Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0)
+    ]
+    let layout = NotationLayoutEngine().layout(
+        input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+    )
+
+    let lower = layout.noteHeads.first { $0.voice == .lower }
+    let upper = layout.noteHeads.first { $0.voice == .upper }
+
+    #expect(lower != nil)
+    #expect(upper != nil)
+    #expect(abs((lower?.position.x ?? 0) - (upper?.position.x ?? 0)) >= 8)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/NotationLayoutEngineTests test
+```
+
+Expected: FAIL because ledger lines are empty and same-time voices have the same x position.
+
+- [ ] **Step 3: Implement ledger lines and voice offsets**
+
+In `NotationLayoutEngine.layout(input:)`, replace the `noteHeads` and return construction with:
+
+```swift
+let noteHeads = buildNoteHeads(notes: normalizedNotes, measures: measures, input: input)
+let ledgerLines = buildLedgerLines(noteHeads: noteHeads, style: input.style)
+let measureBars = buildMeasureBars(measures: measures)
+let beatLookup = Dictionary(uniqueKeysWithValues: noteHeads.map { ($0.id, $0.position) })
+```
+
+Set `ledgerLines: ledgerLines` in the returned `NotationLayout`.
+
+In `buildNoteHeads`, after calculating `x`, add voice collision offset:
+
+```swift
+let voice = NotationVoice.voice(for: drumType)
+let collidesAcrossVoices = notes.contains { candidate in
+    guard candidate !== note,
+          candidate.measureNumber == note.measureNumber,
+          abs(candidate.measureOffset - note.measureOffset) < 0.0001,
+          let candidateDrum = DrumType.from(noteType: candidate.noteType) else {
+        return false
+    }
+    return NotationVoice.voice(for: candidateDrum) != voice
+}
+let adjustedX = collidesAcrossVoices
+    ? x + (voice == .upper ? input.style.voiceCollisionOffset : -input.style.voiceCollisionOffset)
+    : x
+```
+
+Use `voice` and `adjustedX` in `RenderedNoteHead`.
+
+Add this helper to `NotationLayoutEngine`:
+
+```swift
+private func buildLedgerLines(
+    noteHeads: [RenderedNoteHead],
+    style: NotationLayoutStyle
+) -> [RenderedLedgerLine] {
+    noteHeads.flatMap { head -> [RenderedLedgerLine] in
+        let topStaffStep = -8
+        let bottomStaffStep = 0
+        let ledgerSteps: [Int]
+
+        if head.staffStep < topStaffStep {
+            ledgerSteps = stride(from: topStaffStep - 2, through: head.staffStep, by: -2).map { $0 }
+        } else if head.staffStep > bottomStaffStep {
+            ledgerSteps = stride(from: bottomStaffStep + 2, through: head.staffStep, by: 2).map { $0 }
+        } else {
+            ledgerSteps = []
+        }
+
+        return ledgerSteps.map { step in
+            let y = GameplayLayout.StaffLinePosition.line1.absoluteY(for: head.row)
+                + CGFloat(step) * (style.staffLineSpacing / 2)
+            let halfWidth = style.noteHeadWidth / 2 + style.ledgerLineOverhang
+            return RenderedLedgerLine(
+                id: "ledger_\(head.id)_\(step)",
+                row: head.row,
+                start: CGPoint(x: head.position.x - halfWidth, y: y),
+                end: CGPoint(x: head.position.x + halfWidth, y: y)
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/NotationLayoutEngineTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Virgo/layout/NotationLayoutEngine.swift VirgoTests/NotationLayoutEngineTests.swift
+git commit -m "Add notation ledger lines and voices"
+```
+
+---
+
+### Task 4: Add Stem Direction and Beam Primitives
+
+**Files:**
+- Modify: `Virgo/layout/NotationLayoutEngine.swift`
+- Modify: `VirgoTests/NotationLayoutEngineTests.swift`
+
+- [ ] **Step 1: Add failing stem and beam tests**
+
+Append:
+
+```swift
+@Test("high crash stem points down")
+func highCrashStemPointsDown() {
+    let note = Note(interval: .eighth, noteType: .crash, measureNumber: 1, measureOffset: 0)
+    let layout = NotationLayoutEngine().layout(
+        input: NotationLayoutInput(notes: [note], timeSignature: .fourFour)
+    )
+
+    #expect(layout.noteHeads.first?.stemDirection == .down)
+    #expect(layout.stems.first?.direction == .down)
+}
+
+@Test("consecutive sixteenths create two beam levels")
+func consecutiveSixteenthsCreateTwoBeamLevels() {
+    let notes = (0..<4).map { index in
+        Note(
+            interval: .sixteenth,
+            noteType: .snare,
+            measureNumber: 1,
+            measureOffset: Double(index) / 16.0
+        )
+    }
+    let layout = NotationLayoutEngine().layout(
+        input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+    )
+
+    #expect(layout.beams.contains { $0.level == 0 })
+    #expect(layout.beams.contains { $0.level == 1 })
+}
+
+@Test("beams do not cross measure boundaries")
+func beamsDoNotCrossMeasureBoundaries() {
+    let notes = [
+        Note(interval: .eighth, noteType: .snare, measureNumber: 1, measureOffset: 0.75),
+        Note(interval: .eighth, noteType: .snare, measureNumber: 2, measureOffset: 0)
+    ]
+    let layout = NotationLayoutEngine().layout(
+        input: NotationLayoutInput(notes: notes, timeSignature: .fourFour)
+    )
+
+    #expect(layout.beams.isEmpty)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/NotationLayoutEngineTests test
+```
+
+Expected: FAIL because stems and beams are not emitted.
+
+- [ ] **Step 3: Implement stem direction, stems, and beams**
+
+In `buildNoteHeads`, compute direction before constructing `RenderedNoteHead`:
+
+```swift
+let direction = stemDirection(for: drumType, voice: voice)
+```
+
+Use `stemDirection: direction`.
+
+Add helpers:
+
+```swift
+private func stemDirection(for drumType: DrumType, voice: NotationVoice) -> StemDirection {
+    if voice == .lower {
+        return .down
+    }
+
+    switch drumType.notePosition {
+    case .aboveLine9, .aboveLine8, .aboveLine7, .aboveLine6, .aboveLine5, .line5:
+        return .down
+    case .spaceBetween4And5, .line4, .spaceBetween3And4, .line3,
+         .spaceBetween2And3, .line2, .spaceBetween1And2, .line1,
+         .spaceBetweenLine1AndBelow, .belowLine1, .belowLine2, .belowLine3,
+         .belowLine4, .belowLine5, .belowLine6:
+        return .up
+    }
+}
+
+private func buildStems(noteHeads: [RenderedNoteHead], style: NotationLayoutStyle) -> [RenderedStem] {
+    noteHeads
+        .filter { $0.interval.needsStem }
+        .map { head in
+            let x = head.position.x + (head.stemDirection == .up ? style.stemXInset : -style.stemXInset)
+            let endY = head.stemDirection == .up
+                ? head.position.y - style.stemLength
+                : head.position.y + style.stemLength
+            return RenderedStem(
+                id: "stem_\(head.id)",
+                noteHeadIDs: [head.id],
+                direction: head.stemDirection,
+                start: CGPoint(x: x, y: head.position.y),
+                end: CGPoint(x: x, y: endY)
+            )
+        }
+}
+
+private func buildBeams(noteHeads: [RenderedNoteHead], style: NotationLayoutStyle) -> [RenderedBeam] {
+    let beamableHeads = noteHeads
+        .filter { $0.interval.needsFlag }
+        .sorted { $0.timePosition < $1.timePosition }
+    let grouped = Dictionary(grouping: beamableHeads) { head in
+        "\(head.measureIndex)_\(head.row)_\(head.voice.rawValue)_\(head.stemDirection.rawValue)"
+    }
+
+    return grouped.values.flatMap { heads in
+        let sorted = heads.sorted { $0.timePosition < $1.timePosition }
+        guard sorted.count >= 2 else { return [RenderedBeam]() }
+
+        var beams: [RenderedBeam] = []
+        let maxLevel = sorted.map(\.interval.flagCount).max() ?? 0
+        for level in 0..<maxLevel {
+            let levelHeads = sorted.filter { $0.interval.flagCount > level }
+            guard levelHeads.count >= 2,
+                  let first = levelHeads.first,
+                  let last = levelHeads.last else { continue }
+            let yOffset = first.stemDirection == .up
+                ? -style.stemLength - CGFloat(level) * style.beamLevelSpacing
+                : style.stemLength + CGFloat(level) * style.beamLevelSpacing
+            beams.append(
+                RenderedBeam(
+                    id: "beam_\(first.id)_\(last.id)_\(level)",
+                    noteHeadIDs: levelHeads.map(\.id),
+                    direction: first.stemDirection,
+                    level: level,
+                    start: CGPoint(x: first.position.x, y: first.position.y + yOffset),
+                    end: CGPoint(x: last.position.x, y: last.position.y + yOffset),
+                    thickness: style.beamThickness
+                )
+            )
+        }
+        return beams
+    }
+}
+```
+
+In `layout(input:)`, compute stems and beams after noteheads:
+
+```swift
+let stems = buildStems(noteHeads: noteHeads, style: input.style)
+let beams = buildBeams(noteHeads: noteHeads, style: input.style)
+```
+
+Set `stems: stems` and `beams: beams` in the returned `NotationLayout`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/NotationLayoutEngineTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Virgo/layout/NotationLayoutEngine.swift VirgoTests/NotationLayoutEngineTests.swift
+git commit -m "Add notation stems and beams"
+```
+
+---
+
+### Task 5: Integrate Layout Cache Into GameplayViewModel
+
+**Files:**
+- Modify: `Virgo/viewmodels/GameplayViewModel.swift`
+- Modify: `VirgoTests/GameplayViewModelTests.swift`
+
+- [ ] **Step 1: Add failing view-model integration test**
+
+Append to `VirgoTests/GameplayViewModelTests.swift`:
+
+```swift
+@Test("setupGameplay caches notation layout")
+@MainActor
+func testSetupGameplayCachesNotationLayout() async throws {
+    let container = TestContainer.isolatedContainer(for: "testSetupGameplayCachesNotationLayout")
+    let song = Song(title: "Layout Song", artist: "Artist", bpm: 120, duration: "0:04")
+    let chart = Chart(difficulty: .medium, level: 20, song: song)
+    chart.notes = [
+        Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0),
+        Note(interval: .sixteenth, noteType: .bass, measureNumber: 1, measureOffset: 0)
+    ]
+    container.context.insert(song)
+    container.context.insert(chart)
+    try container.context.save()
+
+    let viewModel = GameplayViewModel(chart: chart, metronome: MetronomeEngine())
+    await viewModel.loadChartData()
+    viewModel.setupGameplay(loadPersistedSpeed: false)
+
+    #expect(viewModel.cachedNotationLayout.noteHeads.count == 2)
+    #expect(viewModel.cachedNotationLayout.ledgerLines.count >= 0)
+    #expect(!viewModel.cachedNotationBeatPositions.isEmpty)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/GameplayViewModelTests/testSetupGameplayCachesNotationLayout test
+```
+
+Expected: FAIL because `cachedNotationLayout` and `cachedNotationBeatPositions` are undefined.
+
+- [ ] **Step 3: Add layout cache properties and compute them**
+
+In `GameplayViewModel`, add near cached layout data:
+
+```swift
+private(set) var cachedNotationLayout = NotationLayout.empty
+private(set) var cachedNotationBeatPositions: [UInt64: (x: Double, y: Double)] = [:]
+```
+
+Add `empty` to `NotationLayout` in `NotationLayout.swift`:
+
+```swift
+extension NotationLayout {
+    static let empty = NotationLayout(
+        measures: [],
+        noteHeads: [],
+        stems: [],
+        beams: [],
+        ledgerLines: [],
+        measureBars: [],
+        beatLookup: [:],
+        totalHeight: 0
+    )
+}
+```
+
+In `GameplayViewModel.computeCachedLayoutData()`, after `measurePositionMap` setup and before `cacheBeatPositions()`, add:
+
+```swift
+cacheNotationLayout()
+```
+
+Add this method:
+
+```swift
+func cacheNotationLayout() {
+    guard let track = track else {
+        cachedNotationLayout = .empty
+        cachedNotationBeatPositions = [:]
+        return
+    }
+
+    let input = NotationLayoutInput(notes: cachedNotes, timeSignature: track.timeSignature)
+    cachedNotationLayout = NotationLayoutEngine().layout(input: input)
+    cachedNotationBeatPositions = Dictionary(
+        uniqueKeysWithValues: cachedNotationLayout.beatLookup.map {
+            ($0.key, (x: Double($0.value.x), y: Double($0.value.y)))
+        }
+    )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/GameplayViewModelTests/testSetupGameplayCachesNotationLayout test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run notation layout tests**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/NotationLayoutEngineTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Virgo/layout/NotationLayout.swift Virgo/viewmodels/GameplayViewModel.swift VirgoTests/GameplayViewModelTests.swift
+git commit -m "Cache notation layout for gameplay"
+```
+
+---
+
+### Task 6: Render Notation Primitives in SwiftUI
+
+**Files:**
+- Create: `Virgo/views/NotationPrimitiveViews.swift`
+- Modify: `Virgo/views/subviews/GameplaySheetMusicView.swift`
+- Modify: `VirgoTests/SwiftUIRenderingCoverageTests.swift`
+
+- [ ] **Step 1: Add primitive view rendering coverage**
+
+Append to `VirgoTests/SwiftUIRenderingCoverageTests.swift`:
+
+```swift
+@Test("notation primitive views render expected symbols")
+@MainActor
+func testNotationPrimitiveViewsRenderExpectedSymbols() throws {
+    let head = RenderedNoteHead(
+        id: 1,
+        sourceNoteID: ObjectIdentifier(Note(interval: .quarter, noteType: .snare, measureNumber: 1, measureOffset: 0)),
+        drumType: .snare,
+        voice: .upper,
+        timePosition: 0,
+        measureIndex: 0,
+        row: 0,
+        position: CGPoint(x: 100, y: 100),
+        staffStep: -4,
+        stemDirection: .up,
+        interval: .quarter
+    )
+
+    SwiftUITestUtilities.assertView(
+        NotationNoteHeadView(noteHead: head, isActive: false),
+        containsStrings: [DrumType.snare.symbol]
+    )
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/SwiftUIRenderingCoverageTests/testNotationPrimitiveViewsRenderExpectedSymbols test
+```
+
+Expected: FAIL because `NotationNoteHeadView` is undefined.
+
+- [ ] **Step 3: Add primitive views**
+
+Create `Virgo/views/NotationPrimitiveViews.swift`:
+
+```swift
+import SwiftUI
+
+struct NotationNoteHeadView: View {
+    let noteHead: RenderedNoteHead
+    let isActive: Bool
+
+    var body: some View {
+        Text(noteHead.drumType.symbol)
+            .font(.system(size: GameplayLayout.drumSymbolFontSize, weight: .bold))
+            .foregroundColor(isActive ? .yellow : .white)
+            .position(noteHead.position)
+    }
+}
+
+struct NotationStemView: View {
+    let stem: RenderedStem
+    let isActive: Bool
+
+    var body: some View {
+        Path { path in
+            path.move(to: stem.start)
+            path.addLine(to: stem.end)
+        }
+        .stroke(isActive ? Color.yellow : Color.white, lineWidth: GameplayLayout.stemWidth)
+    }
+}
+
+struct NotationBeamView: View {
+    let beam: RenderedBeam
+    let isActive: Bool
+
+    var body: some View {
+        Path { path in
+            path.move(to: beam.start)
+            path.addLine(to: beam.end)
+        }
+        .stroke(isActive ? Color.yellow : Color.white, lineWidth: beam.thickness)
+    }
+}
+
+struct NotationLedgerLineView: View {
+    let ledgerLine: RenderedLedgerLine
+
+    var body: some View {
+        Path { path in
+            path.move(to: ledgerLine.start)
+            path.addLine(to: ledgerLine.end)
+        }
+        .stroke(Color.white, lineWidth: 2)
+    }
+}
+
+struct NotationMeasureBarView: View {
+    let measureBar: RenderedMeasureBar
+
+    var body: some View {
+        let centerY = GameplayLayout.StaffLinePosition.line3.absoluteY(for: measureBar.row)
+
+        if measureBar.isFinal {
+            HStack(spacing: GameplayLayout.doubleBarLineSpacing) {
+                Rectangle()
+                    .frame(width: GameplayLayout.doubleBarLineWidths.thin, height: GameplayLayout.staffHeight)
+                Rectangle()
+                    .frame(width: GameplayLayout.doubleBarLineWidths.thick, height: GameplayLayout.staffHeight)
+            }
+            .foregroundColor(.white)
+            .position(x: measureBar.x, y: centerY)
+        } else {
+            Rectangle()
+                .frame(width: GameplayLayout.barLineWidth, height: GameplayLayout.staffHeight)
+                .foregroundColor(.white.opacity(0.8))
+                .position(x: measureBar.x, y: centerY)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Replace note/bar rendering path**
+
+In `GameplaySheetMusicView.barLinesView`, prefer notation bars:
+
+```swift
+if !viewModel.cachedNotationLayout.measureBars.isEmpty {
+    ForEach(viewModel.cachedNotationLayout.measureBars) { measureBar in
+        NotationMeasureBarView(measureBar: measureBar)
+    }
+} else {
+    existingBarLineFallback
+}
+```
+
+Refactor the existing bar-line body into `existingBarLineFallback` as a local `Group`.
+
+In `drumNotationView`, replace beam and `DrumBeatView` loops with:
+
+```swift
+ZStack {
+    ForEach(viewModel.cachedNotationLayout.ledgerLines) { ledgerLine in
+        NotationLedgerLineView(ledgerLine: ledgerLine)
+    }
+
+    ForEach(viewModel.cachedNotationLayout.beams) { beam in
+        let isActive = !Set(beam.noteHeadIDs).isDisjoint(with: viewModel.activeNotationNoteHeadIDs)
+        NotationBeamView(beam: beam, isActive: isActive)
+    }
+
+    ForEach(viewModel.cachedNotationLayout.stems) { stem in
+        let isActive = !Set(stem.noteHeadIDs).isDisjoint(with: viewModel.activeNotationNoteHeadIDs)
+        NotationStemView(stem: stem, isActive: isActive)
+    }
+
+    ForEach(viewModel.cachedNotationLayout.noteHeads) { noteHead in
+        NotationNoteHeadView(
+            noteHead: noteHead,
+            isActive: viewModel.activeNotationNoteHeadIDs.contains(noteHead.id)
+        )
+    }
+}
+```
+
+Add to `GameplayViewModel`:
+
+```swift
+var activeNotationNoteHeadIDs: Set<UInt64> {
+    guard let activeBeatId else { return [] }
+    return [activeBeatId]
+}
+```
+
+This preserves current single-active-column behavior initially. Later tasks can map all noteheads at the active time position.
+
+- [ ] **Step 5: Run rendering and layout tests**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/SwiftUIRenderingCoverageTests/testNotationPrimitiveViewsRenderExpectedSymbols \
+  -only-testing:VirgoTests/NotationLayoutEngineTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Virgo/views/NotationPrimitiveViews.swift Virgo/views/subviews/GameplaySheetMusicView.swift Virgo/viewmodels/GameplayViewModel.swift VirgoTests/SwiftUIRenderingCoverageTests.swift
+git commit -m "Render gameplay notation primitives"
+```
+
+---
+
+### Task 7: Align Active Highlight and Purple Progress Bar
+
+**Files:**
+- Modify: `Virgo/layout/NotationLayout.swift`
+- Modify: `Virgo/viewmodels/GameplayViewModel.swift`
+- Modify: `VirgoTests/GameplayViewModelTests.swift`
+
+- [ ] **Step 1: Add failing active-position test**
+
+Append to `VirgoTests/GameplayViewModelTests.swift`:
+
+```swift
+@Test("notation active lookup finds all noteheads at current time")
+@MainActor
+func testNotationActiveLookupFindsAllNoteheadsAtCurrentTime() async throws {
+    let container = TestContainer.isolatedContainer(for: "testNotationActiveLookupFindsAllNoteheadsAtCurrentTime")
+    let song = Song(title: "Active Layout", artist: "Artist", bpm: 120, duration: "0:04")
+    let chart = Chart(difficulty: .medium, level: 20, song: song)
+    chart.notes = [
+        Note(interval: .sixteenth, noteType: .snare, measureNumber: 1, measureOffset: 0),
+        Note(interval: .sixteenth, noteType: .bass, measureNumber: 1, measureOffset: 0)
+    ]
+    container.context.insert(song)
+    container.context.insert(chart)
+    try container.context.save()
+
+    let viewModel = GameplayViewModel(chart: chart, metronome: MetronomeEngine())
+    await viewModel.loadChartData()
+    viewModel.setupGameplay(loadPersistedSpeed: false)
+    viewModel.updateActiveNotation(forTimePosition: 0)
+
+    #expect(viewModel.activeNotationNoteHeadIDs.count == 2)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/GameplayViewModelTests/testNotationActiveLookupFindsAllNoteheadsAtCurrentTime test
+```
+
+Expected: FAIL because `updateActiveNotation(forTimePosition:)` is undefined or only one ID is active.
+
+- [ ] **Step 3: Add time-position lookup to `NotationLayout`**
+
+In `NotationLayout`, add:
+
+```swift
+var noteHeadIDsByTimePosition: [Int: Set<UInt64>]
+```
+
+Update `NotationLayout.empty` with:
+
+```swift
+noteHeadIDsByTimePosition: [:]
+```
+
+In `NotationLayoutEngine.layout(input:)`, build:
+
+```swift
+let noteHeadIDsByTimePosition = Dictionary(grouping: noteHeads) {
+    Int(($0.timePosition * 1_000_000).rounded())
+}.mapValues { Set($0.map(\.id)) }
+```
+
+Pass it into `NotationLayout`.
+
+- [ ] **Step 4: Add active notation state**
+
+In `GameplayViewModel`, replace computed `activeNotationNoteHeadIDs` with stored state:
+
+```swift
+private(set) var activeNotationNoteHeadIDs: Set<UInt64> = []
+
+func updateActiveNotation(forTimePosition timePosition: Double) {
+    let key = Int((timePosition * 1_000_000).rounded())
+    activeNotationNoteHeadIDs = cachedNotationLayout.noteHeadIDsByTimePosition[key] ?? []
+}
+```
+
+Where `activeBeatId` is updated in `updateVisualElementsFromMetronome()`, also call:
+
+```swift
+updateActiveNotation(forTimePosition: currentTimePosition)
+```
+
+Where playback is reset, add:
+
+```swift
+activeNotationNoteHeadIDs = []
+```
+
+- [ ] **Step 5: Run active-position test**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/GameplayViewModelTests/testNotationActiveLookupFindsAllNoteheadsAtCurrentTime test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run layout and gameplay view-model tests touched by this change**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' \
+  -only-testing:VirgoTests/NotationLayoutEngineTests \
+  -only-testing:VirgoTests/GameplayViewModelTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Virgo/layout/NotationLayout.swift Virgo/layout/NotationLayoutEngine.swift Virgo/viewmodels/GameplayViewModel.swift VirgoTests/GameplayViewModelTests.swift
+git commit -m "Align notation active highlighting"
+```
+
+---
+
+### Task 8: Full Verification and Cleanup
+
+**Files:**
+- Modify if needed: `Virgo/views/DrumBeatView.swift`
+- Modify if needed: `Virgo/views/BeamView.swift`
+- Modify if needed: `Virgo/utilities/BeamGroupingLogic.swift`
+- Modify if needed: `Virgo/viewmodels/GameplayViewModel.swift`
+
+- [ ] **Step 1: Search for old rendering dependencies**
+
+Run:
+
+```bash
+rg -n "cachedDrumBeats|cachedBeamGroups|beatToBeamGroupMap|DrumBeatView|BeamGroupView|BeamView" Virgo VirgoTests
+```
+
+Expected: Remaining references are either test-only, compatibility-only, or unrelated to the active gameplay rendering path.
+
+- [ ] **Step 2: Remove dead active rendering code if references are gone**
+
+If `DrumBeatView`, `BeamView`, or `BeamGroupingLogic` are unused by production code after the primitive rendering path, delete only the unused files and update tests that reference them. If tests still cover those types for compatibility, keep the files and add comments stating they are legacy fallback components.
+
+Use this comment if files are kept:
+
+```swift
+// Legacy notation renderer retained for compatibility tests while gameplay uses NotationLayoutEngine.
+```
+
+- [ ] **Step 3: Run unit tests in CI format**
+
+Run:
+
+```bash
+xcodebuild test \
+  -project Virgo.xcodeproj \
+  -scheme Virgo \
+  -destination 'platform=macOS' \
+  -configuration Debug \
+  -only-testing:VirgoTests \
+  ONLY_ACTIVE_ARCH=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  -enableCodeCoverage YES \
+  -destination-timeout 300 \
+  -derivedDataPath ./DerivedData
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run macOS build**
+
+Run:
+
+```bash
+xcodebuild -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' build
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit cleanup**
+
+If cleanup changed files:
+
+```bash
+git add Virgo VirgoTests
+git commit -m "Clean up legacy notation rendering path"
+```
+
+If cleanup changed nothing, do not create an empty commit.
+
+---
+
+## Self-Review
+
+- Spec coverage: adaptive spacing is covered by Task 2; ledger lines and voices by Task 3; stem direction and beams by Task 4; view-model caching by Task 5; SwiftUI rendering by Task 6; active highlighting/progress alignment by Task 7; verification/cleanup by Task 8.
+- Placeholder scan: the plan intentionally avoids deferred implementation placeholders. Follow-up decisions from the spec remain out of scope.
+- Type consistency: `NotationLayoutInput`, `NotationLayoutStyle`, `NotationVoice`, `StemDirection`, `NotationLayout`, and render primitive names are introduced in Task 1 and reused consistently in later tasks.

--- a/docs/superpowers/specs/2026-05-01-gameplay-note-rendering-design.md
+++ b/docs/superpowers/specs/2026-05-01-gameplay-note-rendering-design.md
@@ -1,0 +1,174 @@
+# Gameplay Note Rendering Design
+
+## Context
+
+Virgo's gameplay notation currently renders notes through a split set of responsibilities:
+
+- `GameplayViewModel` groups SwiftData `Note` values into `DrumBeat` values and caches x/y positions.
+- `GameplayLayout` provides fixed horizontal and vertical constants.
+- `DrumBeatView` decides notehead, stem, flag, and connector geometry while drawing.
+- `BeamView` draws flat beams independently from notehead/stem layout.
+
+This makes the renderer fragile because notation rules are inferred locally by SwiftUI views instead of being resolved once by a layout pass. The current symptoms are:
+
+- Sixteenth notes are visually too dense because a 4/4 measure uses fixed quarter-note spacing, which leaves only 12.5px between sixteenth-note columns.
+- Notes above or below the five staff lines do not receive ledger lines.
+- Mixed rhythms such as sixteenth snare plus eighth kick can collide because same-time grouping does not model visual voices.
+- Stem and beam direction is incorrect for high notes because stems/beams are effectively always drawn upward.
+
+The product priority is gameplay readability over strict sheet-music engraving. The renderer should still be music-aware, but it may expand spacing, separate voices, or simplify engraving if that produces a clearer playable chart.
+
+## Goals
+
+- Render dense drum charts clearly enough for gameplay, especially sixteenth-note passages.
+- Centralize notation layout decisions in one pure, testable layout engine.
+- Support ledger lines for notes outside the main five-line staff.
+- Support stem and beam direction decisions based on visual voice and note height.
+- Separate upper drum voices from lower kick/pedal voices when needed to prevent collisions.
+- Keep SwiftUI rendering fast by caching resolved geometry before playback.
+
+## Non-Goals
+
+- Full professional engraving fidelity.
+- Rest rendering, ties, tuplets, grace notes, or cross-staff notation.
+- Changing input timing, scoring, MIDI routing, or DTX parsing semantics.
+- Reworking the gameplay playback or metronome synchronization architecture.
+
+## Proposed Architecture
+
+Add a pure `NotationLayoutEngine` under `Virgo/layout/`. It converts raw notes and track metadata into render primitives that SwiftUI can paint without re-deciding notation rules.
+
+Inputs:
+
+- `[Note]`
+- `TimeSignature`
+- drum-to-staff-position map
+- `NotationLayoutStyle`
+
+Outputs:
+
+- `NotationLayout`
+- `RenderedMeasure`
+- `RenderedNoteHead`
+- `RenderedStem`
+- `RenderedBeam`
+- `RenderedLedgerLine`
+- `RenderedMeasureBar`
+
+`GameplayViewModel` should call the layout engine during setup and cache the resulting `NotationLayout`. `GameplaySheetMusicView` should render from this layout instead of directly iterating `cachedDrumBeats`, `cachedBeamGroups`, and `cachedBeatPositions`.
+
+The existing `DrumBeat` and `BeamGroup` types can be kept temporarily during migration, but the target state is for them to become internal implementation details or be replaced by layout primitives.
+
+## Layout Rules
+
+### Horizontal Spacing
+
+Measure width should be adaptive. The engine should inspect the smallest subdivision used in each measure and enforce a minimum readable column gap.
+
+Initial style constants:
+
+- Minimum note-column gap: 28px.
+- Minimum quarter-beat gap: keep the existing 50px when density is low.
+- Measure padding: preserve room for bar lines and visual breathing space.
+
+For a 4/4 measure with sixteenth notes, the measure should expand enough that adjacent sixteenth-note columns are at least the minimum column gap. This is more important than fitting more measures per row.
+
+### Gameplay Voices
+
+The engine should split notes into visual voices:
+
+- Lower voice: kick and hi-hat pedal.
+- Upper voice: snare, toms, cymbals, cowbell, hi-hat, ride.
+
+At the same time position, notes within a voice may share a stem when visually compatible. Notes across voices should be allowed to use separate stems and small x offsets when needed. This prevents kick/snare mixed rhythms from creating ambiguous columns.
+
+### Vertical Positioning
+
+All vertical geometry should use a single staff-step coordinate system, then convert to pixels in one place. This avoids mixing relative y offsets in the layout layer with absolute row positions in views.
+
+The initial implementation should use the current default `DrumType.notePosition` mapping. Integrating `DrumNotationSettingsManager` into gameplay rendering is a separate follow-up because the settings screen currently does not appear to feed gameplay notation.
+
+### Ledger Lines
+
+For every notehead outside the five staff lines, emit short horizontal ledger-line primitives for each crossed staff line.
+
+Rules:
+
+- Ledger width should be wider than the notehead by a small margin.
+- Ledger lines should be centered on the notehead x position.
+- Multiple simultaneous noteheads sharing a ledger line may merge into one wider ledger primitive if their x ranges overlap.
+
+### Stem Direction
+
+Stem direction should be explicit on every rendered stem.
+
+Default gameplay rules:
+
+- Lower voice stems down.
+- Upper voice stems up unless the group's average note height is above the staff midpoint enough that downward stems improve readability.
+- High cymbal/crash groups above the staff should stem down with beams below the noteheads.
+- Single unbeamed notes should use the same direction rule as their voice/group.
+
+### Beams
+
+Beam geometry should be produced by the layout engine, not by `BeamView`.
+
+Rules:
+
+- Beam groups do not cross measure boundaries.
+- Beam groups do not cross row boundaries.
+- Beam side follows stem direction.
+- Beam levels follow `NoteInterval.flagCount`.
+- For gameplay readability, beams can stay flat initially; sloped beams are optional later.
+
+### Rendering
+
+SwiftUI views should become renderers for primitives:
+
+- `NoteHeadView` paints the drum symbol.
+- `StemPrimitiveView` paints a stem from `start` to `end`.
+- `BeamPrimitiveView` paints a beam segment.
+- `LedgerLineView` paints a short horizontal line.
+- `MeasureBarView` paints regular and final bar lines.
+
+Views should not calculate beam membership, stem direction, ledger-line count, or collision offsets.
+
+## Data Flow
+
+1. `GameplayViewModel.loadChartData()` caches SwiftData relationships as it does today.
+2. `GameplayViewModel.setupGameplay()` builds a `NotationLayoutInput`.
+3. `NotationLayoutEngine.layout(input:)` returns a pure `NotationLayout`.
+4. `GameplayViewModel` caches the layout and creates fast lookup maps for active-beat highlighting and purple-bar positioning.
+5. `GameplaySheetMusicView` renders layout primitives.
+6. Playback updates only active state and progress indicator position, not static note geometry.
+
+## Testing
+
+Use Swift Testing with pure layout tests where possible:
+
+- Sixteenth notes in 4/4 produce adjacent x positions at least 28px apart.
+- A note above `line5` emits the expected ledger line count.
+- A kick plus snare at the same time position produces separate lower/upper voice stems.
+- High cymbal groups choose downward stems and below-note beams.
+- Beam groups stop at measure boundaries.
+- Beam groups stop at row boundaries.
+- Low-density quarter-note measures preserve existing readable spacing.
+
+SwiftUI snapshot-style tests can remain secondary because the critical behavior is deterministic geometry.
+
+## Migration Plan
+
+Implement incrementally to reduce risk:
+
+1. Add layout primitive models and `NotationLayoutEngine` with tests.
+2. Move horizontal position calculation into the engine while rendering existing note views from engine positions.
+3. Add ledger-line primitives and render them.
+4. Add explicit stem-direction and beam primitives.
+5. Add gameplay voice separation and collision offsets.
+6. Remove or deprecate duplicated stem/beam decisions from `DrumBeatView` and `BeamView`.
+
+## Follow-Up Decisions
+
+- Whether `DrumNotationSettingsManager` should become a gameplay rendering dependency.
+- Exact minimum spacing constants may need tuning after viewing real dense charts.
+- Whether to keep flat beams permanently or add optional sloped beams later.

--- a/server/README.md
+++ b/server/README.md
@@ -15,15 +15,15 @@ FastAPI backend server for serving DTX drum chart files, designed for deployment
 1. Install dependencies:
 ```bash
 cd server
-pip install -r requirements.txt
+uv sync
 ```
 
 2. Run the server:
 ```bash
-python main.py
+uv run uvicorn main:app --host 127.0.0.1 --port 8001 --reload
 ```
 
-The server will start on `http://localhost:8000`
+The server will start on `http://127.0.0.1:8001`
 
 ## API Endpoints
 

--- a/server/main.py
+++ b/server/main.py
@@ -324,4 +324,4 @@ def on_fetch(request, env):
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=8001)

--- a/server/main.py
+++ b/server/main.py
@@ -323,5 +323,12 @@ def on_fetch(request, env):
     pass
 
 if __name__ == "__main__":
+    import os
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8001)
+
+    # Read host/port from environment with secure defaults
+    # 127.0.0.1 (localhost-only) is default for local dev security
+    host = os.environ.get("HOST", "127.0.0.1")
+    port = int(os.environ.get("PORT", "8001"))
+
+    uvicorn.run(app, host=host, port=port)


### PR DESCRIPTION
## Summary
- Add notation layout engine for rendering drum sheet music in gameplay view
- Cache notation layout data to avoid per-frame recalculation
- Preserve trailing measures when song ends mid-measure
- Align notation highlight with progress bar and fix playhead positioning
- Add comprehensive tests for notation layout engine and gameplay view model

## Changes
- `NotationLayout.swift`: Core layout data structures (measure positions, beam groups, beat positions)
- `NotationLayoutEngine.swift`: Layout computation engine for drum notation
- `GameplayViewModel.swift`: Pre-compute layout data and sync with playback
- `GameplaySheetMusicView.swift`: SwiftUI rendering of notation primitives
- Tests for layout engine and gameplay view model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cached notation layout engine plus SwiftUI primitives for noteheads, stems, beams, flags, ledger lines, and measure bars driving playback rendering.

* **Improvements**
  * Continuous ~30Hz visual playhead, refined active-beat highlighting using notation geometry, purple-bar positioning from layout, stem-aware flag rendering, and normalized note positioning.

* **Tests**
  * Extensive unit and rendering tests covering layout spacing, beams/flags, playback sync, primitives, and sheet sizing.

* **Documentation**
  * Design and implementation plans for gameplay note rendering added.

* **Chores**
  * Local dev start instructions and project scheme/config updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->