### PR TITLE
feat: live score snapshot system with HUD & results rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ ui-test-activity-log.json
 Screenshot*.png
 
 .claude/settings.local.json
+.devin/config.local.json
 .xcodebuildmcp/

--- a/Virgo/components/GameplayHeaderView.swift
+++ b/Virgo/components/GameplayHeaderView.swift
@@ -20,64 +20,129 @@ struct GameplayHeaderView: View {
     let onRestart: () -> Void
 
     var body: some View {
+        // Score display reads a snapshot here so score observation stays scoped
+        // to this compact HUD instead of the full gameplay view tree.
+        let snapshot = viewModel?.liveScoreSnapshot ?? .empty
+        ViewThatFits(in: .horizontal) {
+            regularHeader(snapshot: snapshot)
+                .frame(minWidth: 620)
+
+            compactHeader(snapshot: snapshot)
+        }
+        .background(Color.black.opacity(0.8))
+    }
+
+    private func regularHeader(snapshot: LiveScoreSnapshot) -> some View {
         HStack {
-            Button(action: onDismiss) {
-                Image(systemName: "chevron.left")
-                    .font(.title2)
-                    .foregroundColor(.white)
-            }
-            .accessibilityLabel("Go back")
-            .accessibilityHint("Returns to the song list")
+            backButton
             .padding(.leading)
 
             Spacer()
 
-            VStack(spacing: 4) {
-                Text(track.title)
-                    .font(.headline)
-                    .foregroundColor(.white)
-                    .multilineTextAlignment(.center)
-
-                Text(track.artist)
-                    .font(.subheadline)
-                    .foregroundColor(.gray)
-                    .multilineTextAlignment(.center)
-            }
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel("\(track.title) by \(track.artist)")
+            titleBlock(alignment: .center, titleLineLimit: nil, artistLineLimit: nil)
 
             Spacer()
 
-            // Score display reads a snapshot here so score observation stays scoped
-            // to this compact HUD instead of the full gameplay view tree.
-            let snapshot = viewModel?.liveScoreSnapshot ?? .empty
-            GameplayScoreHUDView(
-                snapshot: snapshot,
-                showMilestone: viewModel?.showMilestoneAnimation ?? false,
-                showBreak: viewModel?.showComboBreakFeedback ?? false
-            )
+            scoreHUD(snapshot: snapshot)
 
-            HStack(spacing: 12) {
-                Button(action: onRestart) {
-                    Image(systemName: "backward.end.fill")
-                        .font(.title2)
-                        .foregroundColor(.white)
-                }
-                .accessibilityLabel("Restart")
-                .accessibilityHint("Restarts playback from the beginning")
-
-                Button(action: onPlayPause) {
-                    Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
-                        .font(.largeTitle)
-                        .foregroundColor(isPlaying ? .red : .green)
-                }
-                .accessibilityLabel(isPlaying ? "Pause" : "Play")
-                .accessibilityHint(isPlaying ? "Pauses the drum track" : "Starts playing the drum track")
-            }
+            transportControls
             .padding(.trailing)
         }
         .padding(.vertical, 8)
-        .background(Color.black.opacity(0.8))
+    }
+
+    private func compactHeader(snapshot: LiveScoreSnapshot) -> some View {
+        VStack(spacing: 6) {
+            HStack(spacing: 10) {
+                backButton
+
+                titleBlock(alignment: .leading, titleLineLimit: 1, artistLineLimit: 1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .layoutPriority(1)
+
+                transportControls
+            }
+
+            scoreHUD(snapshot: snapshot)
+                .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+    }
+
+    private var backButton: some View {
+        Button(action: onDismiss) {
+            Image(systemName: "chevron.left")
+                .font(.title2)
+                .foregroundColor(.white)
+        }
+        .accessibilityLabel("Go back")
+        .accessibilityHint("Returns to the song list")
+    }
+
+    private var transportControls: some View {
+        HStack(spacing: 12) {
+            Button(action: onRestart) {
+                Image(systemName: "backward.end.fill")
+                    .font(.title2)
+                    .foregroundColor(.white)
+            }
+            .accessibilityLabel("Restart")
+            .accessibilityHint("Restarts playback from the beginning")
+
+            Button(action: onPlayPause) {
+                Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                    .font(.largeTitle)
+                    .foregroundColor(isPlaying ? .red : .green)
+            }
+            .accessibilityLabel(isPlaying ? "Pause" : "Play")
+            .accessibilityHint(isPlaying ? "Pauses the drum track" : "Starts playing the drum track")
+        }
+    }
+
+    private func titleBlock(
+        alignment: HorizontalAlignment,
+        titleLineLimit: Int?,
+        artistLineLimit: Int?
+    ) -> some View {
+        VStack(alignment: alignment, spacing: 4) {
+            Text(track.title)
+                .font(.headline)
+                .foregroundColor(.white)
+                .multilineTextAlignment(alignment.textAlignment)
+                .lineLimit(titleLineLimit)
+                .minimumScaleFactor(0.75)
+
+            Text(track.artist)
+                .font(.subheadline)
+                .foregroundColor(.gray)
+                .multilineTextAlignment(alignment.textAlignment)
+                .lineLimit(artistLineLimit)
+                .minimumScaleFactor(0.75)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(track.title) by \(track.artist)")
+    }
+
+    private func scoreHUD(snapshot: LiveScoreSnapshot) -> some View {
+        GameplayScoreHUDView(
+            snapshot: snapshot,
+            showMilestone: viewModel?.showMilestoneAnimation ?? false,
+            showBreak: viewModel?.showComboBreakFeedback ?? false
+        )
+    }
+}
+
+private extension HorizontalAlignment {
+    var textAlignment: TextAlignment {
+        switch self {
+        case .leading:
+            return .leading
+        case .trailing:
+            return .trailing
+        default:
+            return .center
+        }
     }
 }
 

--- a/Virgo/components/GameplayHeaderView.swift
+++ b/Virgo/components/GameplayHeaderView.swift
@@ -48,21 +48,14 @@ struct GameplayHeaderView: View {
 
             Spacer()
 
-            // Score and combo display — reading from viewModel here keeps the
-            // observation dependency scoped to this subview only.
-            VStack(alignment: .trailing, spacing: 2) {
-                let score = viewModel?.scoreEngine.score ?? 0
-                Text("\(score)")
-                    .font(.system(.body, design: .monospaced).weight(.semibold))
-                    .foregroundColor(.white)
-                    .accessibilityLabel("Score: \(score)")
-
-                ComboCounterView(
-                    combo: viewModel?.scoreEngine.combo ?? 0,
-                    showMilestone: viewModel?.showMilestoneAnimation ?? false,
-                    showBreak: viewModel?.showComboBreakFeedback ?? false
-                )
-            }
+            // Score display reads a snapshot here so score observation stays scoped
+            // to this compact HUD instead of the full gameplay view tree.
+            let snapshot = viewModel?.liveScoreSnapshot ?? .empty
+            GameplayScoreHUDView(
+                snapshot: snapshot,
+                showMilestone: viewModel?.showMilestoneAnimation ?? false,
+                showBreak: viewModel?.showComboBreakFeedback ?? false
+            )
 
             HStack(spacing: 12) {
                 Button(action: onRestart) {
@@ -85,6 +78,54 @@ struct GameplayHeaderView: View {
         }
         .padding(.vertical, 8)
         .background(Color.black.opacity(0.8))
+    }
+}
+
+// MARK: - Score HUD
+
+private struct GameplayScoreHUDView: View {
+    let snapshot: LiveScoreSnapshot
+    let showMilestone: Bool
+    let showBreak: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ScoreStatCell(label: "SCORE", value: "\(snapshot.score)", color: .white, minWidth: 76)
+            ScoreStatCell(label: "ACC", value: snapshot.hitAccuracyPercentText, color: .green, minWidth: 54)
+            ScoreStatCell(label: "QLTY", value: snapshot.timingQualityPercentText, color: .cyan, minWidth: 54)
+            ComboCounterView(
+                combo: snapshot.currentCombo,
+                showMilestone: showMilestone,
+                showBreak: showBreak
+            )
+            .frame(minWidth: 44, alignment: .trailing)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "Score \(snapshot.score), accuracy \(snapshot.hitAccuracyPercentText), " +
+            "quality \(snapshot.timingQualityPercentText), combo \(snapshot.currentCombo)"
+        )
+    }
+}
+
+private struct ScoreStatCell: View {
+    let label: String
+    let value: String
+    let color: Color
+    let minWidth: CGFloat
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 1) {
+            Text(value)
+                .font(.system(.body, design: .monospaced).weight(.semibold))
+                .foregroundColor(color)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+            Text(label)
+                .font(.system(size: 9, weight: .semibold, design: .rounded))
+                .foregroundColor(.gray)
+        }
+        .frame(minWidth: minWidth, alignment: .trailing)
     }
 }
 

--- a/Virgo/utilities/LiveScoreSnapshot.swift
+++ b/Virgo/utilities/LiveScoreSnapshot.swift
@@ -65,6 +65,8 @@ struct LiveScoreSnapshot: Equatable {
         return weightedHits / Double(judgedNotes) * 100.0
     }
 
+    /// Rounds a percentage for display, guarding against floating-point boundary cases
+    /// (e.g., 57.4999999 → 58). Two-stage: micro-round to 6 decimals, then round to integer.
     private static func percentText(_ value: Double) -> String {
         let normalizedValue = (value * 1_000_000).rounded() / 1_000_000
         return "\(Int(normalizedValue.rounded()))%"

--- a/Virgo/utilities/LiveScoreSnapshot.swift
+++ b/Virgo/utilities/LiveScoreSnapshot.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+struct LiveScoreSnapshot: Equatable {
+    let score: Int
+    let currentCombo: Int
+    let maxCombo: Int
+    let perfectCount: Int
+    let greatCount: Int
+    let goodCount: Int
+    let missCount: Int
+    let hitAccuracy: Double
+    let timingQuality: Double
+    let averageTimingDeviation: Double?
+    let earlyPercentage: Double
+    let latePercentage: Double
+    let timingTendency: TimingTendency
+
+    static let empty = LiveScoreSnapshot(scoreEngine: ScoreEngine())
+
+    init(scoreEngine: ScoreEngine) {
+        self.score = scoreEngine.score
+        self.currentCombo = scoreEngine.combo
+        self.maxCombo = scoreEngine.maxCombo
+        self.perfectCount = scoreEngine.perfectCount
+        self.greatCount = scoreEngine.greatCount
+        self.goodCount = scoreEngine.goodCount
+        self.missCount = scoreEngine.missCount
+        self.hitAccuracy = scoreEngine.accuracyPercentage
+        self.timingQuality = Self.calculateTimingQuality(
+            perfectCount: scoreEngine.perfectCount,
+            greatCount: scoreEngine.greatCount,
+            goodCount: scoreEngine.goodCount,
+            missCount: scoreEngine.missCount
+        )
+        self.averageTimingDeviation = scoreEngine.averageTimingDeviation
+        self.earlyPercentage = scoreEngine.earlyPercentage
+        self.latePercentage = scoreEngine.latePercentage
+        self.timingTendency = scoreEngine.timingTendency
+    }
+
+    var judgedNoteCount: Int {
+        perfectCount + greatCount + goodCount + missCount
+    }
+
+    var hitAccuracyPercentText: String {
+        Self.percentText(hitAccuracy)
+    }
+
+    var timingQualityPercentText: String {
+        Self.percentText(timingQuality)
+    }
+
+    private static func calculateTimingQuality(
+        perfectCount: Int,
+        greatCount: Int,
+        goodCount: Int,
+        missCount: Int
+    ) -> Double {
+        let judgedNotes = perfectCount + greatCount + goodCount + missCount
+        guard judgedNotes > 0 else { return 0.0 }
+
+        let weightedHits = Double(perfectCount)
+            + Double(greatCount) * TimingAccuracy.great.scoreMultiplier
+            + Double(goodCount) * TimingAccuracy.good.scoreMultiplier
+        return weightedHits / Double(judgedNotes) * 100.0
+    }
+
+    private static func percentText(_ value: Double) -> String {
+        let normalizedValue = (value * 1_000_000).rounded() / 1_000_000
+        return "\(Int(normalizedValue.rounded()))%"
+    }
+}

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -168,8 +168,13 @@ final class GameplayViewModel {
     // MARK: - Scoring State
     /// All combo and scoring state
     var scoreEngine = ScoreEngine()
+    var liveScoreSnapshot: LiveScoreSnapshot {
+        LiveScoreSnapshot(scoreEngine: scoreEngine)
+    }
     /// Snapshot of scoreEngine captured at session end before resetScoring clears it
     var sessionScoreEngine = ScoreEngine()
+    /// Snapshot captured at session end before resetScoring clears live state.
+    var sessionScoreSnapshot = LiveScoreSnapshot.empty
     /// Final score captured at session end (survives resetScoring)
     var sessionFinalScore: Int = 0
     /// Whether the verified save returned a new high-score record (set by handlePlaybackCompletion).
@@ -1463,6 +1468,7 @@ final class GameplayViewModel {
         playbackTimer = nil
         // Capture final score and snapshot scoreEngine before reset clears them
         let finalScore = scoreEngine.score
+        let finalSnapshot = LiveScoreSnapshot(scoreEngine: scoreEngine)
         let isNewRecord = highScoreService.saveIfHighScore(finalScore, for: chart.persistentModelID)
         sessionScoreEngine = scoreEngine
         resetPlaybackState()
@@ -1471,6 +1477,7 @@ final class GameplayViewModel {
         bgmPlayer?.stop()
         // Set session result after reset (resetScoring zeroes sessionFinalScore)
         sessionFinalScore = finalScore
+        sessionScoreSnapshot = finalSnapshot
         sessionIsNewRecord = isNewRecord
         isShowingSessionResults = true
         Logger.audioPlayback(
@@ -1873,6 +1880,7 @@ final class GameplayViewModel {
     func resetScoring() {
         scoreEngine.reset()
         sessionFinalScore = 0
+        sessionScoreSnapshot = .empty
         sessionIsNewRecord = false
         isShowingSessionResults = false
         showMilestoneAnimation = false

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -171,12 +171,12 @@ final class GameplayViewModel {
     var liveScoreSnapshot: LiveScoreSnapshot {
         LiveScoreSnapshot(scoreEngine: scoreEngine)
     }
-    /// Snapshot of scoreEngine captured at session end before resetScoring clears it
+    /// Snapshot of scoreEngine captured at session end before resetScoring clears it.
+    /// Retained for test observability of raw timing deviations (not exposed in LiveScoreSnapshot).
+    /// Production code reads sessionScoreSnapshot; remove once snapshot exposes deviation detail.
     var sessionScoreEngine = ScoreEngine()
     /// Snapshot captured at session end before resetScoring clears live state.
     var sessionScoreSnapshot = LiveScoreSnapshot.empty
-    /// Final score captured at session end (survives resetScoring)
-    var sessionFinalScore: Int = 0
     /// Whether the verified save returned a new high-score record (set by handlePlaybackCompletion).
     /// Passed directly to SessionResultsView so the NEW HIGH SCORE badge reflects
     /// whether the write actually succeeded, not just a local score comparison.
@@ -1475,8 +1475,7 @@ final class GameplayViewModel {
         playbackStartTime = nil
         pausedElapsedTime = 0.0
         bgmPlayer?.stop()
-        // Set session result after reset (resetScoring zeroes sessionFinalScore)
-        sessionFinalScore = finalScore
+        // Set session result after reset
         sessionScoreSnapshot = finalSnapshot
         sessionIsNewRecord = isNewRecord
         isShowingSessionResults = true
@@ -1881,7 +1880,6 @@ final class GameplayViewModel {
     /// Resets all scoring state. Called by resetPlaybackState() on restart and completion.
     func resetScoring() {
         scoreEngine.reset()
-        sessionFinalScore = 0
         sessionScoreSnapshot = .empty
         sessionIsNewRecord = false
         isShowingSessionResults = false

--- a/Virgo/viewmodels/GameplayViewModel.swift
+++ b/Virgo/viewmodels/GameplayViewModel.swift
@@ -1832,6 +1832,8 @@ final class GameplayViewModel {
 
     /// Scan cachedNotes for notes that scrolled past without any hit attempt.
     func scanForMissedNotes(upToTimePosition playheadPosition: Double) {
+        guard isPlaying || playheadPosition.isInfinite else { return }
+
         // Offset the miss boundary by the good-tier late tolerance so that late hits
         // arriving within ±100 ms can still score before we auto-mark them missed.
         let bpm = effectiveBPM()

--- a/Virgo/views/GameplayView.swift
+++ b/Virgo/views/GameplayView.swift
@@ -113,10 +113,9 @@ struct GameplayView: View {
         )) {
             if let vm = viewModel {
                 SessionResultsView(
-                    finalScore: vm.sessionFinalScore,
                     highScore: vm.highScoreService.highScore(for: chart.persistentModelID),
                     isNewRecord: vm.sessionIsNewRecord,
-                    scoreEngine: vm.sessionScoreEngine,
+                    scoreSnapshot: vm.sessionScoreSnapshot,
                     onPlayAgain: {
                         vm.isShowingSessionResults = false
                         vm.restartPlayback()

--- a/Virgo/views/subviews/SessionResultsView.swift
+++ b/Virgo/views/subviews/SessionResultsView.swift
@@ -8,17 +8,16 @@
 import SwiftUI
 
 struct SessionResultsView: View {
-    let finalScore: Int
     let highScore: Int
     /// Whether the save service confirmed this score as a verified new record.
     /// Derived from `HighScoreService.saveIfHighScore` return value rather than
     /// a local score comparison, so the badge only appears when the write succeeded.
     let isNewRecord: Bool
-    let scoreEngine: ScoreEngine
+    let scoreSnapshot: LiveScoreSnapshot
     let onPlayAgain: () -> Void
     let onDone: () -> Void
 
-    private var isNewHighScore: Bool { finalScore > 0 && isNewRecord }
+    private var isNewHighScore: Bool { scoreSnapshot.score > 0 && isNewRecord }
 
     var body: some View {
         NavigationStack {
@@ -40,10 +39,10 @@ struct SessionResultsView: View {
 
                         // Accuracy ring + Score
                         HStack(spacing: 32) {
-                            AccuracyCircleView(percentage: scoreEngine.accuracyPercentage)
+                            AccuracyCircleView(percentage: scoreSnapshot.hitAccuracy)
 
                             VStack(spacing: 4) {
-                                Text("\(finalScore)")
+                                Text("\(scoreSnapshot.score)")
                                     .font(.system(size: 44, weight: .bold, design: .monospaced))
                                     .foregroundColor(.white)
                                 Text("SCORE")
@@ -54,10 +53,10 @@ struct SessionResultsView: View {
 
                         // Hit breakdown chart
                         AccuracyBreakdownChart(
-                            perfectCount: scoreEngine.perfectCount,
-                            greatCount: scoreEngine.greatCount,
-                            goodCount: scoreEngine.goodCount,
-                            missCount: scoreEngine.missCount
+                            perfectCount: scoreSnapshot.perfectCount,
+                            greatCount: scoreSnapshot.greatCount,
+                            goodCount: scoreSnapshot.goodCount,
+                            missCount: scoreSnapshot.missCount
                         )
                         .padding(.horizontal)
                         .padding(.vertical, 8)
@@ -67,10 +66,10 @@ struct SessionResultsView: View {
 
                         // Timing deviation
                         TimingDeviationView(
-                            averageDeviation: scoreEngine.averageTimingDeviation,
-                            earlyPercentage: scoreEngine.earlyPercentage,
-                            latePercentage: scoreEngine.latePercentage,
-                            tendency: scoreEngine.timingTendency
+                            averageDeviation: scoreSnapshot.averageTimingDeviation,
+                            earlyPercentage: scoreSnapshot.earlyPercentage,
+                            latePercentage: scoreSnapshot.latePercentage,
+                            tendency: scoreSnapshot.timingTendency
                         )
                         .padding(.horizontal)
                         .padding(.vertical, 8)
@@ -119,7 +118,8 @@ struct SessionResultsView: View {
 
     private var statsGrid: some View {
         HStack(spacing: 0) {
-            statCell(label: "MAX COMBO", value: "\(scoreEngine.maxCombo)x", color: .orange)
+            statCell(label: "MAX COMBO", value: "\(scoreSnapshot.maxCombo)x", color: .orange)
+            statCell(label: "QUALITY", value: scoreSnapshot.timingQualityPercentText, color: .cyan)
             statCell(label: "BEST SCORE", value: "\(highScore)", color: .purple)
         }
         .padding(.horizontal)
@@ -150,10 +150,9 @@ struct SessionResultsView: View {
     for _ in 0..<3 { engine.processHit(accuracy: .miss) }
 
     return SessionResultsView(
-        finalScore: 2450,
         highScore: 2450,
         isNewRecord: true,
-        scoreEngine: engine,
+        scoreSnapshot: LiveScoreSnapshot(scoreEngine: engine),
         onPlayAgain: {},
         onDone: {}
     )

--- a/VirgoTests/GameplayViewModelCoveragePlaybackAdditionsTests.swift
+++ b/VirgoTests/GameplayViewModelCoveragePlaybackAdditionsTests.swift
@@ -384,4 +384,21 @@ struct GameplayViewModelPlaybackCoverageTests {
         #expect(vm.scoreEngine.missCount == 0)
         #expect(vm.liveScoreSnapshot.judgedNoteCount == 0)
     }
+
+    @Test("infinite missed-note scan flushes remaining misses while paused")
+    func testInfiniteMissScanFlushesRemainingMissesWhilePaused() async throws {
+        let vm = GameplayViewModelCoverageTestSupport.makeViewModel(noteCount: 2)
+        await vm.loadChartData()
+        vm.setupGameplay()
+        defer { vm.cleanup() }
+
+        vm.startPlayback()
+        vm.pausePlayback()
+
+        #expect(vm.isPlaying == false)
+        vm.scanForMissedNotes(upToTimePosition: .infinity)
+
+        #expect(vm.scoreEngine.missCount == 2)
+        #expect(vm.liveScoreSnapshot.judgedNoteCount == 2)
+    }
 }

--- a/VirgoTests/GameplayViewModelCoveragePlaybackAdditionsTests.swift
+++ b/VirgoTests/GameplayViewModelCoveragePlaybackAdditionsTests.swift
@@ -92,7 +92,7 @@ struct GameplayViewModelPlaybackCoverageTests {
         vm.handlePlaybackCompletion()
 
         #expect(vm.isShowingSessionResults == true)
-        #expect(vm.sessionFinalScore == scoreAtCompletion)
+        #expect(vm.sessionScoreSnapshot.score == scoreAtCompletion)
         #expect(vm.sessionScoreEngine.score == scoreAtCompletion)
         #expect(vm.scoreEngine.score == 0)
     }

--- a/VirgoTests/GameplayViewModelCoveragePlaybackAdditionsTests.swift
+++ b/VirgoTests/GameplayViewModelCoveragePlaybackAdditionsTests.swift
@@ -367,4 +367,21 @@ struct GameplayViewModelPlaybackCoverageTests {
         #expect(elapsed == 0.0,
                 "calculateElapsedTime should clamp to zero before scheduled start, got \(elapsed ?? -1)")
     }
+
+    @Test("finite missed-note scan is ignored while playback is paused")
+    func testFiniteMissScanIgnoredWhilePaused() async throws {
+        let vm = GameplayViewModelCoverageTestSupport.makeViewModel(noteCount: 2)
+        await vm.loadChartData()
+        vm.setupGameplay()
+        defer { vm.cleanup() }
+
+        vm.startPlayback()
+        vm.pausePlayback()
+
+        #expect(vm.isPlaying == false)
+        vm.scanForMissedNotes(upToTimePosition: 10.0)
+
+        #expect(vm.scoreEngine.missCount == 0)
+        #expect(vm.liveScoreSnapshot.judgedNoteCount == 0)
+    }
 }

--- a/VirgoTests/GameplayViewModelCoveragePlaybackAdditionsTests.swift
+++ b/VirgoTests/GameplayViewModelCoveragePlaybackAdditionsTests.swift
@@ -10,6 +10,60 @@ import Foundation
 @Suite("GameplayViewModelPlaybackCoverageTests", .serialized)
 @MainActor
 struct GameplayViewModelPlaybackCoverageTests {
+    @Test("liveScoreSnapshot reflects current score engine state")
+    func testLiveScoreSnapshotReflectsCurrentScore() async throws {
+        let vm = GameplayViewModelCoverageTestSupport.makeViewModel(noteCount: 2)
+        await vm.loadChartData()
+        vm.setupGameplay()
+        defer { vm.cleanup() }
+
+        vm.isPlaying = true
+        let note = try #require(vm.cachedNotes.first)
+        let result = NoteMatchResult(
+            hitInput: InputHit(drumType: .kick, velocity: 1.0, timestamp: Date()),
+            matchedNote: note,
+            timingAccuracy: .perfect,
+            measureNumber: note.measureNumber,
+            measureOffset: note.measureOffset,
+            timingError: 0.0
+        )
+
+        vm.recordHit(result: result)
+
+        #expect(vm.liveScoreSnapshot.score == 100)
+        #expect(vm.liveScoreSnapshot.currentCombo == 1)
+        #expect(vm.liveScoreSnapshot.hitAccuracy == 100.0)
+        #expect(vm.liveScoreSnapshot.timingQuality == 100.0)
+    }
+
+    @Test("handlePlaybackCompletion captures final score snapshot before reset")
+    func testHandlePlaybackCompletionCapturesFinalScoreSnapshot() async throws {
+        let vm = GameplayViewModelCoverageTestSupport.makeViewModel(noteCount: 2)
+        await vm.loadChartData()
+        vm.setupGameplay()
+        defer { vm.cleanup() }
+
+        vm.startPlayback()
+        let note = try #require(vm.cachedNotes.first)
+        let result = NoteMatchResult(
+            hitInput: InputHit(drumType: .kick, velocity: 1.0, timestamp: Date()),
+            matchedNote: note,
+            timingAccuracy: .great,
+            measureNumber: note.measureNumber,
+            measureOffset: note.measureOffset,
+            timingError: 20.0
+        )
+        vm.recordHit(result: result)
+
+        vm.handlePlaybackCompletion()
+
+        #expect(vm.liveScoreSnapshot.score == 0)
+        #expect(vm.sessionScoreSnapshot.score == 80)
+        #expect(vm.sessionScoreSnapshot.currentCombo == 1)
+        #expect(vm.sessionScoreSnapshot.timingQuality == 80.0)
+        #expect(vm.sessionScoreSnapshot.averageTimingDeviation == 20.0)
+    }
+
     // MARK: - handlePlaybackCompletion session-result state (lines 1041–1049)
 
     @Test("handlePlaybackCompletion sets isShowingSessionResults and captures session score snapshot")

--- a/VirgoTests/LiveScoreSnapshotTests.swift
+++ b/VirgoTests/LiveScoreSnapshotTests.swift
@@ -1,0 +1,82 @@
+import Testing
+@testable import Virgo
+
+@Suite("LiveScoreSnapshot Tests")
+struct LiveScoreSnapshotTests {
+    @Test("empty snapshot returns zeroed display stats")
+    func emptySnapshotReturnsZeroes() {
+        let snapshot = LiveScoreSnapshot(scoreEngine: ScoreEngine())
+
+        #expect(snapshot.score == 0)
+        #expect(snapshot.currentCombo == 0)
+        #expect(snapshot.maxCombo == 0)
+        #expect(snapshot.judgedNoteCount == 0)
+        #expect(snapshot.hitAccuracy == 0.0)
+        #expect(snapshot.timingQuality == 0.0)
+        #expect(snapshot.hitAccuracyPercentText == "0%")
+        #expect(snapshot.timingQualityPercentText == "0%")
+    }
+
+    @Test("snapshot exposes score combo and counts from ScoreEngine")
+    func snapshotExposesScoreComboAndCounts() {
+        var engine = ScoreEngine()
+        engine.processHit(accuracy: .perfect, timingError: -10.0)
+        engine.processHit(accuracy: .great, timingError: 20.0)
+        engine.processHit(accuracy: .good, timingError: 50.0)
+        engine.processHit(accuracy: .miss)
+
+        let snapshot = LiveScoreSnapshot(scoreEngine: engine)
+
+        #expect(snapshot.score == engine.score)
+        #expect(snapshot.currentCombo == engine.combo)
+        #expect(snapshot.maxCombo == engine.maxCombo)
+        #expect(snapshot.perfectCount == 1)
+        #expect(snapshot.greatCount == 1)
+        #expect(snapshot.goodCount == 1)
+        #expect(snapshot.missCount == 1)
+        #expect(snapshot.judgedNoteCount == 4)
+    }
+
+    @Test("hit accuracy counts non-miss hits over all judged notes")
+    func hitAccuracyUsesNonMissOverJudgedNotes() {
+        var engine = ScoreEngine()
+        engine.processHit(accuracy: .perfect)
+        engine.processHit(accuracy: .great)
+        engine.processHit(accuracy: .good)
+        engine.processHit(accuracy: .miss)
+
+        let snapshot = LiveScoreSnapshot(scoreEngine: engine)
+
+        #expect(abs(snapshot.hitAccuracy - 75.0) < 0.001)
+        #expect(snapshot.hitAccuracyPercentText == "75%")
+    }
+
+    @Test("timing quality uses weighted perfect great good and miss values")
+    func timingQualityUsesWeightedCounts() {
+        var engine = ScoreEngine()
+        engine.processHit(accuracy: .perfect)
+        engine.processHit(accuracy: .great)
+        engine.processHit(accuracy: .good)
+        engine.processHit(accuracy: .miss)
+
+        let snapshot = LiveScoreSnapshot(scoreEngine: engine)
+
+        // (1.0 + 0.8 + 0.5 + 0.0) / 4 * 100 = 57.5
+        #expect(abs(snapshot.timingQuality - 57.5) < 0.001)
+        #expect(snapshot.timingQualityPercentText == "58%")
+    }
+
+    @Test("snapshot carries timing deviation fields")
+    func snapshotCarriesTimingFields() {
+        var engine = ScoreEngine()
+        engine.processHit(accuracy: .perfect, timingError: -20.0)
+        engine.processHit(accuracy: .great, timingError: 10.0)
+
+        let snapshot = LiveScoreSnapshot(scoreEngine: engine)
+
+        #expect(snapshot.averageTimingDeviation != nil)
+        #expect(snapshot.earlyPercentage == engine.earlyPercentage)
+        #expect(snapshot.latePercentage == engine.latePercentage)
+        #expect(snapshot.timingTendency == engine.timingTendency)
+    }
+}

--- a/VirgoTests/ScoringIntegrationTests.swift
+++ b/VirgoTests/ScoringIntegrationTests.swift
@@ -68,7 +68,7 @@ struct ScoringIntegrationTests {
         #expect(vm.scoreEngine.score == 0)
         #expect(vm.scoreEngine.combo == 0)
         #expect(vm.isShowingSessionResults == false)
-        #expect(vm.sessionFinalScore == 0)
+        #expect(vm.sessionScoreSnapshot.score == 0)
     }
 
     // MARK: - recordHit
@@ -199,14 +199,14 @@ struct ScoringIntegrationTests {
 
     // MARK: - Session Results
 
-    @Test("handlePlaybackCompletion sets sessionFinalScore before reset")
+    @Test("handlePlaybackCompletion captures score in sessionScoreSnapshot before reset")
     func testHandlePlaybackCompletionPreservesScore() {
         let vm = makeViewModel()
         vm.isPlaying = true
         vm.recordHit(result: makePerfectResult())
         let expectedScore = vm.scoreEngine.score
         vm.handlePlaybackCompletion()
-        #expect(vm.sessionFinalScore == expectedScore)
+        #expect(vm.sessionScoreSnapshot.score == expectedScore)
         #expect(vm.isShowingSessionResults == true)
     }
 
@@ -216,7 +216,7 @@ struct ScoringIntegrationTests {
         vm.isPlaying = true
         vm.recordHit(result: makePerfectResult())
         vm.handlePlaybackCompletion()
-        #expect(vm.scoreEngine.score == 0) // reset, sessionFinalScore holds the final
+        #expect(vm.scoreEngine.score == 0) // reset, snapshot holds the final score
     }
 
     // MARK: - Timing Error Passthrough

--- a/VirgoTests/SwiftUIRenderingCoverageTests.swift
+++ b/VirgoTests/SwiftUIRenderingCoverageTests.swift
@@ -538,6 +538,47 @@ struct SwiftUIRenderingCoverageTests {
         }
     }
 
+    @Test("GameplayHeaderView uses compact score layout at iPhone portrait width")
+    func testGameplayHeaderViewUsesCompactScoreLayoutAtPortraitWidth() async throws {
+        try await TestSetup.withTestSetup {
+            let vm = await GameplayViewModelCoverageTestSupport.makePreparedViewModel()
+            vm.isPlaying = true
+            let note = try #require(vm.cachedNotes.first)
+            let result = NoteMatchResult(
+                hitInput: InputHit(drumType: .kick, velocity: 1.0, timestamp: Date()),
+                matchedNote: note,
+                timingAccuracy: .perfect,
+                measureNumber: note.measureNumber,
+                measureOffset: note.measureOffset,
+                timingError: 0.0
+            )
+            vm.recordHit(result: result)
+
+            let track = try #require(vm.track)
+            let view = GameplayHeaderView(
+                track: track,
+                isPlaying: .constant(true),
+                viewModel: vm,
+                onDismiss: {},
+                onPlayPause: {},
+                onRestart: {}
+            )
+            .background(Color.black)
+
+            let mountedView = SwiftUITestUtilities.assertViewWithEnvironment(
+                view,
+                size: CGSize(width: 390, height: 160)
+            )
+            let texts = SwiftUITestUtilities.renderedTexts(from: mountedView.root)
+
+            for string in ["SCORE", "ACC", "QLTY", "100%", "1x"] {
+                #expect(texts.contains(string), "Expected compact header texts to include '\(string)', got \(texts)")
+            }
+
+            vm.cleanup()
+        }
+    }
+
     private func makeDownloadedSong(title: String) -> Song {
         let notes = [
             Note(interval: .quarter, noteType: .bass, measureNumber: 1, measureOffset: 0.0),

--- a/VirgoTests/SwiftUIRenderingCoverageTests.swift
+++ b/VirgoTests/SwiftUIRenderingCoverageTests.swift
@@ -500,6 +500,42 @@ struct SwiftUIRenderingCoverageTests {
         }
     }
 
+    @Test("GameplayHeaderView renders score snapshot stats")
+    func testGameplayHeaderViewRendersScoreSnapshotStats() async throws {
+        try await TestSetup.withTestSetup {
+            let vm = await GameplayViewModelCoverageTestSupport.makePreparedViewModel()
+            vm.isPlaying = true
+            let note = try #require(vm.cachedNotes.first)
+            let result = NoteMatchResult(
+                hitInput: InputHit(drumType: .kick, velocity: 1.0, timestamp: Date()),
+                matchedNote: note,
+                timingAccuracy: .perfect,
+                measureNumber: note.measureNumber,
+                measureOffset: note.measureOffset,
+                timingError: 0.0
+            )
+            vm.recordHit(result: result)
+
+            let track = try #require(vm.track)
+            let view = GameplayHeaderView(
+                track: track,
+                isPlaying: .constant(true),
+                viewModel: vm,
+                onDismiss: {},
+                onPlayPause: {},
+                onRestart: {}
+            )
+            .background(Color.black)
+
+            SwiftUITestUtilities.assertView(
+                view,
+                containsStrings: ["SCORE", "ACC", "QLTY", "100%", "1x"],
+                size: CGSize(width: 1280, height: 130)
+            )
+            vm.cleanup()
+        }
+    }
+
     private func makeDownloadedSong(title: String) -> Song {
         let notes = [
             Note(interval: .quarter, noteType: .bass, measureNumber: 1, measureOffset: 0.0),

--- a/VirgoTests/SwiftUIRenderingCoverageTests.swift
+++ b/VirgoTests/SwiftUIRenderingCoverageTests.swift
@@ -375,17 +375,19 @@ struct SwiftUIRenderingCoverageTests {
     @Test("SessionResultsView renders a verified new high score state")
     func testSessionResultsViewRenderingForNewRecord() async throws {
         try await TestSetup.withTestSetup {
+            let scoreEngine = makeScoreEngineForResults()
+            let expectedScore = scoreEngine.score.formatted()
             let view = SessionResultsView(
-                finalScore: 2450,
                 highScore: 2450,
                 isNewRecord: true,
-                scoreEngine: makeScoreEngineForResults(),
+                scoreSnapshot: LiveScoreSnapshot(scoreEngine: scoreEngine),
                 onPlayAgain: {},
                 onDone: {}
             )
 
-            SwiftUITestUtilities.assertViewWithEnvironment(
+            SwiftUITestUtilities.assertView(
                 view,
+                containsStrings: [expectedScore, "QUALITY"],
                 size: CGSize(width: 900, height: 900)
             )
         }
@@ -399,16 +401,16 @@ struct SwiftUIRenderingCoverageTests {
             scoreEngine.processHit(accuracy: .miss)
 
             let view = SessionResultsView(
-                finalScore: 80,
                 highScore: 900,
                 isNewRecord: false,
-                scoreEngine: scoreEngine,
+                scoreSnapshot: LiveScoreSnapshot(scoreEngine: scoreEngine),
                 onPlayAgain: {},
                 onDone: {}
             )
 
-            SwiftUITestUtilities.assertViewWithEnvironment(
+            SwiftUITestUtilities.assertView(
                 view,
+                containsStrings: ["QUALITY", "40%"],
                 size: CGSize(width: 900, height: 900)
             )
         }

--- a/docs/superpowers/plans/2026-05-19-score-system-presentation.md
+++ b/docs/superpowers/plans/2026-05-19-score-system-presentation.md
@@ -1,0 +1,818 @@
+# Score System Presentation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Harden Virgo's existing scoring loop and present score, combo, hit accuracy, timing quality, and results through a clean snapshot-driven UI contract.
+
+**Architecture:** Keep `ScoreEngine` as the pure scoring authority. Add an immutable `LiveScoreSnapshot` presentation model derived from `ScoreEngine`, expose live and final snapshots from `GameplayViewModel`, then update `GameplayHeaderView` and `SessionResultsView` to consume snapshots instead of duplicating formulas.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Observation, Swift Testing, SwiftData, Xcode file-system synchronized groups.
+
+---
+
+## Reference
+
+- Spec: `docs/superpowers/specs/2026-05-19-score-system-presentation-design.md`
+- Existing scoring: `Virgo/utilities/ScoreEngine.swift`
+- Existing gameplay coordinator: `Virgo/viewmodels/GameplayViewModel.swift`
+- Existing HUD: `Virgo/components/GameplayHeaderView.swift`
+- Existing results sheet: `Virgo/views/subviews/SessionResultsView.swift`
+- Existing score tests: `VirgoTests/ScoreEngineTests.swift`, `VirgoTests/ScoreEngineEdgeCaseTests.swift`
+- Existing gameplay tests: `VirgoTests/GameplayViewModelTests.swift`, `VirgoTests/GameplayViewModelCoveragePlaybackAdditionsTests.swift`
+- Existing render tests: `VirgoTests/SwiftUIRenderingCoverageTests.swift`
+
+The project uses `PBXFileSystemSynchronizedRootGroup`, so new Swift files under `Virgo/` and `VirgoTests/` should be picked up without manual `.pbxproj` file references.
+
+Leave `.superpowers/` visual-companion artifacts untracked.
+
+## Task 1: Add `LiveScoreSnapshot`
+
+**Files:**
+- Create: `Virgo/utilities/LiveScoreSnapshot.swift`
+- Create: `VirgoTests/LiveScoreSnapshotTests.swift`
+
+**Step 1: Write the failing tests**
+
+Create `VirgoTests/LiveScoreSnapshotTests.swift`:
+
+```swift
+import Testing
+@testable import Virgo
+
+@Suite("LiveScoreSnapshot Tests")
+struct LiveScoreSnapshotTests {
+    @Test("empty snapshot returns zeroed display stats")
+    func emptySnapshotReturnsZeroes() {
+        let snapshot = LiveScoreSnapshot(scoreEngine: ScoreEngine())
+
+        #expect(snapshot.score == 0)
+        #expect(snapshot.currentCombo == 0)
+        #expect(snapshot.maxCombo == 0)
+        #expect(snapshot.judgedNoteCount == 0)
+        #expect(snapshot.hitAccuracy == 0.0)
+        #expect(snapshot.timingQuality == 0.0)
+        #expect(snapshot.hitAccuracyPercentText == "0%")
+        #expect(snapshot.timingQualityPercentText == "0%")
+    }
+
+    @Test("snapshot exposes score combo and counts from ScoreEngine")
+    func snapshotExposesScoreComboAndCounts() {
+        var engine = ScoreEngine()
+        engine.processHit(accuracy: .perfect, timingError: -10.0)
+        engine.processHit(accuracy: .great, timingError: 20.0)
+        engine.processHit(accuracy: .good, timingError: 50.0)
+        engine.processHit(accuracy: .miss)
+
+        let snapshot = LiveScoreSnapshot(scoreEngine: engine)
+
+        #expect(snapshot.score == engine.score)
+        #expect(snapshot.currentCombo == engine.combo)
+        #expect(snapshot.maxCombo == engine.maxCombo)
+        #expect(snapshot.perfectCount == 1)
+        #expect(snapshot.greatCount == 1)
+        #expect(snapshot.goodCount == 1)
+        #expect(snapshot.missCount == 1)
+        #expect(snapshot.judgedNoteCount == 4)
+    }
+
+    @Test("hit accuracy counts non-miss hits over all judged notes")
+    func hitAccuracyUsesNonMissOverJudgedNotes() {
+        var engine = ScoreEngine()
+        engine.processHit(accuracy: .perfect)
+        engine.processHit(accuracy: .great)
+        engine.processHit(accuracy: .good)
+        engine.processHit(accuracy: .miss)
+
+        let snapshot = LiveScoreSnapshot(scoreEngine: engine)
+
+        #expect(abs(snapshot.hitAccuracy - 75.0) < 0.001)
+        #expect(snapshot.hitAccuracyPercentText == "75%")
+    }
+
+    @Test("timing quality uses weighted perfect great good and miss values")
+    func timingQualityUsesWeightedCounts() {
+        var engine = ScoreEngine()
+        engine.processHit(accuracy: .perfect)
+        engine.processHit(accuracy: .great)
+        engine.processHit(accuracy: .good)
+        engine.processHit(accuracy: .miss)
+
+        let snapshot = LiveScoreSnapshot(scoreEngine: engine)
+
+        // (1.0 + 0.8 + 0.5 + 0.0) / 4 * 100 = 57.5
+        #expect(abs(snapshot.timingQuality - 57.5) < 0.001)
+        #expect(snapshot.timingQualityPercentText == "58%")
+    }
+
+    @Test("snapshot carries timing deviation fields")
+    func snapshotCarriesTimingFields() {
+        var engine = ScoreEngine()
+        engine.processHit(accuracy: .perfect, timingError: -20.0)
+        engine.processHit(accuracy: .great, timingError: 10.0)
+
+        let snapshot = LiveScoreSnapshot(scoreEngine: engine)
+
+        #expect(snapshot.averageTimingDeviation != nil)
+        #expect(snapshot.earlyPercentage == engine.earlyPercentage)
+        #expect(snapshot.latePercentage == engine.latePercentage)
+        #expect(snapshot.timingTendency == engine.timingTendency)
+    }
+}
+```
+
+**Step 2: Run the failing tests**
+
+Run:
+
+```bash
+xcodebuild test \
+  -project Virgo.xcodeproj \
+  -scheme Virgo \
+  -destination 'platform=macOS' \
+  -configuration Debug \
+  -only-testing:VirgoTests/LiveScoreSnapshotTests \
+  ONLY_ACTIVE_ARCH=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  -destination-timeout 300 \
+  -derivedDataPath ./DerivedData
+```
+
+Expected: FAIL because `LiveScoreSnapshot` does not exist.
+
+**Step 3: Implement the minimal model**
+
+Create `Virgo/utilities/LiveScoreSnapshot.swift`:
+
+```swift
+import Foundation
+
+struct LiveScoreSnapshot: Equatable {
+    let score: Int
+    let currentCombo: Int
+    let maxCombo: Int
+    let perfectCount: Int
+    let greatCount: Int
+    let goodCount: Int
+    let missCount: Int
+    let hitAccuracy: Double
+    let timingQuality: Double
+    let averageTimingDeviation: Double?
+    let earlyPercentage: Double
+    let latePercentage: Double
+    let timingTendency: TimingTendency
+
+    static let empty = LiveScoreSnapshot(scoreEngine: ScoreEngine())
+
+    init(scoreEngine: ScoreEngine) {
+        self.score = scoreEngine.score
+        self.currentCombo = scoreEngine.combo
+        self.maxCombo = scoreEngine.maxCombo
+        self.perfectCount = scoreEngine.perfectCount
+        self.greatCount = scoreEngine.greatCount
+        self.goodCount = scoreEngine.goodCount
+        self.missCount = scoreEngine.missCount
+        self.hitAccuracy = scoreEngine.accuracyPercentage
+        self.timingQuality = Self.calculateTimingQuality(
+            perfectCount: scoreEngine.perfectCount,
+            greatCount: scoreEngine.greatCount,
+            goodCount: scoreEngine.goodCount,
+            missCount: scoreEngine.missCount
+        )
+        self.averageTimingDeviation = scoreEngine.averageTimingDeviation
+        self.earlyPercentage = scoreEngine.earlyPercentage
+        self.latePercentage = scoreEngine.latePercentage
+        self.timingTendency = scoreEngine.timingTendency
+    }
+
+    var judgedNoteCount: Int {
+        perfectCount + greatCount + goodCount + missCount
+    }
+
+    var hitAccuracyPercentText: String {
+        Self.percentText(hitAccuracy)
+    }
+
+    var timingQualityPercentText: String {
+        Self.percentText(timingQuality)
+    }
+
+    private static func calculateTimingQuality(
+        perfectCount: Int,
+        greatCount: Int,
+        goodCount: Int,
+        missCount: Int
+    ) -> Double {
+        let judgedNotes = perfectCount + greatCount + goodCount + missCount
+        guard judgedNotes > 0 else { return 0.0 }
+
+        let weightedHits = Double(perfectCount)
+            + Double(greatCount) * TimingAccuracy.great.scoreMultiplier
+            + Double(goodCount) * TimingAccuracy.good.scoreMultiplier
+        return weightedHits / Double(judgedNotes) * 100.0
+    }
+
+    private static func percentText(_ value: Double) -> String {
+        "\(Int(value.rounded()))%"
+    }
+}
+```
+
+**Step 4: Run the tests**
+
+Run the same `xcodebuild test ... -only-testing:VirgoTests/LiveScoreSnapshotTests` command.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add Virgo/utilities/LiveScoreSnapshot.swift VirgoTests/LiveScoreSnapshotTests.swift
+git commit -m "feat: add live score snapshot"
+```
+
+## Task 2: Wire live and final snapshots through `GameplayViewModel`
+
+**Files:**
+- Modify: `Virgo/viewmodels/GameplayViewModel.swift`
+- Modify: `VirgoTests/GameplayViewModelCoveragePlaybackAdditionsTests.swift`
+
+**Step 1: Write failing view-model snapshot tests**
+
+Append tests to `GameplayViewModelCoveragePlaybackTests` in `VirgoTests/GameplayViewModelCoveragePlaybackAdditionsTests.swift`:
+
+```swift
+@Test("liveScoreSnapshot reflects current score engine state")
+func testLiveScoreSnapshotReflectsCurrentScore() async throws {
+    let vm = GameplayViewModelCoverageTestSupport.makeViewModel(noteCount: 2)
+    await vm.loadChartData()
+    vm.setupGameplay()
+    defer { vm.cleanup() }
+
+    vm.isPlaying = true
+    let note = try #require(vm.cachedNotes.first)
+    let result = NoteMatchResult(
+        hitInput: InputHit(drumType: .kick, velocity: 1.0, timestamp: Date()),
+        matchedNote: note,
+        timingAccuracy: .perfect,
+        measureNumber: note.measureNumber,
+        measureOffset: note.measureOffset,
+        timingError: 0.0
+    )
+
+    vm.recordHit(result: result)
+
+    #expect(vm.liveScoreSnapshot.score == 100)
+    #expect(vm.liveScoreSnapshot.currentCombo == 1)
+    #expect(vm.liveScoreSnapshot.hitAccuracy == 100.0)
+    #expect(vm.liveScoreSnapshot.timingQuality == 100.0)
+}
+
+@Test("handlePlaybackCompletion captures final score snapshot before reset")
+func testHandlePlaybackCompletionCapturesFinalScoreSnapshot() async throws {
+    let vm = GameplayViewModelCoverageTestSupport.makeViewModel(noteCount: 2)
+    await vm.loadChartData()
+    vm.setupGameplay()
+    defer { vm.cleanup() }
+
+    vm.startPlayback()
+    let note = try #require(vm.cachedNotes.first)
+    let result = NoteMatchResult(
+        hitInput: InputHit(drumType: .kick, velocity: 1.0, timestamp: Date()),
+        matchedNote: note,
+        timingAccuracy: .great,
+        measureNumber: note.measureNumber,
+        measureOffset: note.measureOffset,
+        timingError: 20.0
+    )
+    vm.recordHit(result: result)
+
+    vm.handlePlaybackCompletion()
+
+    #expect(vm.scoreEngine.score == 0)
+    #expect(vm.sessionScoreSnapshot.score == 80)
+    #expect(vm.sessionScoreSnapshot.currentCombo == 1)
+    #expect(vm.sessionScoreSnapshot.timingQuality == 80.0)
+    #expect(vm.sessionScoreSnapshot.averageTimingDeviation == 20.0)
+}
+```
+
+**Step 2: Run the failing tests**
+
+Run:
+
+```bash
+xcodebuild test \
+  -project Virgo.xcodeproj \
+  -scheme Virgo \
+  -destination 'platform=macOS' \
+  -configuration Debug \
+  -only-testing:VirgoTests/GameplayViewModelPlaybackCoverageTests \
+  ONLY_ACTIVE_ARCH=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  -destination-timeout 300 \
+  -derivedDataPath ./DerivedData
+```
+
+Expected: FAIL because `liveScoreSnapshot` and `sessionScoreSnapshot` do not exist.
+
+**Step 3: Add snapshot properties and completion capture**
+
+In `Virgo/viewmodels/GameplayViewModel.swift`, near the scoring state properties, add:
+
+```swift
+    var liveScoreSnapshot: LiveScoreSnapshot {
+        LiveScoreSnapshot(scoreEngine: scoreEngine)
+    }
+    /// Snapshot captured at session end before resetScoring clears live state.
+    var sessionScoreSnapshot = LiveScoreSnapshot.empty
+```
+
+In `handlePlaybackCompletion()`, capture the snapshot before reset:
+
+```swift
+        let finalScore = scoreEngine.score
+        let finalSnapshot = LiveScoreSnapshot(scoreEngine: scoreEngine)
+        let isNewRecord = highScoreService.saveIfHighScore(finalScore, for: chart.persistentModelID)
+        sessionScoreEngine = scoreEngine
+        resetPlaybackState()
+```
+
+After reset, preserve the final snapshot for the results sheet:
+
+```swift
+        sessionFinalScore = finalScore
+        sessionScoreSnapshot = finalSnapshot
+        sessionIsNewRecord = isNewRecord
+        isShowingSessionResults = true
+```
+
+In `resetScoring()`, clear stale final snapshots when a new run starts:
+
+```swift
+        sessionScoreSnapshot = .empty
+```
+
+If a test shows this clears the just-captured completion snapshot, keep the assignment after `resetPlaybackState()` as shown above.
+
+**Step 4: Run the tests**
+
+Run the same `GameplayViewModelPlaybackCoverageTests` command.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add Virgo/viewmodels/GameplayViewModel.swift VirgoTests/GameplayViewModelCoveragePlaybackAdditionsTests.swift
+git commit -m "feat: expose gameplay score snapshots"
+```
+
+## Task 3: Harden paused finite miss scanning
+
+**Files:**
+- Modify: `Virgo/viewmodels/GameplayViewModel.swift`
+- Modify: `VirgoTests/GameplayViewModelCoveragePlaybackAdditionsTests.swift`
+
+**Step 1: Write the failing paused-scan test**
+
+Append to `GameplayViewModelPlaybackCoverageTests`:
+
+```swift
+@Test("finite missed-note scan is ignored while playback is paused")
+func testFiniteMissScanIgnoredWhilePaused() async throws {
+    let vm = GameplayViewModelCoverageTestSupport.makeViewModel(noteCount: 2)
+    await vm.loadChartData()
+    vm.setupGameplay()
+    defer { vm.cleanup() }
+
+    vm.startPlayback()
+    vm.pausePlayback()
+
+    #expect(vm.isPlaying == false)
+    vm.scanForMissedNotes(upToTimePosition: 10.0)
+
+    #expect(vm.scoreEngine.missCount == 0)
+    #expect(vm.liveScoreSnapshot.judgedNoteCount == 0)
+}
+```
+
+**Step 2: Run the failing test**
+
+Run:
+
+```bash
+xcodebuild test \
+  -project Virgo.xcodeproj \
+  -scheme Virgo \
+  -destination 'platform=macOS' \
+  -configuration Debug \
+  -only-testing:VirgoTests/GameplayViewModelPlaybackCoverageTests/testFiniteMissScanIgnoredWhilePaused \
+  ONLY_ACTIVE_ARCH=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  -destination-timeout 300 \
+  -derivedDataPath ./DerivedData
+```
+
+Expected: FAIL because `scanForMissedNotes(upToTimePosition:)` currently has no paused finite-scan guard.
+
+**Step 3: Add the guard**
+
+At the top of `scanForMissedNotes(upToTimePosition:)`, after the method starts and before calculating the miss boundary:
+
+```swift
+        guard isPlaying || playheadPosition.isInfinite else { return }
+```
+
+This allows existing skip-to-end and completion scans that pass `.infinity`, while preventing finite visual-tick style scans from mutating score after pause or disconnect.
+
+**Step 4: Run focused scan tests**
+
+Run:
+
+```bash
+xcodebuild test \
+  -project Virgo.xcodeproj \
+  -scheme Virgo \
+  -destination 'platform=macOS' \
+  -configuration Debug \
+  -only-testing:VirgoTests/GameplayViewModelPlaybackCoverageTests/testFiniteMissScanIgnoredWhilePaused \
+  -only-testing:VirgoTests/GameplayViewModelTests/testScanCursorResetsOnResetScoring \
+  -only-testing:VirgoTests/GameplayViewModelTests/testScanMissTriggersComboBreakFeedback \
+  ONLY_ACTIVE_ARCH=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  -destination-timeout 300 \
+  -derivedDataPath ./DerivedData
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add Virgo/viewmodels/GameplayViewModel.swift VirgoTests/GameplayViewModelCoveragePlaybackAdditionsTests.swift
+git commit -m "fix: ignore paused finite miss scans"
+```
+
+## Task 4: Add snapshot-driven gameplay HUD
+
+**Files:**
+- Modify: `Virgo/components/GameplayHeaderView.swift`
+- Modify: `VirgoTests/SwiftUIRenderingCoverageTests.swift`
+
+**Step 1: Write/update rendering tests**
+
+In `VirgoTests/SwiftUIRenderingCoverageTests.swift`, update the existing header render test or add a new one that prepares a view model with score data:
+
+```swift
+@Test("GameplayHeaderView renders score snapshot stats")
+func testGameplayHeaderViewRendersScoreSnapshotStats() async throws {
+    try await TestSetup.withTestSetup {
+        let vm = await GameplayViewModelCoverageTestSupport.makePreparedViewModel()
+        vm.isPlaying = true
+        let note = try #require(vm.cachedNotes.first)
+        let result = NoteMatchResult(
+            hitInput: InputHit(drumType: .kick, velocity: 1.0, timestamp: Date()),
+            matchedNote: note,
+            timingAccuracy: .perfect,
+            measureNumber: note.measureNumber,
+            measureOffset: note.measureOffset,
+            timingError: 0.0
+        )
+        vm.recordHit(result: result)
+
+        let track = try #require(vm.track)
+        let view = GameplayHeaderView(
+            track: track,
+            isPlaying: .constant(true),
+            viewModel: vm,
+            onDismiss: {},
+            onPlayPause: {},
+            onRestart: {}
+        )
+        .background(Color.black)
+
+        SwiftUITestUtilities.assertViewWithEnvironment(view, size: CGSize(width: 1280, height: 130))
+        vm.cleanup()
+    }
+}
+```
+
+**Step 2: Run the rendering test**
+
+Run:
+
+```bash
+xcodebuild test \
+  -project Virgo.xcodeproj \
+  -scheme Virgo \
+  -destination 'platform=macOS' \
+  -configuration Debug \
+  -only-testing:VirgoTests/SwiftUIRenderingCoverageTests/testGameplayHeaderViewRendersScoreSnapshotStats \
+  ONLY_ACTIVE_ARCH=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  -destination-timeout 300 \
+  -derivedDataPath ./DerivedData
+```
+
+Expected: It may PASS before UI changes if the test only checks renderability. That is acceptable as a coverage test, but still perform Step 3 because the spec requires the new stats in the HUD.
+
+**Step 3: Update the HUD implementation**
+
+In `GameplayHeaderView.body`, derive a snapshot:
+
+```swift
+                let snapshot = viewModel?.liveScoreSnapshot ?? .empty
+                GameplayScoreHUDView(
+                    snapshot: snapshot,
+                    showMilestone: viewModel?.showMilestoneAnimation ?? false,
+                    showBreak: viewModel?.showComboBreakFeedback ?? false
+                )
+```
+
+Replace the current score/combo-only `VStack` with `GameplayScoreHUDView`.
+
+Add private views in `GameplayHeaderView.swift`:
+
+```swift
+private struct GameplayScoreHUDView: View {
+    let snapshot: LiveScoreSnapshot
+    let showMilestone: Bool
+    let showBreak: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ScoreStatCell(label: "SCORE", value: "\(snapshot.score)", color: .white, minWidth: 76)
+            ScoreStatCell(label: "ACC", value: snapshot.hitAccuracyPercentText, color: .green, minWidth: 54)
+            ScoreStatCell(label: "QLTY", value: snapshot.timingQualityPercentText, color: .cyan, minWidth: 54)
+            ComboCounterView(
+                combo: snapshot.currentCombo,
+                showMilestone: showMilestone,
+                showBreak: showBreak
+            )
+            .frame(minWidth: 44, alignment: .trailing)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "Score \(snapshot.score), accuracy \(snapshot.hitAccuracyPercentText), " +
+            "quality \(snapshot.timingQualityPercentText), combo \(snapshot.currentCombo)"
+        )
+    }
+}
+
+private struct ScoreStatCell: View {
+    let label: String
+    let value: String
+    let color: Color
+    let minWidth: CGFloat
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 1) {
+            Text(value)
+                .font(.system(.body, design: .monospaced).weight(.semibold))
+                .foregroundColor(color)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+            Text(label)
+                .font(.system(size: 9, weight: .semibold, design: .rounded))
+                .foregroundColor(.gray)
+        }
+        .frame(minWidth: minWidth, alignment: .trailing)
+    }
+}
+```
+
+Adjust spacing and widths to keep title and controls readable at `1280 x 120`. Keep the header dark and compact; do not add live judgment text.
+
+**Step 4: Run header tests**
+
+Run:
+
+```bash
+xcodebuild test \
+  -project Virgo.xcodeproj \
+  -scheme Virgo \
+  -destination 'platform=macOS' \
+  -configuration Debug \
+  -only-testing:VirgoTests/SwiftUIRenderingCoverageTests/testGameplayHeaderViewRendering \
+  -only-testing:VirgoTests/SwiftUIRenderingCoverageTests/testGameplayHeaderViewRendersScoreSnapshotStats \
+  ONLY_ACTIVE_ARCH=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  -destination-timeout 300 \
+  -derivedDataPath ./DerivedData
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add Virgo/components/GameplayHeaderView.swift VirgoTests/SwiftUIRenderingCoverageTests.swift
+git commit -m "feat: show live score quality in gameplay HUD"
+```
+
+## Task 5: Update results sheet to use final score snapshot
+
+**Files:**
+- Modify: `Virgo/views/subviews/SessionResultsView.swift`
+- Modify: `Virgo/views/GameplayView.swift`
+- Modify: `VirgoTests/SwiftUIRenderingCoverageTests.swift`
+
+**Step 1: Write/update failing results tests**
+
+Update `SessionResultsView` construction in `VirgoTests/SwiftUIRenderingCoverageTests.swift` to pass a snapshot:
+
+```swift
+let scoreEngine = makeScoreEngineForResults()
+let view = SessionResultsView(
+    finalScore: 2450,
+    highScore: 2450,
+    isNewRecord: true,
+    scoreSnapshot: LiveScoreSnapshot(scoreEngine: scoreEngine),
+    onPlayAgain: {},
+    onDone: {}
+)
+```
+
+Apply the same pattern to the non-record results test.
+
+**Step 2: Run the failing rendering tests**
+
+Run:
+
+```bash
+xcodebuild test \
+  -project Virgo.xcodeproj \
+  -scheme Virgo \
+  -destination 'platform=macOS' \
+  -configuration Debug \
+  -only-testing:VirgoTests/SwiftUIRenderingCoverageTests/testSessionResultsViewRenderingForNewRecord \
+  -only-testing:VirgoTests/SwiftUIRenderingCoverageTests/testSessionResultsViewRenderingWithoutRecordBadge \
+  ONLY_ACTIVE_ARCH=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  -destination-timeout 300 \
+  -derivedDataPath ./DerivedData
+```
+
+Expected: FAIL because `SessionResultsView` still accepts `scoreEngine`.
+
+**Step 3: Update `SessionResultsView`**
+
+Change the property:
+
+```swift
+    let scoreSnapshot: LiveScoreSnapshot
+```
+
+Replace direct `scoreEngine` reads:
+
+```swift
+AccuracyCircleView(percentage: scoreSnapshot.hitAccuracy)
+```
+
+```swift
+AccuracyBreakdownChart(
+    perfectCount: scoreSnapshot.perfectCount,
+    greatCount: scoreSnapshot.greatCount,
+    goodCount: scoreSnapshot.goodCount,
+    missCount: scoreSnapshot.missCount
+)
+```
+
+```swift
+TimingDeviationView(
+    averageDeviation: scoreSnapshot.averageTimingDeviation,
+    earlyPercentage: scoreSnapshot.earlyPercentage,
+    latePercentage: scoreSnapshot.latePercentage,
+    tendency: scoreSnapshot.timingTendency
+)
+```
+
+Update `statsGrid` to include max combo, timing quality, and best score:
+
+```swift
+private var statsGrid: some View {
+    HStack(spacing: 0) {
+        statCell(label: "MAX COMBO", value: "\(scoreSnapshot.maxCombo)x", color: .orange)
+        statCell(label: "QUALITY", value: scoreSnapshot.timingQualityPercentText, color: .cyan)
+        statCell(label: "BEST SCORE", value: "\(highScore)", color: .purple)
+    }
+    .padding(.horizontal)
+}
+```
+
+Update the preview to build a `LiveScoreSnapshot(scoreEngine: engine)`.
+
+**Step 4: Update `GameplayView` call site**
+
+In `Virgo/views/GameplayView.swift`, change:
+
+```swift
+                    scoreEngine: vm.sessionScoreEngine,
+```
+
+to:
+
+```swift
+                    scoreSnapshot: vm.sessionScoreSnapshot,
+```
+
+**Step 5: Run the results tests**
+
+Run the same two `SwiftUIRenderingCoverageTests` results tests.
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add Virgo/views/subviews/SessionResultsView.swift Virgo/views/GameplayView.swift VirgoTests/SwiftUIRenderingCoverageTests.swift
+git commit -m "feat: render results from score snapshots"
+```
+
+## Task 6: Run final focused and full verification
+
+**Files:**
+- No code edits unless verification finds a regression.
+
+**Step 1: Run focused score presentation tests**
+
+Run:
+
+```bash
+xcodebuild test \
+  -project Virgo.xcodeproj \
+  -scheme Virgo \
+  -destination 'platform=macOS' \
+  -configuration Debug \
+  -only-testing:VirgoTests/LiveScoreSnapshotTests \
+  -only-testing:VirgoTests/GameplayViewModelPlaybackCoverageTests \
+  -only-testing:VirgoTests/SwiftUIRenderingCoverageTests \
+  ONLY_ACTIVE_ARCH=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  -destination-timeout 300 \
+  -derivedDataPath ./DerivedData
+```
+
+Expected: PASS.
+
+**Step 2: Run full unit tests**
+
+Run:
+
+```bash
+xcodebuild test \
+  -project Virgo.xcodeproj \
+  -scheme Virgo \
+  -destination 'platform=macOS' \
+  -configuration Debug \
+  -only-testing:VirgoTests \
+  ONLY_ACTIVE_ARCH=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  -enableCodeCoverage YES \
+  -destination-timeout 300 \
+  -derivedDataPath ./DerivedData
+```
+
+Expected: PASS.
+
+**Step 3: Run SwiftLint if available**
+
+Run:
+
+```bash
+swiftlint lint
+```
+
+Expected: PASS or only pre-existing warnings unrelated to touched files. If `swiftlint` is unavailable, record that clearly in the final implementation report.
+
+**Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git status -sb
+git diff --stat
+git diff --check
+```
+
+Expected: only score-system files changed, no whitespace errors, `.superpowers/` still untracked unless separately ignored by the user.
+
+**Step 5: Final commit if verification required fixes**
+
+If verification required fixes, commit them:
+
+```bash
+git add Virgo/utilities/LiveScoreSnapshot.swift Virgo/viewmodels/GameplayViewModel.swift Virgo/components/GameplayHeaderView.swift Virgo/views/GameplayView.swift Virgo/views/subviews/SessionResultsView.swift VirgoTests/LiveScoreSnapshotTests.swift VirgoTests/GameplayViewModelCoveragePlaybackAdditionsTests.swift VirgoTests/SwiftUIRenderingCoverageTests.swift
+git commit -m "test: verify score presentation flow"
+```
+
+If no extra fixes were needed after the task commits, do not create an empty commit.

--- a/docs/superpowers/specs/2026-05-16-simfile-graphql-backend-requirements.md
+++ b/docs/superpowers/specs/2026-05-16-simfile-graphql-backend-requirements.md
@@ -1,0 +1,222 @@
+# Simfile GraphQL Backend — Client Requirements
+
+**Author:** Virgo client team
+**Date:** 2026-05-16
+**Audience:** Backend team owning the existing service that will host the simfile GraphQL API
+**Status:** Draft, awaiting backend team review
+
+## 1. Context
+
+Virgo is a SwiftUI drum-notation/practice app (iOS 18.5+, macOS 14.0+). Today it talks to a small standalone FastAPI server (`server/main.py` in the Virgo repo) that lists DTX drum charts and serves the chart, BGM, and preview-audio files for download. That server is being retired and its responsibilities will be moved into your existing backend, exposed as **GraphQL**.
+
+This document describes **what the Virgo client needs to read** from the new API. It does not describe how songs are ingested, parsed, or stored on the server side — those are the backend team's concerns.
+
+## 2. Goals & non-goals
+
+### Goals
+- Let the client browse a catalog of drum songs and their charts.
+- Let the client download the chart file (`.dtx`), full BGM audio (`.ogg`), and short preview clip (`.mp3`) for any song.
+- Support search, filtering, and pagination as the catalog grows.
+- Expose richer metadata than the underlying DTX files provide (genre, tags, accurate duration).
+- Be cacheable and incrementally refreshable from the client.
+
+### Non-goals (v1)
+- Mutations of any kind (no admin, upload, edit, delete).
+- User accounts, authentication, authorization. Anonymous reads only.
+- Ratings, comments, leaderboards, social features.
+- Real-time subscriptions.
+- Backwards compatibility with the legacy "individual `.dtx` file" endpoints (`/dtx/list` → `individual_files`, `/dtx/metadata/{filename}`). The client will drop the corresponding code paths.
+
+## 3. Transport & auth
+
+- **Transport:** HTTPS, single GraphQL endpoint (e.g., `POST /graphql`).
+- **Auth:** None. All queries are public.
+- **CORS:** Not required — the client is a native iOS/macOS app, not a browser. (Permissive CORS is acceptable but not requested.)
+- **Persisted queries:** Optional. The client's query set is small and fixed; if your platform prefers persisted queries we will adopt them.
+
+## 4. File delivery contract
+
+Binary files (DTX charts, BGM, preview audio) live in **Cloudflare R2**. The GraphQL API does **not** stream binary data. Instead, every URL field returns a **short-lived signed R2 URL** that the client downloads directly with `URLSession`.
+
+Requirements:
+
+| Field type     | TTL (recommended) | Optional? | If file missing in R2 |
+| -------------- | ----------------- | --------- | --------------------- |
+| Chart `.dtx`   | ≥ 15 minutes      | No        | Server-side data error — surface as a GraphQL error on the parent `Chart` field |
+| BGM `.ogg`     | ≥ 15 minutes      | Yes       | Return `null` |
+| Preview `.mp3` | ≥ 15 minutes      | Yes       | Return `null` |
+
+The 15-minute floor matters because the client may download a chart immediately and the larger BGM file later in the same session (e.g., on a slow mobile connection). URLs are per-request — the client does not persist them.
+
+GraphQL responses that include signed URLs should carry `Cache-Control: private, max-age=<TTL/2>` so intermediate caches do not serve stale URLs to other clients.
+
+## 5. Data model
+
+A **Song** has 1..N **Charts** (one chart per difficulty). The client renders songs in a list (`ServerSongsView`) and downloads chart + audio assets on demand.
+
+```graphql
+type Song {
+  id: ID!                    # stable identifier (e.g., URL-safe slug). Used as the client cache key.
+  title: String!
+  artist: String!            # default "Unknown Artist" if the underlying source has none
+  bpm: Float!                # tempo in beats-per-minute (Double precision, e.g. 165.55)
+  genre: String              # server-curated; client falls back to "DTX Import" if null
+  tags: [String!]!           # server-curated; empty list is fine
+  durationSeconds: Int       # accurate duration if known; null if not yet computed
+  bgmUrl: String             # signed R2 URL for full BGM .ogg, or null
+  previewAudioUrl: String    # signed R2 URL for ~30s preview .mp3, or null
+  charts: [Chart!]!          # always at least one
+  updatedAt: DateTime!       # last time the server's record changed; powers `updatedSince` filter
+}
+
+type Chart {
+  id: ID!
+  difficulty: Difficulty!    # canonical bucket
+  difficultyLabel: String!   # original label, e.g. "BASIC", "ADVANCED", "EXTREME", "MASTER", "REAL"
+  level: Int!                # numeric level inside the difficulty bucket (e.g. 36, 60, 74, 87)
+  fileUrl: String!           # signed R2 URL for the .dtx chart file
+  fileSizeBytes: Int!
+  fileEncoding: FileEncoding!  # the client must know how to decode the .dtx file's text
+}
+
+enum Difficulty {
+  EASY
+  MEDIUM
+  HARD
+  EXPERT
+}
+
+enum FileEncoding {
+  SHIFT_JIS    # the common case for legacy DTX files
+  UTF_8
+}
+
+scalar DateTime  # ISO-8601 string, UTC
+```
+
+### Field notes
+
+- **`Song.id`** is what the client persists in its SwiftData `ServerSong.songId`. It must be stable across catalog refreshes; renaming/restructuring server-side IDs would invalidate the client's download-state cache.
+- **`Song.artist`, `Song.bpm`** are non-null because the client treats them as guaranteed in its UI. If the source data is missing, the server picks sensible defaults (`"Unknown Artist"`, last-known-good or `120.0`).
+- **`Song.genre`** is nullable: the client falls back to a literal `"DTX Import"` today when nothing is provided, so `null` is safe.
+- **`Song.durationSeconds`** replaces a fragile client-side estimate (the client currently guesses from note counts at ~120 BPM). If accurate duration isn't available the field can be `null` and the client keeps its estimate.
+- **`Chart.difficulty`** is the canonical 4-bucket enum the app's UI groups by. The original label is preserved in `difficultyLabel` for display.
+- **`Chart.fileEncoding`** is required because Virgo decodes the `.dtx` text with the indicated encoding (`String(data:, encoding: .shiftJIS)` today). Without this field, the client must hard-code an assumption.
+
+## 6. Queries
+
+The client needs exactly two read queries.
+
+### 6.1 `song(id: ID!): Song`
+
+Fetch a single song by id. Used when the client refreshes one entry (e.g., after the user opens its detail view, or after a download completes) without re-fetching the whole list.
+
+Returns `null` if not found.
+
+### 6.2 `songs(...): SongConnection!`
+
+Paginated, filterable, sortable listing. Powers the main browse screen (`ServerSongsView`) and any future search UI.
+
+```graphql
+type Query {
+  song(id: ID!): Song
+  songs(
+    first: Int = 50           # max 100
+    after: String             # opaque cursor
+    filter: SongFilter
+    sort: SongSort = TITLE_ASC
+  ): SongConnection!
+}
+
+input SongFilter {
+  query: String               # case-insensitive substring match against title OR artist
+  genres: [String!]
+  difficulty: Difficulty      # song has at least one chart at this difficulty
+  bpmMin: Float
+  bpmMax: Float
+  updatedSince: DateTime      # only songs whose updatedAt > this value
+}
+
+enum SongSort {
+  TITLE_ASC
+  ARTIST_ASC
+  UPDATED_AT_DESC
+  BPM_ASC
+}
+
+type SongConnection {
+  edges: [SongEdge!]!
+  pageInfo: PageInfo!
+  totalCount: Int!            # total matches (server-side count after filters)
+}
+
+type SongEdge {
+  cursor: String!
+  node: Song!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  endCursor: String
+}
+```
+
+### Why cursor pagination
+
+The client maintains a persistent `ServerSong` SwiftData cache that lives across app launches and is refreshed every ~5 minutes. Offset pagination is unstable as the catalog grows or reorders; cursor pagination keeps the client's incremental refresh logic correct.
+
+### `updatedSince` semantics
+
+After the first full load, the client can re-fetch only changed songs via `filter: { updatedSince: <last-known-max-updatedAt> }`. Servers that cannot support this efficiently in v1 may return the full set, but the field should still accept the input so the client doesn't need a schema change later.
+
+## 7. Errors
+
+Use standard GraphQL `errors[]` with an `extensions.code` string. The client maps these to user-facing messages.
+
+| `extensions.code`  | Meaning                                  | Client behavior                          |
+| ------------------ | ---------------------------------------- | ---------------------------------------- |
+| `INVALID_INPUT`    | Filter values out of range / malformed   | Treated as a bug; logged |
+| `RATE_LIMITED`     | Too many requests                        | Backoff + retry once |
+| `INTERNAL`         | Unexpected server error                  | Show generic error, allow retry |
+
+"Not found" cases are **not** errors: `song(id)` returns `null`, and an empty `songs` connection is a valid result.
+
+Field-level errors (e.g., a `Chart.fileUrl` that cannot be signed because the file is missing) should be returned as a GraphQL error on that path so the client can still render the rest of the song.
+
+## 8. Non-functional requirements
+
+- **Latency target:** P95 < 300 ms for `song` and `songs` queries, excluding R2 signing time.
+- **Page size:** `first` defaults to 50, max 100. The client typically requests 50.
+- **Catalog size assumption:** hundreds of songs in v1, low thousands within a year.
+- **Availability:** No formal SLA requested. The client degrades gracefully when offline (shows cached songs).
+- **Schema evolution:** Additive changes preferred. The client uses a typed GraphQL client and is tolerant of unknown fields.
+
+## 9. Reference: where each field is consumed in the client
+
+For traceability when reviewing this spec against the current code:
+
+| GraphQL field                | Client model field                                          | Used in |
+| ---------------------------- | ----------------------------------------------------------- | ------- |
+| `Song.id`                    | `ServerSong.songId`                                         | Cache key; download path |
+| `Song.title`                 | `ServerSong.title` / `Song.title`                           | List, detail, gameplay header |
+| `Song.artist`                | `ServerSong.artist` / `Song.artist`                         | List, detail |
+| `Song.bpm`                   | `ServerSong.bpm` / `Song.bpm`                               | Metronome, gameplay |
+| `Song.genre`                 | `Song.genre`                                                | List filter, library grouping |
+| `Song.durationSeconds`       | `Song.duration` (formatted as `mm:ss`)                      | List, detail |
+| `Song.bgmUrl`                | downloaded → `Song.bgmFilePath`                             | BGM playback in gameplay |
+| `Song.previewAudioUrl`       | downloaded → `Song.previewFilePath`                         | Preview clip in song list |
+| `Chart.difficulty`           | `ServerChart.difficulty` / `Chart.difficulty`               | Difficulty badge, chart selection |
+| `Chart.difficultyLabel`      | `ServerChart.difficultyLabel`                               | Display label |
+| `Chart.level`                | `ServerChart.level` / `Chart.level`                         | Difficulty level number |
+| `Chart.fileUrl`              | downloaded → fed into `DTXFileParser`                       | Note parsing for gameplay |
+| `Chart.fileSizeBytes`        | `ServerChart.size`                                          | Download progress UX |
+| `Chart.fileEncoding`         | currently hard-coded as Shift-JIS in the client             | DTX text decoding |
+
+## 10. Open questions for backend team
+
+These are answers we'd like before client integration starts:
+
+1. **Signed URL TTL:** Is ≥ 15 min feasible with your R2 setup?
+2. **`updatedSince` filter:** Can it be supported efficiently in v1, or should the client plan to do full refreshes only?
+3. **Schema introspection:** Will introspection be enabled in production? (Affects whether we can run codegen against the live endpoint or need a pre-published schema file.)
+4. **Endpoint URL & environments:** What hosts should the client target for dev / staging / prod?

--- a/docs/superpowers/specs/2026-05-19-score-system-presentation-design.md
+++ b/docs/superpowers/specs/2026-05-19-score-system-presentation-design.md
@@ -1,0 +1,172 @@
+# Score System Presentation Design
+
+**Date:** 2026-05-19  
+**Status:** Approved for implementation planning  
+**Scope:** Harden the existing live scoring loop and improve gameplay/results presentation.
+
+## 1. Context
+
+Virgo already has an active gameplay scoring pipeline:
+
+```text
+InputManager
+  -> InputTimingMatcher
+      -> NoteMatchResult
+          -> GameplayViewModel.recordHit(result:)
+              -> ScoreEngine
+```
+
+`ScoreEngine` owns score, combo, hit counts, miss counts, and timing deviation state. `GameplayViewModel` coordinates session timing, duplicate-hit rejection, auto-miss scanning, completion, and high-score persistence through `HighScoreService`. `GameplayHeaderView` already displays score and combo, and `SessionResultsView` already shows a post-run summary.
+
+This feature should not replace that architecture. It should finish the scoring presentation around the existing system, make the live HUD more useful during tablet play, and harden edge cases that could make scoring feel unfair.
+
+## 2. Goals
+
+- Keep `ScoreEngine` as the scoring authority.
+- Add a clear live presentation contract for score, combo, hit accuracy, weighted timing quality, counts, and timing stats.
+- Keep live gameplay feedback glanceable and readable on a tablet.
+- Do not show live judgment text such as `PERFECT`, `GREAT`, `GOOD`, or `MISS`.
+- Improve the results sheet so it explains the session after play ends.
+- Preserve current duplicate-hit handling, auto-miss late-window behavior, and per-chart high-score persistence.
+- Add focused tests around scoring math, session edge cases, and UI-facing snapshots.
+
+## 3. Non-Goals
+
+- Replacing the scoring engine with a new rhythm-game ruleset.
+- Adding a life gauge, fail state, rank letters, rewards, progression, or calibration tools.
+- Changing MIDI routing, keyboard mapping, DTX parsing, notation layout, or audio sync behavior.
+- Showing per-hit judgment labels during gameplay.
+- Adding hardware-dependent MIDI tests.
+
+## 4. Scoring Contract
+
+The existing score rules remain the baseline:
+
+- Perfect hit: 100 base points.
+- Great hit: 80 base points.
+- Good hit: 50 base points.
+- Miss: 0 points and combo reset.
+- Combo multiplier tiers stay at 10, 25, 50, and 100 combo.
+- Non-miss hits increment combo before scoring.
+- Auto-missed notes increment miss count and reset combo without adding score.
+- Per-chart high scores are saved only when the final score is strictly greater than the existing record.
+
+The presentation layer should expose these derived values:
+
+| Value | Meaning |
+|---|---|
+| `score` | Current score from `ScoreEngine` |
+| `currentCombo` | Current combo, also used as the live streak stat |
+| `maxCombo` | Best combo reached in the session |
+| `hitAccuracy` | Non-miss judged notes divided by total judged notes, returning 0 when no notes are judged |
+| `timingQuality` | `(perfect * 1.0 + great * 0.8 + good * 0.5) / judgedNotes * 100`, with Miss weighted as 0 and empty sessions returning 0 |
+| `perfectCount` / `greatCount` / `goodCount` / `missCount` | Session count breakdown |
+| `averageTimingDeviation` | Mean timing error for non-miss hits with timing data |
+| `timingTendency` | Early, late, or balanced session tendency |
+
+`hitAccuracy` and `timingQuality` are intentionally separate. Hit accuracy answers "how many notes did I avoid missing?" Timing quality answers "how clean were my judged notes?"
+
+## 5. Presentation Model
+
+Add a small immutable presentation model named `LiveScoreSnapshot`, derived from `ScoreEngine`.
+
+The snapshot should:
+
+- centralize live/result formulas so SwiftUI views do not duplicate scoring math;
+- be cheap to create on the main actor after each scoring change;
+- expose formatted or raw numeric values as needed by the UI;
+- be testable without SwiftUI or audio dependencies;
+- support both live HUD and results surfaces.
+
+`ScoreEngine` may expose any pure computed properties needed to build the snapshot, but UI components should prefer consuming the snapshot instead of reaching into all `ScoreEngine` internals directly.
+
+## 6. Gameplay HUD Design
+
+The live HUD should stay compact and stable. It should show:
+
+- score;
+- current combo;
+- hit accuracy;
+- timing quality.
+
+It should not show judgment text. On a tablet, the player is focused on the chart and drum input; detailed text feedback would be hard to read and could distract from the notation.
+
+The HUD should use stable dimensions for score/stat cells so changing numbers do not shift the sheet music. The existing header is the right surface, but it should be reorganized so stats are readable without crowding the title or controls.
+
+## 7. Results Design
+
+The results sheet should carry the detailed feedback that is intentionally absent during live play. It should show:
+
+- final score;
+- best score;
+- new-best badge only when `HighScoreService.saveIfHighScore` confirms the write;
+- hit accuracy;
+- timing quality;
+- max combo;
+- Perfect / Great / Good / Miss breakdown;
+- average timing deviation and timing tendency;
+- `Play Again` and `Done` actions.
+
+The results surface should explain the run in a way the player can read after finishing. It should not require reconstructing meaning from raw counts alone.
+
+## 8. Edge Cases
+
+The implementation should preserve or add explicit coverage for these behaviors:
+
+- Hits before playback starts or after playback stops are ignored.
+- Duplicate hits against the same note do not change score or combo.
+- Wrong-lane hits inside the search window count as misses only when no matching note exists for that lane.
+- Auto-missed notes are marked only after the Good late window has passed.
+- Pause, MIDI disconnect, and resume do not create unavoidable misses.
+- Playback completion waits through the final late-hit grace window before saving.
+- Skip-to-end marks all unscored notes as misses before saving.
+- Zero scores do not create high-score records.
+- Failed high-score writes do not show the new-best badge.
+
+## 9. Data Flow
+
+1. `InputManager` receives keyboard or MIDI input during active playback.
+2. `InputTimingMatcher` converts input into a `NoteMatchResult`.
+3. `GameplayInputHandler` forwards the result to `GameplayViewModel.recordHit(result:)`.
+4. `GameplayViewModel` scans prior missed notes, rejects duplicate hits, and updates `ScoreEngine`.
+5. `GameplayViewModel` exposes a live score snapshot for HUD rendering.
+6. On completion, `GameplayViewModel` saves the final score through `HighScoreService`.
+7. `GameplayViewModel` captures a final score snapshot before resetting live state.
+8. `SessionResultsView` renders the final snapshot and verified high-score state.
+
+## 10. Testing Strategy
+
+Use Swift Testing with deterministic unit coverage.
+
+Pure scoring tests:
+
+- `hitAccuracy` with empty, all-hit, all-miss, and mixed sessions.
+- `timingQuality` with Perfect, Great, Good, Miss, and mixed sessions.
+- count math, reset behavior, combo multiplier boundaries, and max combo.
+- snapshot construction from representative `ScoreEngine` states.
+
+Gameplay view-model tests:
+
+- hit recording updates score snapshot;
+- duplicate-hit rejection does not mutate score;
+- auto-miss late-window behavior preserves valid late hits;
+- pause/resume and MIDI disconnect paths do not advance miss scanning while paused;
+- skip-to-end marks remaining notes as misses before saving;
+- completion captures final score and snapshot before reset;
+- failed or non-record high-score saves do not show new-best state.
+
+UI/component tests:
+
+- gameplay HUD receives and renders score, combo, hit accuracy, and timing quality;
+- results summary receives and renders final score, high score, max combo, quality stats, and timing tendency;
+- live HUD layout gives score and stat cells fixed or minimum widths so changing values do not resize the header.
+
+Verification after implementation should run focused scoring/view-model tests first, then the full macOS `VirgoTests` command from the repository instructions.
+
+## 11. Implementation Notes
+
+- Keep scoring formulas pure and isolated.
+- Avoid introducing `@Published` hot-path dependencies into `GameplayView`.
+- Keep `GameplayViewModel` as the coordinator for live session state.
+- Keep persistence outside the input/scoring hot path.
+- Stage only score-system files during implementation; `.superpowers/` visual companion artifacts should remain uncommitted.


### PR DESCRIPTION
## Summary
- Introduce `LiveScoreSnapshot` as an immutable, display-ready value-type that captures all scoring state from `ScoreEngine`
- Redesign `GameplayHeaderView` with `ViewThatFits`-based adaptive layout (regular vs compact) and a new score HUD showing SCORE, ACC, and QLTY stats
- Expose `liveScoreSnapshot` on `GameplayViewModel` so the HUD observation stays scoped to the header subview
- Update `SessionResultsView` to render from `LiveScoreSnapshot` instead of directly observing `ScoreEngine`; adds QUALITY stat to the results grid
- Fix finite missed-note scan to be ignored while playback is paused (infinite scan still flushes remaining misses)
- Add comprehensive unit tests for snapshot logic, view-model lifecycle, and SwiftUI rendering coverage for both regular and compact header layouts

## Test plan
- [x] `LiveScoreSnapshotTests` — empty state, score/combo counts, hit accuracy, timing quality, timing deviation fields
- [x] `GameplayViewModelPlaybackCoverageTests` — live snapshot reflection, completion capture, paused finite miss scan, infinite miss flush while paused
- [x] `SwiftUIRenderingCoverageTests` — header renders snapshot stats, compact layout at iPhone portrait width

Generated with [Devin](https://cli.devin.ai/docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gameplay header layout now adapts between regular and compact designs based on available screen space
  * Score display reorganized with improved visibility of accuracy, quality, and combo statistics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cwchanap/Virgo/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->