### PR TITLE
[codex] fix macOS UI test selectors

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -62,6 +62,15 @@ jobs:
         
       - name: Show available simulators
         run: xcrun simctl list devices available
+
+      - name: Disable macOS setup assistant
+        run: |
+          defaults write com.apple.SetupAssistant DidSeeCloudSetup -bool true
+          defaults write com.apple.SetupAssistant DidSeePrivacy -bool true
+          defaults write com.apple.SetupAssistant DidSeeSiriSetup -bool true
+          defaults write com.apple.SetupAssistant LastSeenCloudProductVersion "$(sw_vers -productVersion)"
+          defaults write com.apple.SetupAssistant LastSeenBuddyBuildVersion "$(sw_vers -buildVersion)"
+          killall "Setup Assistant" || true
         
       - name: Clean build folder
         run: xcodebuild clean -project Virgo.xcodeproj -scheme Virgo

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -112,6 +112,9 @@ jobs:
           echo "  Device: ${{ matrix.destination }}"
           echo "  Test target: $TEST_TARGET"
           echo "  Timeout: ${TIMEOUT}s"
+
+          mkdir -p ./ui-test-results
+          rm -rf ./ui-test-results/ui-tests.xcresult
           
           xcodebuild test-without-building \
             -project Virgo.xcodeproj \
@@ -124,7 +127,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             -enableCodeCoverage YES \
             -destination-timeout $TIMEOUT \
-            -resultBundlePath ./ui-test-results \
+            -resultBundlePath ./ui-test-results/ui-tests.xcresult \
             | tee ui-test-output.log
             
       - name: Set device name for artifacts

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -3,6 +3,8 @@ name: macOS UI Tests
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
   # Allow manual trigger for testing
   workflow_dispatch:
     inputs:

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ ui-test-activity-log.json
 Screenshot*.png
 
 .claude/settings.local.json
+.superpowers/
 .devin/config.local.json
 .xcodebuildmcp/

--- a/Virgo/components/DifficultyExpansionView.swift
+++ b/Virgo/components/DifficultyExpansionView.swift
@@ -81,6 +81,8 @@ struct ChartSelectionCard: View {
             .opacity(isPressed ? 0.8 : 1.0)
         }
         .buttonStyle(PlainButtonStyle())
+        .accessibilityIdentifier("chartDifficulty\(chart.difficulty.rawValue)")
+        .accessibilityLabel("\(chart.difficulty.rawValue) difficulty, \(chart.notesCount) notes, Level \(chart.level)")
         .onLongPressGesture(minimumDuration: 0, maximumDistance: .infinity, pressing: { pressing in
             withAnimation(.easeInOut(duration: 0.1)) {
                 isPressed = pressing

--- a/Virgo/components/ExpandableSongRow.swift
+++ b/Virgo/components/ExpandableSongRow.swift
@@ -71,6 +71,7 @@ struct ExpandableSongRow: View {
                             .foregroundColor(isPlaying ? .red : .purple)
                     }
                     .buttonStyle(PlainButtonStyle())
+                    .accessibilityLabel(isPlaying ? "Pause" : "Play")
                     .onTapGesture { onPlayTap() } // Prevent song expansion when tapping play
 
                     // Song Info
@@ -108,6 +109,7 @@ struct ExpandableSongRow: View {
                                     .foregroundColor(song.isSaved ? .purple : .gray)
                             }
                             .buttonStyle(PlainButtonStyle())
+                            .accessibilityLabel(song.isSaved ? "Saved" : "Bookmark")
 
                             // Available Difficulties
                             HStack(spacing: 2) {

--- a/Virgo/components/ExpandableSongRow.swift
+++ b/Virgo/components/ExpandableSongRow.swift
@@ -62,83 +62,85 @@ struct ExpandableSongRow: View {
     var body: some View {
         VStack(spacing: 0) {
             // Main song row
-            Button(action: onSongTap) {
-                HStack(spacing: 12) {
-                    // Play/Pause Button
-                    Button(action: onPlayTap) {
-                        Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
-                            .font(.system(size: 40))
-                            .foregroundColor(isPlaying ? .red : .purple)
-                    }
-                    .buttonStyle(PlainButtonStyle())
-                    .accessibilityLabel(isPlaying ? "Pause" : "Play")
-                    .onTapGesture { onPlayTap() } // Prevent song expansion when tapping play
-
-                    // Song Info
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(song.title)
-                            .font(.headline)
-                            .lineLimit(1)
-                            .foregroundColor(.white)
-
-                        Text(song.artist)
-                            .font(.subheadline)
-                            .foregroundColor(.gray)
-                            .lineLimit(1)
-
-                        HStack(spacing: 12) {
-                            Label("\(song.bpm) BPM", systemImage: "metronome")
-                            Label(song.duration, systemImage: "clock")
-                            Label(song.genre, systemImage: "music.quarternote.3")
-                            Label(song.timeSignature.displayName, systemImage: "music.note")
-                            Label("\(relationshipData.measureCount) measures", systemImage: "music.note.list")
-                        }
-                        .font(.caption)
-                        .foregroundColor(.gray)
-                    }
-
-                    Spacer()
-
-                    // Save Button and Available Difficulties and Expand Indicator
-                    VStack(spacing: 4) {
-                        HStack(spacing: 8) {
-                            // Save Button
-                            Button(action: onSaveTap) {
-                                Image(systemName: song.isSaved ? "bookmark.fill" : "bookmark")
-                                    .font(.system(size: 18))
-                                    .foregroundColor(song.isSaved ? .purple : .gray)
-                            }
-                            .buttonStyle(PlainButtonStyle())
-                            .accessibilityLabel(song.isSaved ? "Remove bookmark" : "Save song")
-                            .accessibilityValue(song.isSaved ? "Saved" : "Not saved")
-
-                            // Available Difficulties
-                            HStack(spacing: 2) {
-                                ForEach(relationshipData.availableDifficulties, id: \.self) { difficulty in
-                                    DifficultyBadge(difficulty: difficulty, size: .small)
-                                }
-                            }
-                        }
-
-                        HStack(spacing: 4) {
-                            Image(systemName: "chevron.down")
-                                .font(.caption)
-                                .foregroundColor(.gray)
-                                .rotationEffect(.degrees(isExpanded ? 180 : 0))
-                                .animation(.easeInOut(duration: 0.3), value: isExpanded)
-
-                            Text("\(relationshipData.chartCount) charts")
-                                .font(.caption2)
-                                .foregroundColor(.gray)
-                        }
-                    }
+            HStack(spacing: 12) {
+                // Play/Pause Button
+                Button(action: onPlayTap) {
+                    Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                        .font(.system(size: 40))
+                        .foregroundColor(isPlaying ? .red : .purple)
                 }
-                .padding(.vertical, 8)
-                .padding(.horizontal, 12)
-                .background(isPlaying ? Color.purple.opacity(0.2) : Color.white.opacity(0.1))
-                .cornerRadius(12)
+                .buttonStyle(PlainButtonStyle())
+                .accessibilityLabel(isPlaying ? "Pause" : "Play")
+
+                // Song Info
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(song.title)
+                        .font(.headline)
+                        .lineLimit(1)
+                        .foregroundColor(.white)
+
+                    Text(song.artist)
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                        .lineLimit(1)
+
+                    HStack(spacing: 12) {
+                        Label("\(song.bpm) BPM", systemImage: "metronome")
+                        Label(song.duration, systemImage: "clock")
+                        Label(song.genre, systemImage: "music.quarternote.3")
+                        Label(song.timeSignature.displayName, systemImage: "music.note")
+                        Label("\(relationshipData.measureCount) measures", systemImage: "music.note.list")
+                    }
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onSongTap)
+
+                // Save Button and Available Difficulties and Expand Indicator
+                VStack(spacing: 4) {
+                    HStack(spacing: 8) {
+                        // Save Button
+                        Button(action: onSaveTap) {
+                            Image(systemName: song.isSaved ? "bookmark.fill" : "bookmark")
+                                .font(.system(size: 18))
+                                .foregroundColor(song.isSaved ? .purple : .gray)
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                        .accessibilityLabel(song.isSaved ? "Remove bookmark" : "Save song")
+                        .accessibilityIdentifier("downloadedSongBookmarkButton")
+                        .accessibilityValue(song.isSaved ? "Saved" : "Not saved")
+
+                        // Available Difficulties
+                        HStack(spacing: 2) {
+                            ForEach(relationshipData.availableDifficulties, id: \.self) { difficulty in
+                                DifficultyBadge(difficulty: difficulty, size: .small)
+                            }
+                        }
+                        .contentShape(Rectangle())
+                        .onTapGesture(perform: onSongTap)
+                    }
+
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.down")
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                            .rotationEffect(.degrees(isExpanded ? 180 : 0))
+                            .animation(.easeInOut(duration: 0.3), value: isExpanded)
+
+                        Text("\(relationshipData.chartCount) charts")
+                            .font(.caption2)
+                            .foregroundColor(.gray)
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture(perform: onSongTap)
+                }
             }
-            .buttonStyle(PlainButtonStyle())
+            .padding(.vertical, 8)
+            .padding(.horizontal, 12)
+            .background(isPlaying ? Color.purple.opacity(0.2) : Color.white.opacity(0.1))
+            .cornerRadius(12)
 
             // Expanded difficulty options
             if isExpanded {

--- a/Virgo/components/ExpandableSongRow.swift
+++ b/Virgo/components/ExpandableSongRow.swift
@@ -109,7 +109,8 @@ struct ExpandableSongRow: View {
                                     .foregroundColor(song.isSaved ? .purple : .gray)
                             }
                             .buttonStyle(PlainButtonStyle())
-                            .accessibilityLabel(song.isSaved ? "Saved" : "Bookmark")
+                            .accessibilityLabel(song.isSaved ? "Remove bookmark" : "Save song")
+                            .accessibilityValue(song.isSaved ? "Saved" : "Not saved")
 
                             // Available Difficulties
                             HStack(spacing: 2) {

--- a/Virgo/components/GameplayControlsView.swift
+++ b/Virgo/components/GameplayControlsView.swift
@@ -60,6 +60,7 @@ struct GameplayControlsView: View {
                         .foregroundColor(.white)
                 }
                 .accessibilityLabel("Restart")
+                .accessibilityIdentifier("gameplayMainRestartButton")
                 .accessibilityHint("Restarts the track from the beginning")
 
                 Button(action: onPlayPause) {
@@ -68,6 +69,7 @@ struct GameplayControlsView: View {
                         .foregroundColor(isPlaying ? .red : .green)
                 }
                 .accessibilityLabel(isPlaying ? "Pause" : "Play")
+                .accessibilityIdentifier("gameplayMainPlayPauseButton")
                 .accessibilityHint(isPlaying ? "Pauses playback" : "Starts playback")
 
                 Button(action: onSkipToEnd) {
@@ -76,6 +78,7 @@ struct GameplayControlsView: View {
                         .foregroundColor(.white)
                 }
                 .accessibilityLabel("Skip to end")
+                .accessibilityIdentifier("gameplaySkipToEndButton")
                 .accessibilityHint("Jumps to the end of the track")
             }
 

--- a/Virgo/components/GameplayHeaderView.swift
+++ b/Virgo/components/GameplayHeaderView.swift
@@ -77,6 +77,7 @@ struct GameplayHeaderView: View {
                 .foregroundColor(.white)
         }
         .accessibilityLabel("Go back")
+        .accessibilityIdentifier("gameplayBackButton")
         .accessibilityHint("Returns to the song list")
     }
 
@@ -88,6 +89,7 @@ struct GameplayHeaderView: View {
                     .foregroundColor(.white)
             }
             .accessibilityLabel("Restart")
+            .accessibilityIdentifier("gameplayHeaderRestartButton")
             .accessibilityHint("Restarts playback from the beginning")
 
             Button(action: onPlayPause) {
@@ -96,6 +98,7 @@ struct GameplayHeaderView: View {
                     .foregroundColor(isPlaying ? .red : .green)
             }
             .accessibilityLabel(isPlaying ? "Pause" : "Play")
+            .accessibilityIdentifier("gameplayHeaderPlayPauseButton")
             .accessibilityHint(isPlaying ? "Pauses the drum track" : "Starts playing the drum track")
         }
     }

--- a/Virgo/views/DownloadedSongsView.swift
+++ b/Virgo/views/DownloadedSongsView.swift
@@ -201,6 +201,9 @@ struct DownloadedSongRowWithDelete: View {
                 .foregroundColor(song.isSaved ? .purple : .gray)
         }
         .buttonStyle(PlainButtonStyle())
+        .accessibilityLabel(song.isSaved ? "Remove bookmark" : "Save song")
+        .accessibilityIdentifier("downloadedSongBookmarkButton")
+        .accessibilityValue(song.isSaved ? "Saved" : "Not saved")
     }
     
     private var difficultyBadges: some View {

--- a/Virgo/views/SongsTabView.swift
+++ b/Virgo/views/SongsTabView.swift
@@ -91,6 +91,8 @@ struct SongsTabView: View {
                                     )
                             }
                             .disabled(serverSongService.isRefreshing)
+                            .accessibilityIdentifier("refreshServerSongsButton")
+                            .accessibilityLabel("Refresh server songs")
                             .onLongPressGesture(minimumDuration: 1.0) {
                                 Task {
                                     await serverSongService.forceRefreshServerSongs()

--- a/VirgoUITests/GameplayViewUITests.swift
+++ b/VirgoUITests/GameplayViewUITests.swift
@@ -85,8 +85,8 @@ final class GameplayViewUITests: XCTestCase {
         try openGameplay(in: app)
 
         // Test header contains track information
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].exists, "Track title should be displayed")
-        XCTAssertTrue(app.staticTexts["Rock Masters"].exists, "Artist name should be displayed")
+        try requireStaticText(containing: "Thunder Beat", in: app)
+        try requireStaticText(containing: "Rock Masters", in: app)
 
         // Test back button exists and is accessible
         let backButton = try requireControl(named: "Go back", in: app)
@@ -106,7 +106,7 @@ final class GameplayViewUITests: XCTestCase {
 
         // The fact that we can see the play button and track info suggests the sheet music area
         // has also loaded (since they're part of the same view hierarchy)
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].exists)
+        try requireStaticText(containing: "Thunder Beat", in: app)
     }
 
     @MainActor
@@ -122,8 +122,8 @@ final class GameplayViewUITests: XCTestCase {
 
         // Controls should be in the bottom area of the screen
         // We can verify this by checking that controls exist alongside the main content
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].exists && playButton.exists, 
-                     "Both header and controls should be visible simultaneously")
+        try requireStaticText(containing: "Thunder Beat", in: app)
+        XCTAssertTrue(playButton.exists, "Controls should be visible with the header")
     }
 
     @MainActor
@@ -164,8 +164,8 @@ final class GameplayViewUITests: XCTestCase {
         XCTAssertTrue(backButton.isHittable, "Back button should be accessible")
 
         // Test that text elements are readable
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].exists, "Track title should be accessible")
-        XCTAssertTrue(app.staticTexts["Rock Masters"].exists, "Artist should be accessible")
+        try requireStaticText(containing: "Thunder Beat", in: app)
+        try requireStaticText(containing: "Rock Masters", in: app)
     }
 
     @MainActor
@@ -179,8 +179,8 @@ final class GameplayViewUITests: XCTestCase {
 
         // Test navigation to second track.
         try openGameplay(in: app, songTitle: "Jazz Groove", artist: "Smooth Collective")
-        XCTAssertTrue(app.staticTexts["Jazz Groove"].waitForExistence(timeout: 10))
-        XCTAssertTrue(app.staticTexts["Smooth Collective"].waitForExistence(timeout: 10))
+        try requireStaticText(containing: "Jazz Groove", in: app)
+        try requireStaticText(containing: "Smooth Collective", in: app)
 
         // Navigate back again
         try tapBackFromGameplay(in: app)
@@ -205,8 +205,8 @@ final class GameplayViewUITests: XCTestCase {
         }
 
         // Verify UI is still functional after rapid interactions
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].exists, "Track title should still be visible")
-        XCTAssertTrue(app.buttons["Play"].exists, "Play button should still be functional")
+        try requireStaticText(containing: "Thunder Beat", in: app)
+        try requireControl(named: "Play", in: app, timeout: 3)
         XCTAssertTrue(restartButton.exists, "Restart button should still be functional")
 
         // Test final navigation back

--- a/VirgoUITests/GameplayViewUITests.swift
+++ b/VirgoUITests/GameplayViewUITests.swift
@@ -32,16 +32,7 @@ final class GameplayViewUITests: XCTestCase {
 
     @discardableResult
     private func requirePlaybackButton(timeout: TimeInterval = 3) throws -> XCUIElement {
-        let playButton = app.buttons.matching(NSPredicate(format: "label == %@", "Play")).firstMatch
-        let pauseButton = app.buttons.matching(NSPredicate(format: "label == %@", "Pause")).firstMatch
-        guard let button = waitForFirstExisting([
-            playButton,
-            pauseButton
-        ], timeout: timeout) else {
-            XCTFail("Expected Play or Pause button to exist")
-            throw UITestFailure.elementNotFound("Play or Pause")
-        }
-        return button
+        try requireGameplayPlayPauseControl(in: app, timeout: timeout)
     }
 
     @MainActor
@@ -58,13 +49,13 @@ final class GameplayViewUITests: XCTestCase {
     @MainActor
     func testGameplayViewPlaybackControls() throws {
         try openGameplay(in: app)
-        let playButton = try requireControl(named: "Play", in: app)
+        let playButton = try requirePlaybackButton()
 
         // Test play button exists and is tappable
         XCTAssertTrue(playButton.isHittable)
 
         // Test restart button exists
-        let restartButton = try requireControl(named: "Restart", in: app)
+        let restartButton = try requireGameplayRestartControl(in: app)
         XCTAssertTrue(restartButton.isHittable)
 
         // Test play button tap
@@ -79,7 +70,7 @@ final class GameplayViewUITests: XCTestCase {
         restartButton.tap()
 
         // After restart, should have play button available
-        try requireControl(named: "Play", in: app, timeout: 3)
+        try requirePlaybackButton(timeout: 3)
     }
 
     @MainActor
@@ -104,7 +95,7 @@ final class GameplayViewUITests: XCTestCase {
         // that the main scrollable area exists by checking that the screen has loaded properly
 
         // Verify the view has loaded by checking for both header and control elements
-        try requireControl(named: "Play", in: app)
+        try requirePlaybackButton()
 
         // The fact that we can see the play button and track info suggests the sheet music area
         // has also loaded (since they're part of the same view hierarchy)
@@ -114,12 +105,12 @@ final class GameplayViewUITests: XCTestCase {
     @MainActor
     func testGameplayViewControlsArea() throws {
         try openGameplay(in: app)
-        let playButton = try requireControl(named: "Play", in: app)
+        let playButton = try requirePlaybackButton()
 
         // Test that control elements are present and accessible
         XCTAssertTrue(playButton.isHittable, "Play button should be accessible")
 
-        let restartButton = try requireControl(named: "Restart", in: app)
+        let restartButton = try requireGameplayRestartControl(in: app)
         XCTAssertTrue(restartButton.isHittable, "Restart button should be accessible")
 
         // Controls should be in the bottom area of the screen
@@ -131,7 +122,7 @@ final class GameplayViewUITests: XCTestCase {
     @MainActor
     func testGameplayViewPlaybackSequence() throws {
         try openGameplay(in: app)
-        let playButton = try requireControl(named: "Play", in: app)
+        let playButton = try requirePlaybackButton()
 
         // Test complete playback sequence
         // 1. Initial state - should have play button
@@ -144,11 +135,11 @@ final class GameplayViewUITests: XCTestCase {
         try requirePlaybackButton(timeout: 2)
 
         // 4. Test restart functionality
-        let restartButton = try requireControl(named: "Restart", in: app)
+        let restartButton = try requireGameplayRestartControl(in: app)
         restartButton.tap()
 
         // 5. After restart - should return to initial state
-        try requireControl(named: "Play", in: app, timeout: 3)
+        try requirePlaybackButton(timeout: 3)
     }
 
     @MainActor
@@ -156,10 +147,10 @@ final class GameplayViewUITests: XCTestCase {
         try openGameplay(in: app)
 
         // Test that key interactive elements are accessible
-        let playButton = try requireControl(named: "Play", in: app)
+        let playButton = try requirePlaybackButton()
         XCTAssertTrue(playButton.isHittable, "Play button should be accessible")
 
-        let restartButton = try requireControl(named: "Restart", in: app)
+        let restartButton = try requireGameplayRestartControl(in: app)
         XCTAssertTrue(restartButton.isHittable, "Restart button should be accessible")
 
         let backButton = try requireControl(named: "Go back", in: app)
@@ -194,7 +185,7 @@ final class GameplayViewUITests: XCTestCase {
         try openGameplay(in: app)
 
         // Rapid interaction test - ensure UI remains stable
-        let restartButton = try requireControl(named: "Restart", in: app)
+        let restartButton = try requireGameplayRestartControl(in: app)
 
         // Multiple rapid interactions
         for _ in 0..<3 {
@@ -203,12 +194,12 @@ final class GameplayViewUITests: XCTestCase {
             XCTAssertTrue(restartButton.waitForExistence(timeout: 1.0), "Restart button should remain available")
             restartButton.tap()
             // Wait for button to be responsive after tap
-            try requireControl(named: "Play", in: app, timeout: 1)
+            try requirePlaybackButton(timeout: 1)
         }
 
         // Verify UI is still functional after rapid interactions
         try requireStaticText(containing: "Thunder Beat", in: app)
-        try requireControl(named: "Play", in: app, timeout: 3)
+        try requirePlaybackButton(timeout: 3)
         XCTAssertTrue(restartButton.exists, "Restart button should still be functional")
 
         // Test final navigation back

--- a/VirgoUITests/GameplayViewUITests.swift
+++ b/VirgoUITests/GameplayViewUITests.swift
@@ -22,7 +22,7 @@ final class GameplayViewUITests: XCTestCase {
         app.launchArguments.append("-UITesting")
         app.launchArguments.append("-ResetState")
         app.launch()
-        dismissSetupAssistantIfPresent()
+        dismissSetupAssistantIfPresent(returningTo: app)
     }
 
     override func tearDownWithError() throws {

--- a/VirgoUITests/GameplayViewUITests.swift
+++ b/VirgoUITests/GameplayViewUITests.swift
@@ -32,9 +32,11 @@ final class GameplayViewUITests: XCTestCase {
 
     @discardableResult
     private func requirePlaybackButton(timeout: TimeInterval = 3) throws -> XCUIElement {
+        let playButton = app.buttons.matching(NSPredicate(format: "label == %@", "Play")).firstMatch
+        let pauseButton = app.buttons.matching(NSPredicate(format: "label == %@", "Pause")).firstMatch
         guard let button = waitForFirstExisting([
-            app.buttons["Play"],
-            app.buttons["Pause"]
+            playButton,
+            pauseButton
         ], timeout: timeout) else {
             XCTFail("Expected Play or Pause button to exist")
             throw UITestFailure.elementNotFound("Play or Pause")

--- a/VirgoUITests/GameplayViewUITests.swift
+++ b/VirgoUITests/GameplayViewUITests.swift
@@ -18,6 +18,7 @@ final class GameplayViewUITests: XCTestCase {
         // ContentView.isUITesting checks for this argument
         app = XCUIApplication()
         app.launchArguments.append("-UITesting")
+        app.launchArguments.append("-ResetState")
         app.launch()
     }
 
@@ -26,108 +27,80 @@ final class GameplayViewUITests: XCTestCase {
         app?.terminate()
     }
 
+    @discardableResult
+    private func requirePlaybackButton(timeout: TimeInterval = 3) throws -> XCUIElement {
+        guard let button = waitForFirstExisting([
+            app.buttons["Play"],
+            app.buttons["Pause"]
+        ], timeout: timeout) else {
+            XCTFail("Expected Play or Pause button to exist")
+            throw UITestFailure.elementNotFound("Play or Pause")
+        }
+        return button
+    }
+
     @MainActor
     func testGameplayViewNavigation() throws {
-        // Navigate to ContentView
-        app.buttons["START"].tap()
-        XCTAssertTrue(app.staticTexts["Songs"].waitForExistence(timeout: 10))
-        
-        // Navigate to GameplayView by tapping on first track
-        app.staticTexts["Thunder Beat"].tap()
-        
-        // Verify GameplayView elements load
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
-        XCTAssertTrue(app.staticTexts["Rock Masters"].exists)
-        
+        try openGameplay(in: app)
+
         // Test back navigation
-        let backButton = app.buttons.matching(identifier: "chevron.left").firstMatch
-        XCTAssertTrue(backButton.waitForExistence(timeout: 5))
-        backButton.tap()
-        
+        try tapBackFromGameplay(in: app)
+
         // Verify we're back on the songs list
         XCTAssertTrue(app.staticTexts["Songs"].waitForExistence(timeout: 10))
     }
 
     @MainActor
     func testGameplayViewPlaybackControls() throws {
-        // Navigate to GameplayView
-        app.buttons["START"].tap()
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
-        app.staticTexts["Thunder Beat"].tap()
-        
-        // Wait for GameplayView to load
-        let playButton = app.buttons.matching(identifier: "play.circle.fill").firstMatch
-        XCTAssertTrue(playButton.waitForExistence(timeout: 10))
-        
+        try openGameplay(in: app)
+        let playButton = try requireControl(named: "Play", in: app)
+
         // Test play button exists and is tappable
         XCTAssertTrue(playButton.isHittable)
-        
+
         // Test restart button exists
-        let restartButton = app.buttons.matching(identifier: "backward.end.fill").firstMatch
-        XCTAssertTrue(restartButton.waitForExistence(timeout: 5))
+        let restartButton = try requireControl(named: "Restart", in: app)
         XCTAssertTrue(restartButton.isHittable)
-        
+
         // Test play button tap
         playButton.tap()
-        
-        // After tapping play, wait for either play or pause button to be available
-        let playButtonAfterTap = app.buttons.matching(identifier: "play.circle.fill").firstMatch
-        let pauseButton = app.buttons.matching(identifier: "pause.circle.fill").firstMatch
-        
-        // Wait for either button state to be available
-        let buttonAvailable = playButtonAfterTap.waitForExistence(timeout: 2.0) ||
-                               pauseButton.waitForExistence(timeout: 2.0)
-        XCTAssertTrue(buttonAvailable, "Either play or pause button should be available")
-        
+
+        let playbackButton = try requirePlaybackButton(timeout: 2)
+
         // Test that we can tap the button again (whether it's play or pause)
-        let playbackButton = playButtonAfterTap.exists ? playButtonAfterTap : pauseButton
         XCTAssertTrue(playbackButton.isHittable)
-        
+
         // Test restart functionality
         restartButton.tap()
-        
+
         // After restart, should have play button available
-        XCTAssertTrue(app.buttons.matching(identifier: "play.circle.fill").firstMatch.waitForExistence(timeout: 3))
+        try requireControl(named: "Play", in: app, timeout: 3)
     }
 
     @MainActor
     func testGameplayViewHeaderElements() throws {
-        // Navigate to GameplayView
-        app.buttons["START"].tap()
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
-        app.staticTexts["Thunder Beat"].tap()
-        
-        // Wait for GameplayView to load
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
-        
+        try openGameplay(in: app)
+
         // Test header contains track information
         XCTAssertTrue(app.staticTexts["Thunder Beat"].exists, "Track title should be displayed")
         XCTAssertTrue(app.staticTexts["Rock Masters"].exists, "Artist name should be displayed")
-        
+
         // Test back button exists and is accessible
-        let backButton = app.buttons.matching(identifier: "chevron.left").firstMatch
-        XCTAssertTrue(backButton.waitForExistence(timeout: 5))
+        let backButton = try requireControl(named: "Go back", in: app)
         XCTAssertTrue(backButton.isHittable, "Back button should be tappable")
     }
 
     @MainActor
     func testGameplayViewSheetMusicArea() throws {
-        // Navigate to GameplayView
-        app.buttons["START"].tap()
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
-        app.staticTexts["Thunder Beat"].tap()
-        
-        // Wait for GameplayView to load
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
-        
+        try openGameplay(in: app)
+
         // The sheet music area should be present (this is the main content area)
         // We can't easily test for specific musical notation elements, but we can test
         // that the main scrollable area exists by checking that the screen has loaded properly
-        
+
         // Verify the view has loaded by checking for both header and control elements
-        let playButton = app.buttons.matching(identifier: "play.circle.fill").firstMatch
-        XCTAssertTrue(playButton.waitForExistence(timeout: 10))
-        
+        try requireControl(named: "Play", in: app)
+
         // The fact that we can see the play button and track info suggests the sheet music area
         // has also loaded (since they're part of the same view hierarchy)
         XCTAssertTrue(app.staticTexts["Thunder Beat"].exists)
@@ -135,22 +108,15 @@ final class GameplayViewUITests: XCTestCase {
 
     @MainActor
     func testGameplayViewControlsArea() throws {
-        // Navigate to GameplayView
-        app.buttons["START"].tap()
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
-        app.staticTexts["Thunder Beat"].tap()
-        
-        // Wait for GameplayView to load
-        let playButton = app.buttons.matching(identifier: "play.circle.fill").firstMatch
-        XCTAssertTrue(playButton.waitForExistence(timeout: 10))
-        
+        try openGameplay(in: app)
+        let playButton = try requireControl(named: "Play", in: app)
+
         // Test that control elements are present and accessible
         XCTAssertTrue(playButton.isHittable, "Play button should be accessible")
-        
-        let restartButton = app.buttons.matching(identifier: "backward.end.fill").firstMatch
-        XCTAssertTrue(restartButton.waitForExistence(timeout: 5))
+
+        let restartButton = try requireControl(named: "Restart", in: app)
         XCTAssertTrue(restartButton.isHittable, "Restart button should be accessible")
-        
+
         // Controls should be in the bottom area of the screen
         // We can verify this by checking that controls exist alongside the main content
         XCTAssertTrue(app.staticTexts["Thunder Beat"].exists && playButton.exists, 
@@ -159,68 +125,41 @@ final class GameplayViewUITests: XCTestCase {
 
     @MainActor
     func testGameplayViewPlaybackSequence() throws {
-        // Navigate to GameplayView
-        app.buttons["START"].tap()
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
-        app.staticTexts["Thunder Beat"].tap()
-        
-        // Wait for GameplayView to load
-        let playButton = app.buttons.matching(identifier: "play.circle.fill").firstMatch
-        XCTAssertTrue(playButton.waitForExistence(timeout: 10))
-        
+        try openGameplay(in: app)
+        let playButton = try requireControl(named: "Play", in: app)
+
         // Test complete playback sequence
         // 1. Initial state - should have play button
         XCTAssertTrue(playButton.exists, "Should start with play button")
-        
+
         // 2. Start playback
         playButton.tap()
-        
-        // Wait for playback state to update - either play or pause button should be available
-        let playButtonElement = app.buttons.matching(identifier: "play.circle.fill").firstMatch
-        let pauseButtonElement = app.buttons.matching(identifier: "pause.circle.fill").firstMatch
-        let playbackStateUpdated = playButtonElement.waitForExistence(timeout: 2.0) ||
-                                    pauseButtonElement.waitForExistence(timeout: 2.0)
-        XCTAssertTrue(playbackStateUpdated, "Playback state should update after play button tap")
-        
-        // 3. During playback - button state might change
-        // (In some implementations, play becomes pause during playback)
-        let hasPlayButton = playButtonElement.exists
-        let hasPauseButton = pauseButtonElement.exists
-        XCTAssertTrue(hasPlayButton || hasPauseButton, "Should have either play or pause button during playback")
-        
+
+        // 3. During playback - button state might change.
+        try requirePlaybackButton(timeout: 2)
+
         // 4. Test restart functionality
-        let restartButton = app.buttons.matching(identifier: "backward.end.fill").firstMatch
-        XCTAssertTrue(restartButton.exists)
+        let restartButton = try requireControl(named: "Restart", in: app)
         restartButton.tap()
-        
+
         // 5. After restart - should return to initial state
-        XCTAssertTrue(app.buttons.matching(identifier: "play.circle.fill").firstMatch.waitForExistence(timeout: 3),
-                     "Should return to play button after restart")
+        try requireControl(named: "Play", in: app, timeout: 3)
     }
 
     @MainActor
     func testGameplayViewAccessibility() throws {
-        // Navigate to GameplayView
-        app.buttons["START"].tap()
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
-        app.staticTexts["Thunder Beat"].tap()
-        
-        // Wait for GameplayView to load
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
-        
+        try openGameplay(in: app)
+
         // Test that key interactive elements are accessible
-        let playButton = app.buttons.matching(identifier: "play.circle.fill").firstMatch
-        XCTAssertTrue(playButton.waitForExistence(timeout: 10))
+        let playButton = try requireControl(named: "Play", in: app)
         XCTAssertTrue(playButton.isHittable, "Play button should be accessible")
-        
-        let restartButton = app.buttons.matching(identifier: "backward.end.fill").firstMatch
-        XCTAssertTrue(restartButton.waitForExistence(timeout: 5))
+
+        let restartButton = try requireControl(named: "Restart", in: app)
         XCTAssertTrue(restartButton.isHittable, "Restart button should be accessible")
-        
-        let backButton = app.buttons.matching(identifier: "chevron.left").firstMatch
-        XCTAssertTrue(backButton.waitForExistence(timeout: 5))
+
+        let backButton = try requireControl(named: "Go back", in: app)
         XCTAssertTrue(backButton.isHittable, "Back button should be accessible")
-        
+
         // Test that text elements are readable
         XCTAssertTrue(app.staticTexts["Thunder Beat"].exists, "Track title should be accessible")
         XCTAssertTrue(app.staticTexts["Rock Masters"].exists, "Artist should be accessible")
@@ -228,67 +167,47 @@ final class GameplayViewUITests: XCTestCase {
 
     @MainActor
     func testGameplayViewMultipleTracksNavigation() throws {
-        // Navigate to ContentView
-        app.buttons["START"].tap()
-        XCTAssertTrue(app.staticTexts["Songs"].waitForExistence(timeout: 10))
-        
         // Test navigation to first track
-        app.staticTexts["Thunder Beat"].tap()
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
-        XCTAssertTrue(app.staticTexts["Rock Masters"].exists)
-        
+        try openGameplay(in: app)
+
         // Navigate back
-        let backButton = app.buttons.matching(identifier: "chevron.left").firstMatch
-        backButton.tap()
+        try tapBackFromGameplay(in: app)
         XCTAssertTrue(app.staticTexts["Songs"].waitForExistence(timeout: 10))
-        
-        // Test navigation to second track (must always be present)
-        XCTAssertTrue(app.staticTexts["Jazz Groove"].waitForExistence(timeout: 10), "Jazz Groove track must be available")
-        app.staticTexts["Jazz Groove"].tap()
+
+        // Test navigation to second track.
+        try openGameplay(in: app, songTitle: "Jazz Groove", artist: "Smooth Collective")
         XCTAssertTrue(app.staticTexts["Jazz Groove"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.staticTexts["Smooth Collective"].waitForExistence(timeout: 10))
 
         // Navigate back again
-        let backButton2 = app.buttons.matching(identifier: "chevron.left").firstMatch
-        backButton2.tap()
+        try tapBackFromGameplay(in: app)
         XCTAssertTrue(app.staticTexts["Songs"].waitForExistence(timeout: 10))
     }
 
     @MainActor
     func testGameplayViewStabilityDuringInteraction() throws {
-        // Navigate to GameplayView
-        app.buttons["START"].tap()
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
-        app.staticTexts["Thunder Beat"].tap()
-        
-        // Wait for GameplayView to load
-        let playButton = app.buttons.matching(identifier: "play.circle.fill").firstMatch
-        XCTAssertTrue(playButton.waitForExistence(timeout: 10))
-        
+        try openGameplay(in: app)
+
         // Rapid interaction test - ensure UI remains stable
-        let restartButton = app.buttons.matching(identifier: "backward.end.fill").firstMatch
-        
+        let restartButton = try requireControl(named: "Restart", in: app)
+
         // Multiple rapid interactions
         for _ in 0..<3 {
-            playButton.tap()
+            try requirePlaybackButton(timeout: 1).tap()
             // Wait for button to be responsive after tap
             XCTAssertTrue(restartButton.waitForExistence(timeout: 1.0), "Restart button should remain available")
             restartButton.tap()
             // Wait for button to be responsive after tap
-            XCTAssertTrue(playButton.waitForExistence(timeout: 1.0), "Play button should remain available")
+            try requireControl(named: "Play", in: app, timeout: 1)
         }
-        
+
         // Verify UI is still functional after rapid interactions
         XCTAssertTrue(app.staticTexts["Thunder Beat"].exists, "Track title should still be visible")
-        XCTAssertTrue(
-            app.buttons.matching(identifier: "play.circle.fill").firstMatch.exists,
-            "Play button should still be functional"
-        )
+        XCTAssertTrue(app.buttons["Play"].exists, "Play button should still be functional")
         XCTAssertTrue(restartButton.exists, "Restart button should still be functional")
-        
+
         // Test final navigation back
-        let backButton = app.buttons.matching(identifier: "chevron.left").firstMatch
-        backButton.tap()
+        try tapBackFromGameplay(in: app)
         XCTAssertTrue(app.staticTexts["Songs"].waitForExistence(timeout: 10))
     }
 }

--- a/VirgoUITests/GameplayViewUITests.swift
+++ b/VirgoUITests/GameplayViewUITests.swift
@@ -13,6 +13,8 @@ final class GameplayViewUITests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
+        installSystemDialogHandlers()
+        dismissSetupAssistantIfPresent()
 
         // Add custom launch argument to distinguish UI tests from unit tests
         // ContentView.isUITesting checks for this argument
@@ -20,6 +22,7 @@ final class GameplayViewUITests: XCTestCase {
         app.launchArguments.append("-UITesting")
         app.launchArguments.append("-ResetState")
         app.launch()
+        dismissSetupAssistantIfPresent()
     }
 
     override func tearDownWithError() throws {

--- a/VirgoUITests/ServerSongsUITests.swift
+++ b/VirgoUITests/ServerSongsUITests.swift
@@ -46,11 +46,10 @@ final class ServerSongsUITests: XCTestCase {
         return XCTWaiter.wait(for: [enabledExpectation], timeout: timeout) == .completed
     }
 
-    private func waitForServerTabState(timeout: TimeInterval = 3) -> Bool {
+    private func waitForServerTabState(timeout: TimeInterval = 5) -> Bool {
         waitForStaticText(containing: "Loading server songs", in: app, timeout: timeout) ||
             waitForStaticText(containing: "No Server Songs", in: app, timeout: timeout) ||
-            waitForStaticText(containing: "songs available", in: app, timeout: timeout) ||
-            app.buttons["refreshServerSongsButton"].waitForExistence(timeout: timeout)
+            waitForStaticText(containing: "songs available", in: app, timeout: timeout)
     }
 
     @MainActor

--- a/VirgoUITests/ServerSongsUITests.swift
+++ b/VirgoUITests/ServerSongsUITests.swift
@@ -21,7 +21,7 @@ final class ServerSongsUITests: XCTestCase {
         app.launchArguments.append("-UITesting")
         app.launchArguments.append("-ResetState")
         app.launch()
-        dismissSetupAssistantIfPresent()
+        dismissSetupAssistantIfPresent(returningTo: app)
     }
 
     override func tearDownWithError() throws {

--- a/VirgoUITests/ServerSongsUITests.swift
+++ b/VirgoUITests/ServerSongsUITests.swift
@@ -40,59 +40,47 @@ final class ServerSongsUITests: XCTestCase {
         return button
     }
 
-    private func waitForEnabled(_ element: XCUIElement, timeout: TimeInterval = 10) {
+    private func waitForEnabled(_ element: XCUIElement, timeout: TimeInterval = 10) -> Bool {
         let enabledPredicate = NSPredicate(format: "enabled == true")
         let enabledExpectation = expectation(for: enabledPredicate, evaluatedWith: element)
-        wait(for: [enabledExpectation], timeout: timeout)
+        return XCTWaiter.wait(for: [enabledExpectation], timeout: timeout) == .completed
+    }
+
+    private func waitForServerTabState(timeout: TimeInterval = 3) -> Bool {
+        waitForStaticText(containing: "Loading server songs", in: app, timeout: timeout) ||
+            waitForStaticText(containing: "No Server Songs", in: app, timeout: timeout) ||
+            waitForStaticText(containing: "songs available", in: app, timeout: timeout) ||
+            app.buttons["refreshServerSongsButton"].waitForExistence(timeout: timeout)
     }
 
     @MainActor
     func testServerSongsTab() throws {
         try openSongsView(in: app)
-        
+
         // Switch to Server tab
-        let serverTab = try requireControl(named: "Server", in: app, timeout: 5)
-        if !serverTab.isSelected {
-            serverTab.tap()
-        }
-        XCTAssertTrue(serverTab.isSelected)
-        
+        XCTAssertTrue(switchToServerTab(app: app))
+
         // Verify refresh button exists
         let refreshButton = try requireRefreshButton()
-        waitForEnabled(refreshButton)
-        
+        XCTAssertTrue(waitForEnabled(refreshButton))
+
         // Test refresh functionality
         refreshButton.tap()
-        
-        // Should see either loading state or server songs
-        let loadingText = app.staticTexts["Loading server songs..."]
-        let emptyStateIcon = app.images["cloud"]
-        let emptyStateText = app.staticTexts["No Server Songs"]
-        
-        // One of these should appear
-        XCTAssertTrue(
-            loadingText.waitForExistence(timeout: 3) ||
-            emptyStateIcon.waitForExistence(timeout: 3) ||
-            emptyStateText.waitForExistence(timeout: 3)
-        )
+
+        XCTAssertTrue(waitForServerTabState())
     }
     
     @MainActor
     func testServerSongsEmptyState() throws {
         try openSongsView(in: app)
-        
+
         // Switch to Server tab
-        try tapControl(named: "Server", in: app, timeout: 5)
+        XCTAssertTrue(switchToServerTab(app: app))
         
         // Wait for loading to complete and verify empty state (assuming no server connection)
-        let emptyStateText = app.staticTexts["No Server Songs"]
-        let instructionText = app.staticTexts["Tap the refresh button to load songs from the server"]
-        
         // Wait for either empty state or songs to appear after network request
-        let emptyStateAppeared = emptyStateText.waitForExistence(timeout: 8)
-        let songsAppeared = app.staticTexts
-            .matching(NSPredicate(format: "label CONTAINS 'songs available'"))
-            .firstMatch.waitForExistence(timeout: 8)
+        let emptyStateAppeared = waitForStaticText(containing: "No Server Songs", in: app, timeout: 8)
+        let songsAppeared = waitForStaticText(containing: "songs available", in: app, timeout: 8)
         
         XCTAssertTrue(
             emptyStateAppeared || songsAppeared,
@@ -100,32 +88,37 @@ final class ServerSongsUITests: XCTestCase {
         )
         
         if emptyStateAppeared {
-            XCTAssertTrue(emptyStateText.exists, "Empty state text should be visible")
-            XCTAssertTrue(instructionText.exists, "Instruction text should be visible")
+            XCTAssertTrue(
+                waitForStaticText(containing: "No Server Songs", in: app),
+                "Empty state text should be visible"
+            )
+            XCTAssertTrue(
+                waitForStaticText(containing: "Tap the refresh button to load songs from the server", in: app),
+                "Instruction text should be visible"
+            )
         }
     }
     
     @MainActor
     func testServerSongsRefreshButton() throws {
         try openSongsView(in: app)
-        
+
         // Switch to Server tab
-        try tapControl(named: "Server", in: app, timeout: 5)
-        
+        XCTAssertTrue(switchToServerTab(app: app))
+
         let refreshButton = try requireRefreshButton()
-        waitForEnabled(refreshButton)
-        
+        XCTAssertTrue(waitForEnabled(refreshButton))
+
         // Test refresh button tap
         refreshButton.tap()
-        
-        // Refresh can finish quickly when the local server is unavailable, so wait for the final enabled state.
-        waitForEnabled(refreshButton)
+
+        XCTAssertTrue(waitForServerTabState())
     }
     
     @MainActor
     func testSongsTabSearchFunctionality() throws {
         try openSongsView(in: app)
-        
+
         // Test search in Downloaded tab
         XCTAssertTrue(switchToDownloadedTab(app: app))
         
@@ -145,7 +138,7 @@ final class ServerSongsUITests: XCTestCase {
         XCTAssertTrue(clearButton.waitForNonExistence(timeout: 3))
         
         // Test search in Server tab
-        try tapControl(named: "Server", in: app, timeout: 5)
+        XCTAssertTrue(switchToServerTab(app: app))
         
         // Search should work in server tab too
         searchField.tap()
@@ -162,24 +155,24 @@ final class ServerSongsUITests: XCTestCase {
         
         // Check Downloaded tab song count
         let downloadedTab = try requireControl(named: "Downloaded", in: app, timeout: 5)
-        if !downloadedTab.isSelected {
+        if !controlIsSelected(downloadedTab) {
             downloadedTab.tap()
         }
-        
-        let songCountText = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'songs available'")).firstMatch
+
+        let songCountText = app.staticTexts.matching(textContainsPredicate("songs available")).firstMatch
         XCTAssertTrue(songCountText.waitForExistence(timeout: 5))
         
         // Switch to Server tab and check count updates
         let serverTab = try requireControl(named: "Server", in: app, timeout: 5)
         serverTab.tap()
-        
+
         // Song count should update when switching tabs
         XCTAssertTrue(songCountText.waitForExistence(timeout: 5))
-        let serverCountText = songCountText.label
-        
+        let serverCountText = elementText(songCountText)
+
         // Switch back to Downloaded tab
         downloadedTab.tap()
-        let downloadedCountText = songCountText.label
+        let downloadedCountText = elementText(songCountText)
         
         // Assert that counts are tracked separately between tabs
         XCTAssertFalse(downloadedCountText.isEmpty, "Downloaded count should be displayed")

--- a/VirgoUITests/ServerSongsUITests.swift
+++ b/VirgoUITests/ServerSongsUITests.swift
@@ -17,6 +17,7 @@ final class ServerSongsUITests: XCTestCase {
         // ContentView.isUITesting checks for this argument
         app = XCUIApplication()
         app.launchArguments.append("-UITesting")
+        app.launchArguments.append("-ResetState")
         app.launch()
     }
 
@@ -24,19 +25,38 @@ final class ServerSongsUITests: XCTestCase {
         app?.terminate()
     }
 
+    private func requireRefreshButton(timeout: TimeInterval = 5) throws -> XCUIElement {
+        guard let button = waitForFirstExisting([
+            app.buttons["refreshServerSongsButton"],
+            app.buttons["Refresh server songs"],
+            app.buttons["arrow.clockwise"]
+        ], timeout: timeout) else {
+            XCTFail("Refresh button should exist")
+            throw UITestFailure.elementNotFound("Refresh server songs")
+        }
+        return button
+    }
+
+    private func waitForEnabled(_ element: XCUIElement, timeout: TimeInterval = 10) {
+        let enabledPredicate = NSPredicate(format: "enabled == true")
+        let enabledExpectation = expectation(for: enabledPredicate, evaluatedWith: element)
+        wait(for: [enabledExpectation], timeout: timeout)
+    }
+
     @MainActor
     func testServerSongsTab() throws {
-        app.buttons["START"].tap()
+        try openSongsView(in: app)
         
         // Switch to Server tab
-        let serverTab = app.buttons["Server"]
-        XCTAssertTrue(serverTab.waitForExistence(timeout: 5))
-        serverTab.tap()
+        let serverTab = try requireControl(named: "Server", in: app, timeout: 5)
+        if !serverTab.isSelected {
+            serverTab.tap()
+        }
         XCTAssertTrue(serverTab.isSelected)
         
         // Verify refresh button exists
-        let refreshButton = app.buttons["arrow.clockwise"]
-        XCTAssertTrue(refreshButton.waitForExistence(timeout: 5))
+        let refreshButton = try requireRefreshButton()
+        waitForEnabled(refreshButton)
         
         // Test refresh functionality
         refreshButton.tap()
@@ -56,20 +76,17 @@ final class ServerSongsUITests: XCTestCase {
     
     @MainActor
     func testServerSongsEmptyState() throws {
-        app.buttons["START"].tap()
+        try openSongsView(in: app)
         
         // Switch to Server tab
-        let serverTab = app.buttons["Server"]
-        XCTAssertTrue(serverTab.waitForExistence(timeout: 5))
-        serverTab.tap()
+        try tapControl(named: "Server", in: app, timeout: 5)
         
         // Wait for loading to complete and verify empty state (assuming no server connection)
-        let emptyStateIcon = app.images["cloud"]
         let emptyStateText = app.staticTexts["No Server Songs"]
         let instructionText = app.staticTexts["Tap the refresh button to load songs from the server"]
         
         // Wait for either empty state or songs to appear after network request
-        let emptyStateAppeared = emptyStateIcon.waitForExistence(timeout: 8)
+        let emptyStateAppeared = emptyStateText.waitForExistence(timeout: 8)
         let songsAppeared = app.staticTexts
             .matching(NSPredicate(format: "label CONTAINS 'songs available'"))
             .firstMatch.waitForExistence(timeout: 8)
@@ -87,38 +104,27 @@ final class ServerSongsUITests: XCTestCase {
     
     @MainActor
     func testServerSongsRefreshButton() throws {
-        app.buttons["START"].tap()
+        try openSongsView(in: app)
         
         // Switch to Server tab
-        let serverTab = app.buttons["Server"]
-        XCTAssertTrue(serverTab.waitForExistence(timeout: 5))
-        serverTab.tap()
+        try tapControl(named: "Server", in: app, timeout: 5)
         
-        let refreshButton = app.buttons["arrow.clockwise"]
-        XCTAssertTrue(refreshButton.waitForExistence(timeout: 5))
+        let refreshButton = try requireRefreshButton()
+        waitForEnabled(refreshButton)
         
         // Test refresh button tap
         refreshButton.tap()
         
-        // Verify button becomes disabled during refresh
-        XCTAssertFalse(refreshButton.isEnabled)
-        
-        // Wait for refresh to complete (button should become enabled again)
-        let enabledPredicate = NSPredicate(format: "enabled == true")
-        let buttonEnabledExpectation = expectation(for: enabledPredicate, evaluatedWith: refreshButton)
-        wait(for: [buttonEnabledExpectation], timeout: 10)
+        // Refresh can finish quickly when the local server is unavailable, so wait for the final enabled state.
+        waitForEnabled(refreshButton)
     }
     
     @MainActor
     func testSongsTabSearchFunctionality() throws {
-        app.buttons["START"].tap()
+        try openSongsView(in: app)
         
         // Test search in Downloaded tab
-        let downloadedTab = app.buttons["Downloaded"]
-        XCTAssertTrue(downloadedTab.waitForExistence(timeout: 5))
-        if !downloadedTab.isSelected {
-            downloadedTab.tap()
-        }
+        XCTAssertTrue(switchToDownloadedTab(app: app))
         
         let searchField = app.textFields["searchField"]
         XCTAssertTrue(searchField.waitForExistence(timeout: 5))
@@ -133,11 +139,10 @@ final class ServerSongsUITests: XCTestCase {
         
         // Test clear functionality
         clearButton.tap()
-        XCTAssertEqual(searchField.value as? String ?? "", "")
+        XCTAssertTrue(clearButton.waitForNonExistence(timeout: 3))
         
         // Test search in Server tab
-        let serverTab = app.buttons["Server"]
-        serverTab.tap()
+        try tapControl(named: "Server", in: app, timeout: 5)
         
         // Search should work in server tab too
         searchField.tap()
@@ -145,16 +150,15 @@ final class ServerSongsUITests: XCTestCase {
         XCTAssertTrue(clearButton.waitForExistence(timeout: 3))
         
         clearButton.tap()
-        XCTAssertEqual(searchField.value as? String ?? "", "")
+        XCTAssertTrue(clearButton.waitForNonExistence(timeout: 3))
     }
     
     @MainActor
     func testSongsTabSongCounter() throws {
-        app.buttons["START"].tap()
+        try openSongsView(in: app)
         
         // Check Downloaded tab song count
-        let downloadedTab = app.buttons["Downloaded"]
-        XCTAssertTrue(downloadedTab.waitForExistence(timeout: 5))
+        let downloadedTab = try requireControl(named: "Downloaded", in: app, timeout: 5)
         if !downloadedTab.isSelected {
             downloadedTab.tap()
         }
@@ -163,7 +167,7 @@ final class ServerSongsUITests: XCTestCase {
         XCTAssertTrue(songCountText.waitForExistence(timeout: 5))
         
         // Switch to Server tab and check count updates
-        let serverTab = app.buttons["Server"]
+        let serverTab = try requireControl(named: "Server", in: app, timeout: 5)
         serverTab.tap()
         
         // Song count should update when switching tabs

--- a/VirgoUITests/ServerSongsUITests.swift
+++ b/VirgoUITests/ServerSongsUITests.swift
@@ -12,6 +12,8 @@ final class ServerSongsUITests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
+        installSystemDialogHandlers()
+        dismissSetupAssistantIfPresent()
 
         // Add custom launch argument to distinguish UI tests from unit tests
         // ContentView.isUITesting checks for this argument
@@ -19,6 +21,7 @@ final class ServerSongsUITests: XCTestCase {
         app.launchArguments.append("-UITesting")
         app.launchArguments.append("-ResetState")
         app.launch()
+        dismissSetupAssistantIfPresent()
     }
 
     override func tearDownWithError() throws {

--- a/VirgoUITests/SongsTabUITests.swift
+++ b/VirgoUITests/SongsTabUITests.swift
@@ -21,7 +21,7 @@ final class SongsTabUITests: XCTestCase {
         app.launchArguments.append("-UITesting")
         app.launchArguments.append("-ResetState")
         app.launch()
-        dismissSetupAssistantIfPresent()
+        dismissSetupAssistantIfPresent(returningTo: app)
     }
 
     /// Launches the app with -SkipSeed flag for tests that need empty state
@@ -32,7 +32,7 @@ final class SongsTabUITests: XCTestCase {
         app.launchArguments.append("-ResetState")
         app.launchArguments.append("-SkipSeed")
         app.launch()
-        dismissSetupAssistantIfPresent()
+        dismissSetupAssistantIfPresent(returningTo: app)
     }
 
     override func tearDownWithError() throws {
@@ -102,7 +102,14 @@ final class SongsTabUITests: XCTestCase {
             if !countText.hasPrefix("0 ") {
                 // Verify downloaded songs list elements exist
                 try requireControl(named: "Play", in: app, timeout: 5)
-                try requireControl(named: "Bookmark", in: app, timeout: 5)
+                let bookmarkPredicate = NSPredicate(
+                    format: "identifier == %@ OR label == %@ OR label == %@",
+                    "downloadedSongBookmarkButton",
+                    "Save song",
+                    "Remove bookmark"
+                )
+                let bookmarkButton = app.buttons.matching(bookmarkPredicate).firstMatch
+                XCTAssertTrue(bookmarkButton.waitForExistence(timeout: 5))
             }
         }
     }

--- a/VirgoUITests/SongsTabUITests.swift
+++ b/VirgoUITests/SongsTabUITests.swift
@@ -64,10 +64,10 @@ final class SongsTabUITests: XCTestCase {
         
         // Test switching between sub-tabs
         serverTab.tap()
-        XCTAssertTrue(serverTab.isSelected)
-        
+        XCTAssertTrue(switchToServerTab(app: app))
+
         downloadedTab.tap()
-        XCTAssertTrue(downloadedTab.isSelected)
+        XCTAssertTrue(switchToDownloadedTab(app: app))
     }
     
     @MainActor
@@ -81,8 +81,10 @@ final class SongsTabUITests: XCTestCase {
         XCTAssertTrue(switchToDownloadedTab(app: app))
 
         // Verify empty state is shown
-        XCTAssertTrue(app.staticTexts["No Downloaded Songs"].exists)
-        XCTAssertTrue(app.staticTexts["Download songs from the Server tab to see them here"].exists)
+        XCTAssertTrue(waitForStaticText(containing: "No Downloaded Songs", in: app, timeout: 5))
+        XCTAssertTrue(
+            waitForStaticText(containing: "Download songs from the Server tab to see them here", in: app, timeout: 5)
+        )
     }
     
     @MainActor
@@ -94,9 +96,9 @@ final class SongsTabUITests: XCTestCase {
         
         // Check if there are downloaded songs (DTX Import genre)
         // This test will pass if there are downloaded songs, or skip verification if empty
-        let songCount = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'songs available'")).firstMatch
+        let songCount = app.staticTexts.matching(textContainsPredicate("songs available")).firstMatch
         if songCount.waitForExistence(timeout: 5) {
-            let countText = songCount.label
+            let countText = elementText(songCount)
             if !countText.hasPrefix("0 ") {
                 // Verify downloaded songs list elements exist
                 try requireControl(named: "Play", in: app, timeout: 5)
@@ -143,10 +145,7 @@ final class SongsTabUITests: XCTestCase {
             
             // Verify expansion content (difficulty badges should appear)
             let difficultyButton = app.buttons.matching(
-                NSPredicate(
-                    format: "(label CONTAINS 'Easy' OR label CONTAINS 'Medium' OR label CONTAINS 'Hard') " +
-                        "AND label CONTAINS 'Level'"
-                )
+                NSPredicate(format: "identifier BEGINSWITH %@", "chartDifficulty")
             ).firstMatch
             XCTAssertTrue(difficultyButton.waitForExistence(timeout: 3))
             
@@ -171,10 +170,8 @@ final class SongsTabUITests: XCTestCase {
         let deleteButton = app.buttons["Delete"]
         if deleteButton.waitForExistence(timeout: 5) {
             // Count songs before deletion
-            let songCountBefore = app.staticTexts.matching(
-                NSPredicate(format: "label CONTAINS 'songs available'")
-            ).firstMatch
-            let beforeText = songCountBefore.label
+            let songCountBefore = app.staticTexts.matching(textContainsPredicate("songs available")).firstMatch
+            let beforeText = elementText(songCountBefore)
             
             // Tap delete button
             deleteButton.tap()
@@ -187,10 +184,8 @@ final class SongsTabUITests: XCTestCase {
             }
             
             // Wait for song count to update or empty state to appear
-            let songCountAfter = app.staticTexts.matching(
-                NSPredicate(format: "label CONTAINS 'songs available'")
-            ).firstMatch
-            let emptyState = app.staticTexts["No songs available"]
+            let songCountAfter = app.staticTexts.matching(textContainsPredicate("songs available")).firstMatch
+            let emptyState = app.staticTexts.matching(textContainsPredicate("No Downloaded Songs")).firstMatch
             
             // Wait for either count update or empty state
             let stateUpdated = songCountAfter.waitForExistence(timeout: 3.0) ||
@@ -198,11 +193,11 @@ final class SongsTabUITests: XCTestCase {
             XCTAssertTrue(stateUpdated, "Song count should update or empty state should appear after deletion")
             
             if songCountAfter.exists {
-                let afterText = songCountAfter.label
+                let afterText = elementText(songCountAfter)
                 XCTAssertNotEqual(beforeText, afterText, "Song count should change after deletion")
             } else {
                 // Empty state should appear if all songs deleted
-                XCTAssertTrue(app.staticTexts["No Downloaded Songs"].waitForExistence(timeout: 5))
+                XCTAssertTrue(waitForStaticText(containing: "No Downloaded Songs", in: app, timeout: 5))
             }
         }
     }

--- a/VirgoUITests/SongsTabUITests.swift
+++ b/VirgoUITests/SongsTabUITests.swift
@@ -115,13 +115,13 @@ final class SongsTabUITests: XCTestCase {
         XCTAssertTrue(switchToDownloadedTab(app: app))
         
         // Find first play button if songs exist
-        let playButton = app.buttons["Play"]
+        let playButton = app.buttons.matching(NSPredicate(format: "label == %@", "Play")).firstMatch
         if playButton.waitForExistence(timeout: 5) {
             // Test play functionality
             playButton.tap()
             
             // Verify play button changes to pause (may take a moment for audio to start)
-            let pauseButton = app.buttons["Pause"]
+            let pauseButton = app.buttons.matching(NSPredicate(format: "label == %@", "Pause")).firstMatch
             XCTAssertTrue(pauseButton.waitForExistence(timeout: 3))
             
             // Test pause functionality
@@ -145,7 +145,7 @@ final class SongsTabUITests: XCTestCase {
             
             // Verify expansion content (difficulty badges should appear)
             let difficultyButton = app.buttons.matching(
-                NSPredicate(format: "identifier BEGINSWITH %@", "chartDifficulty")
+                NSPredicate(format: "identifier BEGINSWITH %@ OR label CONTAINS[c] %@", "chartDifficulty", "difficulty")
             ).firstMatch
             XCTAssertTrue(difficultyButton.waitForExistence(timeout: 3))
             
@@ -167,7 +167,7 @@ final class SongsTabUITests: XCTestCase {
         XCTAssertTrue(switchToDownloadedTab(app: app))
         
         // Find delete button if songs exist
-        let deleteButton = app.buttons["Delete"]
+        let deleteButton = app.buttons.matching(NSPredicate(format: "label == %@", "Delete")).firstMatch
         if deleteButton.waitForExistence(timeout: 5) {
             // Count songs before deletion
             let songCountBefore = app.staticTexts.matching(textContainsPredicate("songs available")).firstMatch

--- a/VirgoUITests/SongsTabUITests.swift
+++ b/VirgoUITests/SongsTabUITests.swift
@@ -12,6 +12,8 @@ final class SongsTabUITests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
+        installSystemDialogHandlers()
+        dismissSetupAssistantIfPresent()
 
         // Add custom launch argument to distinguish UI tests from unit tests
         // ContentView.isUITesting checks for this argument
@@ -19,6 +21,7 @@ final class SongsTabUITests: XCTestCase {
         app.launchArguments.append("-UITesting")
         app.launchArguments.append("-ResetState")
         app.launch()
+        dismissSetupAssistantIfPresent()
     }
 
     /// Launches the app with -SkipSeed flag for tests that need empty state
@@ -29,6 +32,7 @@ final class SongsTabUITests: XCTestCase {
         app.launchArguments.append("-ResetState")
         app.launchArguments.append("-SkipSeed")
         app.launch()
+        dismissSetupAssistantIfPresent()
     }
 
     override func tearDownWithError() throws {

--- a/VirgoUITests/SongsTabUITests.swift
+++ b/VirgoUITests/SongsTabUITests.swift
@@ -40,10 +40,8 @@ final class SongsTabUITests: XCTestCase {
     /// Waits for the START button to appear and taps it.
     /// Use this instead of directly calling app.buttons["START"].tap() to avoid flakiness.
     @MainActor
-    private func tapStartButton() {
-        let startButton = app.buttons["START"]
-        XCTAssertTrue(startButton.waitForExistence(timeout: 5), "START button should exist")
-        startButton.tap()
+    private func tapStartButton() throws {
+        try openSongsView(in: app)
     }
 
     // MARK: - Songs Tab Tests
@@ -51,17 +49,14 @@ final class SongsTabUITests: XCTestCase {
     @MainActor
     func testSongsTabNavigation() throws {
         // Wait for START button to appear before tapping to avoid flakiness
-        tapStartButton()
+        try tapStartButton()
 
         // Navigate to Songs tab via Content View (which shows SongsTabView)
         XCTAssertTrue(app.staticTexts["Songs"].waitForExistence(timeout: 10))
         
         // Verify sub-tab picker exists
-        let downloadedTab = app.buttons["Downloaded"]
-        let serverTab = app.buttons["Server"]
-        
-        XCTAssertTrue(downloadedTab.waitForExistence(timeout: 5))
-        XCTAssertTrue(serverTab.exists)
+        let downloadedTab = try requireControl(named: "Downloaded", in: app, timeout: 5)
+        let serverTab = try requireControl(named: "Server", in: app, timeout: 5)
         
         // Test switching between sub-tabs
         serverTab.tap()
@@ -76,31 +71,22 @@ final class SongsTabUITests: XCTestCase {
         // This test needs empty state, so relaunch with -SkipSeed flag
         launchAppSkippingSeed()
 
-        tapStartButton()
+        try tapStartButton()
 
         // Ensure we're on Downloaded tab (default)
-        let downloadedTab = app.buttons["Downloaded"]
-        XCTAssertTrue(downloadedTab.waitForExistence(timeout: 5))
-        if !downloadedTab.isSelected {
-            downloadedTab.tap()
-        }
+        XCTAssertTrue(switchToDownloadedTab(app: app))
 
         // Verify empty state is shown
-        XCTAssertTrue(app.images["arrow.down.circle"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["No Downloaded Songs"].exists)
         XCTAssertTrue(app.staticTexts["Download songs from the Server tab to see them here"].exists)
     }
     
     @MainActor
     func testDownloadedSongsWithData() throws {
-        tapStartButton()
+        try tapStartButton()
         
         // Ensure we're on Downloaded tab
-        let downloadedTab = app.buttons["Downloaded"]
-        XCTAssertTrue(downloadedTab.waitForExistence(timeout: 5))
-        if !downloadedTab.isSelected {
-            downloadedTab.tap()
-        }
+        XCTAssertTrue(switchToDownloadedTab(app: app))
         
         // Check if there are downloaded songs (DTX Import genre)
         // This test will pass if there are downloaded songs, or skip verification if empty
@@ -109,36 +95,27 @@ final class SongsTabUITests: XCTestCase {
             let countText = songCount.label
             if !countText.hasPrefix("0 ") {
                 // Verify downloaded songs list elements exist
-                XCTAssertTrue(
-                    app.buttons.matching(identifier: "play.circle.fill").firstMatch.waitForExistence(timeout: 5)
-                )
-                XCTAssertTrue(
-                    app.buttons.matching(identifier: "bookmark").firstMatch.waitForExistence(timeout: 5) ||
-                    app.buttons.matching(identifier: "bookmark.fill").firstMatch.exists
-                )
+                try requireControl(named: "Play", in: app, timeout: 5)
+                try requireControl(named: "Bookmark", in: app, timeout: 5)
             }
         }
     }
     
     @MainActor
     func testDownloadedSongsPlayback() throws {
-        tapStartButton()
+        try tapStartButton()
         
         // Ensure we're on Downloaded tab
-        let downloadedTab = app.buttons["Downloaded"]
-        XCTAssertTrue(downloadedTab.waitForExistence(timeout: 5))
-        if !downloadedTab.isSelected {
-            downloadedTab.tap()
-        }
+        XCTAssertTrue(switchToDownloadedTab(app: app))
         
         // Find first play button if songs exist
-        let playButton = app.buttons.matching(identifier: "play.circle.fill").firstMatch
+        let playButton = app.buttons["Play"]
         if playButton.waitForExistence(timeout: 5) {
             // Test play functionality
             playButton.tap()
             
             // Verify play button changes to pause (may take a moment for audio to start)
-            let pauseButton = app.buttons.matching(identifier: "pause.circle.fill").firstMatch
+            let pauseButton = app.buttons["Pause"]
             XCTAssertTrue(pauseButton.waitForExistence(timeout: 3))
             
             // Test pause functionality
@@ -149,24 +126,23 @@ final class SongsTabUITests: XCTestCase {
     
     @MainActor
     func testDownloadedSongExpansion() throws {
-        tapStartButton()
+        try tapStartButton()
         
         // Ensure we're on Downloaded tab
-        let downloadedTab = app.buttons["Downloaded"]
-        XCTAssertTrue(downloadedTab.waitForExistence(timeout: 5))
-        if !downloadedTab.isSelected {
-            downloadedTab.tap()
-        }
+        XCTAssertTrue(switchToDownloadedTab(app: app))
         
         // Find first chart count indicator if songs exist
-        let chartIndicator = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'charts'")).firstMatch
+        let chartIndicator = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'charts'")).firstMatch
         if chartIndicator.waitForExistence(timeout: 5) {
             // Tap to expand
             chartIndicator.tap()
             
             // Verify expansion content (difficulty badges should appear)
             let difficultyButton = app.buttons.matching(
-                NSPredicate(format: "label CONTAINS 'Easy' OR label CONTAINS 'Medium' OR label CONTAINS 'Hard'")
+                NSPredicate(
+                    format: "(label CONTAINS 'Easy' OR label CONTAINS 'Medium' OR label CONTAINS 'Hard') " +
+                        "AND label CONTAINS 'Level'"
+                )
             ).firstMatch
             XCTAssertTrue(difficultyButton.waitForExistence(timeout: 3))
             
@@ -182,14 +158,10 @@ final class SongsTabUITests: XCTestCase {
     
     @MainActor
     func testDownloadedSongDeletion() throws {
-        tapStartButton()
+        try tapStartButton()
         
         // Ensure we're on Downloaded tab
-        let downloadedTab = app.buttons["Downloaded"]
-        XCTAssertTrue(downloadedTab.waitForExistence(timeout: 5))
-        if !downloadedTab.isSelected {
-            downloadedTab.tap()
-        }
+        XCTAssertTrue(switchToDownloadedTab(app: app))
         
         // Find delete button if songs exist
         let deleteButton = app.buttons["Delete"]

--- a/VirgoUITests/UITestHelpers.swift
+++ b/VirgoUITests/UITestHelpers.swift
@@ -66,9 +66,18 @@ extension XCTestCase {
     }
 
     @discardableResult
-    func dismissSetupAssistantIfPresent(timeout: TimeInterval = 2) -> Bool {
+    func dismissSetupAssistantIfPresent(
+        timeout: TimeInterval = 2,
+        returningTo app: XCUIApplication? = nil
+    ) -> Bool {
         let setupAssistant = XCUIApplication(bundleIdentifier: "com.apple.SetupAssistant")
         guard setupAssistant.state != .notRunning else { return false }
+
+        defer {
+            if let app, app.state != .notRunning {
+                app.activate()
+            }
+        }
 
         setupAssistant.activate()
         let deadline = Date().addingTimeInterval(timeout)
@@ -304,20 +313,37 @@ extension XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
-        dismissSetupAssistantIfPresent(timeout: 1)
+        for attempt in 0..<2 {
+            if app.state == .notRunning {
+                app.launch()
+            }
 
-        if !waitForStaticText(containing: "Songs", in: app, timeout: 1) &&
-            !app.textFields["searchField"].waitForExistence(timeout: 1) {
+            dismissSetupAssistantIfPresent(timeout: 1, returningTo: app)
+
+            if songsViewIsLoaded(in: app, timeout: 1) {
+                return
+            }
+
             try tapControl(named: "START", in: app, timeout: timeout, file: file, line: line)
+
+            if songsViewIsLoaded(in: app, timeout: timeout) {
+                return
+            }
+
+            guard attempt == 0, app.state == .notRunning else { break }
         }
 
         XCTAssertTrue(
-            waitForStaticText(containing: "Songs", in: app, timeout: timeout) ||
-                app.textFields["searchField"].waitForExistence(timeout: timeout),
+            songsViewIsLoaded(in: app, timeout: timeout),
             "Songs view should load",
             file: file,
             line: line
         )
+    }
+
+    private func songsViewIsLoaded(in app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        waitForStaticText(containing: "Songs", in: app, timeout: timeout) ||
+            app.textFields["searchField"].waitForExistence(timeout: timeout)
     }
 
     func openGameplay(

--- a/VirgoUITests/UITestHelpers.swift
+++ b/VirgoUITests/UITestHelpers.swift
@@ -226,6 +226,32 @@ extension XCTestCase {
         throw UITestFailure.elementNotFound(label)
     }
 
+    @discardableResult
+    func requireDifficultyButton(
+        named difficulty: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> XCUIElement {
+        let identifier = "chartDifficulty\(difficulty)"
+        let labelPredicate = NSPredicate(
+            format: "label CONTAINS[c] %@ AND (label CONTAINS[c] 'difficulty' OR label CONTAINS[c] 'Level')",
+            difficulty
+        )
+        let candidates = [
+            app.buttons[identifier],
+            app.buttons.matching(labelPredicate).firstMatch
+        ]
+
+        if let element = waitForFirstExisting(candidates, timeout: timeout) {
+            return element
+        }
+
+        XCTFail("Expected \(difficulty) difficulty button to exist", file: file, line: line)
+        throw UITestFailure.elementNotFound(difficulty)
+    }
+
     func openSongsView(
         in app: XCUIApplication,
         timeout: TimeInterval = 10,
@@ -234,12 +260,14 @@ extension XCTestCase {
     ) throws {
         dismissSetupAssistantIfPresent(timeout: 1)
 
-        if !app.staticTexts["Songs"].waitForExistence(timeout: 1) {
+        if !waitForStaticText(containing: "Songs", in: app, timeout: 1) &&
+            !app.textFields["searchField"].waitForExistence(timeout: 1) {
             try tapControl(named: "START", in: app, timeout: timeout, file: file, line: line)
         }
 
         XCTAssertTrue(
-            app.staticTexts["Songs"].waitForExistence(timeout: timeout),
+            waitForStaticText(containing: "Songs", in: app, timeout: timeout) ||
+                app.textFields["searchField"].waitForExistence(timeout: timeout),
             "Songs view should load",
             file: file,
             line: line
@@ -268,17 +296,19 @@ extension XCTestCase {
         chartButton.tap()
 
         XCTAssertTrue(
-            app.staticTexts["Select Difficulty"].waitForExistence(timeout: timeout),
+            waitForStaticText(containing: "Select Difficulty", in: app, timeout: timeout),
             "Difficulty selector should appear",
             file: file,
             line: line
         )
 
-        let difficultyElement = app.buttons["chartDifficulty\(difficulty)"]
-        guard waitForFirstExisting([difficultyElement], timeout: timeout) != nil else {
-            XCTFail("Expected \(difficulty) difficulty button to exist", file: file, line: line)
-            throw UITestFailure.elementNotFound(difficulty)
-        }
+        let difficultyElement = try requireDifficultyButton(
+            named: difficulty,
+            in: app,
+            timeout: timeout,
+            file: file,
+            line: line
+        )
         difficultyElement.tap()
 
         try requireStaticText(containing: songTitle, in: app, timeout: timeout, file: file, line: line)

--- a/VirgoUITests/UITestHelpers.swift
+++ b/VirgoUITests/UITestHelpers.swift
@@ -118,6 +118,63 @@ extension XCTestCase {
         return elements.first(where: { $0.exists })
     }
 
+    func textContainsPredicate(_ text: String) -> NSPredicate {
+        NSPredicate(
+            format: "label CONTAINS[c] %@ OR value CONTAINS[c] %@",
+            text,
+            text
+        )
+    }
+
+    @discardableResult
+    func requireStaticText(
+        containing text: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> XCUIElement {
+        let staticText = app.staticTexts.matching(textContainsPredicate(text)).firstMatch
+        if let element = waitForFirstExisting([staticText], timeout: timeout) {
+            return element
+        }
+
+        XCTFail("Expected static text containing \(text) to exist", file: file, line: line)
+        throw UITestFailure.elementNotFound(text)
+    }
+
+    func waitForStaticText(
+        containing text: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10
+    ) -> Bool {
+        app.staticTexts.matching(textContainsPredicate(text)).firstMatch.waitForExistence(timeout: timeout)
+    }
+
+    func controlIsSelected(_ element: XCUIElement) -> Bool {
+        if element.isSelected {
+            return true
+        }
+
+        if let value = element.value as? String {
+            return value == "1" || value.localizedCaseInsensitiveContains("selected")
+        }
+
+        if let value = element.value as? NSNumber {
+            return value.intValue == 1
+        }
+
+        return false
+    }
+
+    func elementText(_ element: XCUIElement) -> String {
+        if let value = element.value as? String, !value.isEmpty {
+            return value
+        }
+
+        return element.label
+    }
+
     @discardableResult
     func requireControl(
         named name: String,
@@ -205,12 +262,7 @@ extension XCTestCase {
             searchField.clearAndEnterText(songTitle)
         }
 
-        XCTAssertTrue(
-            app.staticTexts[songTitle].waitForExistence(timeout: timeout),
-            "\(songTitle) should be visible before opening gameplay",
-            file: file,
-            line: line
-        )
+        try requireStaticText(containing: songTitle, in: app, timeout: timeout, file: file, line: line)
 
         let chartButton = try requireButton(containing: "charts", in: app, timeout: timeout, file: file, line: line)
         chartButton.tap()
@@ -222,29 +274,15 @@ extension XCTestCase {
             line: line
         )
 
-        let difficultyPredicate = NSPredicate(
-            format: "label CONTAINS[c] %@ AND label CONTAINS[c] 'Level'",
-            difficulty
-        )
-        let difficultyButton = app.buttons.matching(difficultyPredicate).firstMatch
-        guard let difficultyElement = waitForFirstExisting([difficultyButton], timeout: timeout) else {
+        let difficultyElement = app.buttons["chartDifficulty\(difficulty)"]
+        guard waitForFirstExisting([difficultyElement], timeout: timeout) != nil else {
             XCTFail("Expected \(difficulty) difficulty button to exist", file: file, line: line)
             throw UITestFailure.elementNotFound(difficulty)
         }
         difficultyElement.tap()
 
-        XCTAssertTrue(
-            app.staticTexts[songTitle].waitForExistence(timeout: timeout),
-            "\(songTitle) should be visible in gameplay",
-            file: file,
-            line: line
-        )
-        XCTAssertTrue(
-            app.staticTexts[artist].waitForExistence(timeout: timeout),
-            "\(artist) should be visible in gameplay",
-            file: file,
-            line: line
-        )
+        try requireStaticText(containing: songTitle, in: app, timeout: timeout, file: file, line: line)
+        try requireStaticText(containing: artist, in: app, timeout: timeout, file: file, line: line)
         try requireControl(named: "Play", in: app, timeout: timeout, file: file, line: line)
     }
 
@@ -287,11 +325,13 @@ extension XCTestCase {
             app.buttons["Downloaded"],
             app.radioButtons["Downloaded"]
         ], timeout: timeout) else { return false }
-        
-        if !downloadedTab.isSelected {
+
+        if !controlIsSelected(downloadedTab) {
             downloadedTab.tap()
         }
-        return downloadedTab.isSelected
+
+        return waitForStaticText(containing: "songs available", in: app, timeout: timeout) ||
+            waitForStaticText(containing: "No Downloaded Songs", in: app, timeout: timeout)
     }
     
     /// Switch to Server sub-tab in Songs tab
@@ -300,37 +340,47 @@ extension XCTestCase {
             app.buttons["Server"],
             app.radioButtons["Server"]
         ], timeout: timeout) else { return false }
-        
-        if !serverTab.isSelected {
+
+        if !controlIsSelected(serverTab) {
             serverTab.tap()
         }
-        return serverTab.isSelected
+
+        return app.buttons["refreshServerSongsButton"].waitForExistence(timeout: timeout) ||
+            app.buttons["Refresh server songs"].waitForExistence(timeout: timeout)
     }
     
     /// Check if there are any downloaded songs available
     func hasDownloadedSongs(app: XCUIApplication, timeout: TimeInterval = 5) -> Bool {
-        let songCount = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'songs available'")).firstMatch
+        let songCount = app.staticTexts.matching(textContainsPredicate("songs available")).firstMatch
         guard songCount.waitForExistence(timeout: timeout) else { return false }
         
-        let countText = songCount.label
+        let countText = elementText(songCount)
         return !countText.hasPrefix("0 ")
     }
     
     /// Verify Songs tab empty state for Downloaded tab
     func verifyDownloadedSongsEmptyState(app: XCUIApplication, timeout: TimeInterval = 5) -> Bool {
         let emptyIcon = app.images["arrow.down.circle"]
-        let emptyTitle = app.staticTexts["No Downloaded Songs"]
-        let emptyMessage = app.staticTexts["Download songs from the Server tab to see them here"]
-        
-        return waitForElements([emptyIcon, emptyTitle, emptyMessage], timeout: timeout)
+
+        return emptyIcon.waitForExistence(timeout: timeout) &&
+            waitForStaticText(containing: "No Downloaded Songs", in: app, timeout: timeout) &&
+            waitForStaticText(
+                containing: "Download songs from the Server tab to see them here",
+                in: app,
+                timeout: timeout
+            )
     }
     
     /// Verify Songs tab empty state for Server tab
     func verifyServerSongsEmptyState(app: XCUIApplication, timeout: TimeInterval = 5) -> Bool {
         let emptyIcon = app.images["cloud"]
-        let emptyTitle = app.staticTexts["No Server Songs"]
-        let emptyMessage = app.staticTexts["Tap the refresh button to load songs from the server"]
-        
-        return waitForElements([emptyIcon, emptyTitle, emptyMessage], timeout: timeout)
+
+        return emptyIcon.waitForExistence(timeout: timeout) &&
+            waitForStaticText(containing: "No Server Songs", in: app, timeout: timeout) &&
+            waitForStaticText(
+                containing: "Tap the refresh button to load songs from the server",
+                in: app,
+                timeout: timeout
+            )
     }
 }

--- a/VirgoUITests/UITestHelpers.swift
+++ b/VirgoUITests/UITestHelpers.swift
@@ -198,6 +198,51 @@ extension XCTestCase {
     }
 
     @discardableResult
+    func requireGameplayPlayPauseControl(
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> XCUIElement {
+        let playButton = app.buttons.matching(NSPredicate(format: "label == %@", "Play")).firstMatch
+        let pauseButton = app.buttons.matching(NSPredicate(format: "label == %@", "Pause")).firstMatch
+        let candidates = [
+            app.buttons["gameplayMainPlayPauseButton"],
+            app.buttons["gameplayHeaderPlayPauseButton"],
+            playButton,
+            pauseButton
+        ]
+
+        if let element = waitForFirstExisting(candidates, timeout: timeout) {
+            return element
+        }
+
+        XCTFail("Expected gameplay Play or Pause control to exist", file: file, line: line)
+        throw UITestFailure.elementNotFound("gameplay Play or Pause")
+    }
+
+    @discardableResult
+    func requireGameplayRestartControl(
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> XCUIElement {
+        let candidates = [
+            app.buttons["gameplayMainRestartButton"],
+            app.buttons["gameplayHeaderRestartButton"],
+            app.buttons.matching(NSPredicate(format: "label == %@", "Restart")).firstMatch
+        ]
+
+        if let element = waitForFirstExisting(candidates, timeout: timeout) {
+            return element
+        }
+
+        XCTFail("Expected gameplay Restart control to exist", file: file, line: line)
+        throw UITestFailure.elementNotFound("gameplay Restart")
+    }
+
+    @discardableResult
     func tapControl(
         named name: String,
         in app: XCUIApplication,
@@ -314,7 +359,7 @@ extension XCTestCase {
 
         try requireStaticText(containing: songTitle, in: app, timeout: timeout, file: file, line: line)
         try requireStaticText(containing: artist, in: app, timeout: timeout, file: file, line: line)
-        try requireControl(named: "Play", in: app, timeout: timeout, file: file, line: line)
+        try requireGameplayPlayPauseControl(in: app, timeout: timeout, file: file, line: line)
     }
 
     func tapBackFromGameplay(
@@ -323,7 +368,15 @@ extension XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
-        try tapControl(named: "Go back", in: app, timeout: timeout, file: file, line: line)
+        guard let backButton = waitForFirstExisting([
+            app.buttons["gameplayBackButton"],
+            app.buttons.matching(NSPredicate(format: "label == %@", "Go back")).firstMatch
+        ], timeout: timeout) else {
+            XCTFail("Expected gameplay back control to exist", file: file, line: line)
+            throw UITestFailure.elementNotFound("gameplay back")
+        }
+
+        backButton.tap()
     }
 
     /// Wait for multiple elements to exist

--- a/VirgoUITests/UITestHelpers.swift
+++ b/VirgoUITests/UITestHelpers.swift
@@ -11,6 +11,18 @@ enum UITestFailure: Error {
     case elementNotFound(String)
 }
 
+private let systemDialogButtonLabels = [
+    "Continue",
+    "Not Now",
+    "Skip",
+    "Set Up Later",
+    "Don't Share",
+    "Don’t Share",
+    "OK",
+    "Allow",
+    "Close"
+]
+
 // MARK: - Helper Extensions
 extension XCUIElement {
     func clearAndEnterText(_ text: String) {
@@ -47,6 +59,51 @@ extension XCUIElement {
 }
 
 extension XCTestCase {
+    func installSystemDialogHandlers() {
+        addUIInterruptionMonitor(withDescription: "System setup and permission dialogs") { element in
+            self.tapFirstSystemDialogButton(in: element)
+        }
+    }
+
+    @discardableResult
+    func dismissSetupAssistantIfPresent(timeout: TimeInterval = 2) -> Bool {
+        let setupAssistant = XCUIApplication(bundleIdentifier: "com.apple.SetupAssistant")
+        guard setupAssistant.state != .notRunning else { return false }
+
+        setupAssistant.activate()
+        let deadline = Date().addingTimeInterval(timeout)
+
+        repeat {
+            if tapFirstSystemDialogButton(in: setupAssistant) {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
+        return false
+    }
+
+    private func tapFirstSystemDialogButton(in root: XCUIElement) -> Bool {
+        for label in systemDialogButtonLabels {
+            let button = root.buttons[label]
+            if button.exists {
+                button.tap()
+                return true
+            }
+        }
+
+        let continueButton = root.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] %@", "Continue")
+        ).firstMatch
+        if continueButton.exists {
+            continueButton.tap()
+            return true
+        }
+
+        return false
+    }
+
     @discardableResult
     func waitForFirstExisting(_ elements: [XCUIElement], timeout: TimeInterval = 10) -> XCUIElement? {
         let deadline = Date().addingTimeInterval(timeout)
@@ -118,6 +175,8 @@ extension XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
+        dismissSetupAssistantIfPresent(timeout: 1)
+
         if !app.staticTexts["Songs"].waitForExistence(timeout: 1) {
             try tapControl(named: "START", in: app, timeout: timeout, file: file, line: line)
         }

--- a/VirgoUITests/UITestHelpers.swift
+++ b/VirgoUITests/UITestHelpers.swift
@@ -183,9 +183,10 @@ extension XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> XCUIElement {
+        let exactMatch = NSPredicate(format: "identifier == %@ OR label == %@", name, name)
         let candidates = [
-            app.buttons[name],
-            app.radioButtons[name]
+            app.buttons.matching(exactMatch).firstMatch,
+            app.radioButtons.matching(exactMatch).firstMatch
         ]
 
         if let element = waitForFirstExisting(candidates, timeout: timeout) {

--- a/VirgoUITests/UITestHelpers.swift
+++ b/VirgoUITests/UITestHelpers.swift
@@ -7,6 +7,10 @@
 
 import XCTest
 
+enum UITestFailure: Error {
+    case elementNotFound(String)
+}
+
 // MARK: - Helper Extensions
 extension XCUIElement {
     func clearAndEnterText(_ text: String) {
@@ -43,6 +47,157 @@ extension XCUIElement {
 }
 
 extension XCTestCase {
+    @discardableResult
+    func waitForFirstExisting(_ elements: [XCUIElement], timeout: TimeInterval = 10) -> XCUIElement? {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        repeat {
+            if let element = elements.first(where: { $0.exists }) {
+                return element
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        } while Date() < deadline
+
+        return elements.first(where: { $0.exists })
+    }
+
+    @discardableResult
+    func requireControl(
+        named name: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> XCUIElement {
+        let candidates = [
+            app.buttons[name],
+            app.radioButtons[name]
+        ]
+
+        if let element = waitForFirstExisting(candidates, timeout: timeout) {
+            return element
+        }
+
+        XCTFail("Expected control named \(name) to exist", file: file, line: line)
+        throw UITestFailure.elementNotFound(name)
+    }
+
+    @discardableResult
+    func tapControl(
+        named name: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> XCUIElement {
+        let element = try requireControl(named: name, in: app, timeout: timeout, file: file, line: line)
+        element.tap()
+        return element
+    }
+
+    @discardableResult
+    func requireButton(
+        containing label: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> XCUIElement {
+        let button = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", label)).firstMatch
+        if let element = waitForFirstExisting([button], timeout: timeout) {
+            return element
+        }
+
+        XCTFail("Expected button containing \(label) to exist", file: file, line: line)
+        throw UITestFailure.elementNotFound(label)
+    }
+
+    func openSongsView(
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        if !app.staticTexts["Songs"].waitForExistence(timeout: 1) {
+            try tapControl(named: "START", in: app, timeout: timeout, file: file, line: line)
+        }
+
+        XCTAssertTrue(
+            app.staticTexts["Songs"].waitForExistence(timeout: timeout),
+            "Songs view should load",
+            file: file,
+            line: line
+        )
+    }
+
+    func openGameplay(
+        in app: XCUIApplication,
+        songTitle: String = "Thunder Beat",
+        artist: String = "Rock Masters",
+        difficulty: String = "Easy",
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        try openSongsView(in: app, timeout: timeout, file: file, line: line)
+
+        let searchField = app.textFields["searchField"]
+        if searchField.waitForExistence(timeout: 3) {
+            searchField.clearAndEnterText(songTitle)
+        }
+
+        XCTAssertTrue(
+            app.staticTexts[songTitle].waitForExistence(timeout: timeout),
+            "\(songTitle) should be visible before opening gameplay",
+            file: file,
+            line: line
+        )
+
+        let chartButton = try requireButton(containing: "charts", in: app, timeout: timeout, file: file, line: line)
+        chartButton.tap()
+
+        XCTAssertTrue(
+            app.staticTexts["Select Difficulty"].waitForExistence(timeout: timeout),
+            "Difficulty selector should appear",
+            file: file,
+            line: line
+        )
+
+        let difficultyPredicate = NSPredicate(
+            format: "label CONTAINS[c] %@ AND label CONTAINS[c] 'Level'",
+            difficulty
+        )
+        let difficultyButton = app.buttons.matching(difficultyPredicate).firstMatch
+        guard let difficultyElement = waitForFirstExisting([difficultyButton], timeout: timeout) else {
+            XCTFail("Expected \(difficulty) difficulty button to exist", file: file, line: line)
+            throw UITestFailure.elementNotFound(difficulty)
+        }
+        difficultyElement.tap()
+
+        XCTAssertTrue(
+            app.staticTexts[songTitle].waitForExistence(timeout: timeout),
+            "\(songTitle) should be visible in gameplay",
+            file: file,
+            line: line
+        )
+        XCTAssertTrue(
+            app.staticTexts[artist].waitForExistence(timeout: timeout),
+            "\(artist) should be visible in gameplay",
+            file: file,
+            line: line
+        )
+        try requireControl(named: "Play", in: app, timeout: timeout, file: file, line: line)
+    }
+
+    func tapBackFromGameplay(
+        in app: XCUIApplication,
+        timeout: TimeInterval = 5,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        try tapControl(named: "Go back", in: app, timeout: timeout, file: file, line: line)
+    }
+
     /// Wait for multiple elements to exist
     func waitForElements(_ elements: [XCUIElement], timeout: TimeInterval = 10) -> Bool {
         let expectations = elements.map { element in
@@ -63,14 +218,16 @@ extension XCTestCase {
     
     /// Navigate to Songs tab and wait for it to load
     func navigateToSongsTab(app: XCUIApplication, timeout: TimeInterval = 10) -> Bool {
-        app.buttons["START"].tap()
+        try? openSongsView(in: app, timeout: timeout)
         return app.staticTexts["Songs"].waitForExistence(timeout: timeout)
     }
     
     /// Switch to Downloaded sub-tab in Songs tab
     func switchToDownloadedTab(app: XCUIApplication, timeout: TimeInterval = 5) -> Bool {
-        let downloadedTab = app.buttons["Downloaded"]
-        guard downloadedTab.waitForExistence(timeout: timeout) else { return false }
+        guard let downloadedTab = waitForFirstExisting([
+            app.buttons["Downloaded"],
+            app.radioButtons["Downloaded"]
+        ], timeout: timeout) else { return false }
         
         if !downloadedTab.isSelected {
             downloadedTab.tap()
@@ -80,8 +237,10 @@ extension XCTestCase {
     
     /// Switch to Server sub-tab in Songs tab
     func switchToServerTab(app: XCUIApplication, timeout: TimeInterval = 5) -> Bool {
-        let serverTab = app.buttons["Server"]
-        guard serverTab.waitForExistence(timeout: timeout) else { return false }
+        guard let serverTab = waitForFirstExisting([
+            app.buttons["Server"],
+            app.radioButtons["Server"]
+        ], timeout: timeout) else { return false }
         
         if !serverTab.isSelected {
             serverTab.tap()

--- a/VirgoUITests/VirgoUITests.swift
+++ b/VirgoUITests/VirgoUITests.swift
@@ -21,6 +21,7 @@ final class VirgoUITests: XCTestCase {
         // ContentView.isUITesting checks for this argument
         app = XCUIApplication()
         app.launchArguments.append("-UITesting")
+        app.launchArguments.append("-ResetState")
 
         // In UI tests it's important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
@@ -39,7 +40,7 @@ final class VirgoUITests: XCTestCase {
         XCTAssertTrue(app.buttons["START"].exists)
 
         // Tap start button to navigate to content view
-        app.buttons["START"].tap()
+        try tapControl(named: "START", in: app)
 
         // Wait for navigation to complete and verify we're in the songs view
         XCTAssertTrue(app.staticTexts["Songs"].waitForExistence(timeout: 10))
@@ -51,7 +52,7 @@ final class VirgoUITests: XCTestCase {
         app.launch()
 
         // Navigate to songs
-        app.buttons["START"].tap()
+        try openSongsView(in: app)
 
         // Wait for tracks to load with longer timeout
         XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
@@ -67,13 +68,13 @@ final class VirgoUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Medium"].waitForExistence(timeout: 5))
 
         // Verify at least one play button exists
-        XCTAssertTrue(app.buttons.matching(identifier: "play.circle.fill").firstMatch.waitForExistence(timeout: 5))
+        try requireControl(named: "Play", in: app, timeout: 5)
     }
 
     @MainActor
     func testSearchFunctionality() throws {
         app.launch()
-        app.buttons["START"].tap()
+        try openSongsView(in: app)
 
         // Wait for tracks to load
         XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
@@ -108,6 +109,7 @@ final class VirgoUITests: XCTestCase {
         XCTAssertTrue(thunderBeatVisible && jazzGrooveVisible, "All tracks should be visible after clearing search")
 
         // Test search by artist - search for "Smooth" which exists in Jazz Groove
+        searchField.tap()
         searchField.typeText("Smooth")
 
         // Wait for search to filter results
@@ -117,35 +119,18 @@ final class VirgoUITests: XCTestCase {
     @MainActor
     func testGameplayViewNavigation() throws {
         app.launch()
-        app.buttons["START"].tap()
-
-        // Wait for tracks to load
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
-
-        // Tap on first track to navigate to gameplay
-        app.staticTexts["Thunder Beat"].tap()
-
-        // Wait for gameplay view to load by checking for unique gameplay elements
-        let gameplayLoadedPredicate = NSPredicate(format: "exists == true")
-        let playButton = app.buttons.matching(identifier: "play.circle.fill").firstMatch
-        let backButton = app.buttons.matching(identifier: "chevron.left").firstMatch
-
-        let gameplayLoaded = expectation(for: gameplayLoadedPredicate,
-                                         evaluatedWith: playButton,
-                                         handler: nil)
-        wait(for: [gameplayLoaded], timeout: 10)
+        try openGameplay(in: app)
 
         // Verify we're in gameplay view - check for unique gameplay elements
         XCTAssertTrue(app.staticTexts["Thunder Beat"].exists) // Track title in header
         XCTAssertTrue(app.staticTexts["Rock Masters"].exists) // Artist name
 
         // Verify playback controls exist
-        XCTAssertTrue(playButton.exists)
-        XCTAssertTrue(app.buttons.matching(identifier: "backward.end.fill").firstMatch.exists)
+        try requireControl(named: "Play", in: app)
+        try requireControl(named: "Restart", in: app)
 
         // Test back navigation
-        XCTAssertTrue(backButton.waitForExistence(timeout: 5))
-        backButton.tap()
+        try tapBackFromGameplay(in: app)
 
         // Wait for navigation back to complete by checking for songs list
         XCTAssertTrue(app.staticTexts["Songs"].waitForExistence(timeout: 10))
@@ -157,30 +142,30 @@ final class VirgoUITests: XCTestCase {
     @MainActor
     func testTabNavigation() throws {
         app.launch()
-        app.buttons["START"].tap()
+        try openSongsView(in: app)
 
         // Test tab navigation
-        XCTAssertTrue(app.tabBars.buttons["Songs"].exists)
-        XCTAssertTrue(app.tabBars.buttons["Metronome"].exists)
-        XCTAssertTrue(app.tabBars.buttons["Library"].exists)
-        XCTAssertTrue(app.tabBars.buttons["Settings"].exists)
-        XCTAssertTrue(app.tabBars.buttons["Profile"].exists)
+        try requireControl(named: "Songs", in: app)
+        try requireControl(named: "Metronome", in: app)
+        try requireControl(named: "Library", in: app)
+        try requireControl(named: "Settings", in: app)
+        try requireControl(named: "Profile", in: app)
 
         // Test switching tabs
-        app.tabBars.buttons["Metronome"].tap()
+        try tapControl(named: "Metronome", in: app)
         XCTAssertTrue(app.staticTexts["Metronome"].exists)
 
-        app.tabBars.buttons["Library"].tap()
+        try tapControl(named: "Library", in: app)
         XCTAssertTrue(app.staticTexts["Downloaded Songs"].exists)
 
-        app.tabBars.buttons["Settings"].tap()
+        try tapControl(named: "Settings", in: app)
         XCTAssertTrue(app.staticTexts["Settings"].exists)
 
-        app.tabBars.buttons["Profile"].tap()
+        try tapControl(named: "Profile", in: app)
         XCTAssertTrue(app.staticTexts["Profile"].exists)
 
         // Return to songs tab
-        app.tabBars.buttons["Songs"].tap()
+        try tapControl(named: "Songs", in: app)
         XCTAssertTrue(app.staticTexts["Songs"].exists)
     }
 

--- a/VirgoUITests/VirgoUITests.swift
+++ b/VirgoUITests/VirgoUITests.swift
@@ -57,17 +57,13 @@ final class VirgoUITests: XCTestCase {
         try openSongsView(in: app)
 
         // Wait for tracks to load with longer timeout
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
+        try requireStaticText(containing: "Thunder Beat", in: app, timeout: 10)
 
         // Verify sample tracks are displayed
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].exists)
-        XCTAssertTrue(app.staticTexts["Rock Masters"].exists)
-        XCTAssertTrue(
-            app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'BPM'"))
-                .firstMatch
-                .waitForExistence(timeout: 5)
-        )
-        XCTAssertTrue(app.staticTexts["Medium"].waitForExistence(timeout: 5))
+        try requireStaticText(containing: "Thunder Beat", in: app, timeout: 5)
+        try requireStaticText(containing: "Rock Masters", in: app, timeout: 5)
+        XCTAssertTrue(waitForStaticText(containing: "BPM", in: app, timeout: 5))
+        XCTAssertTrue(waitForStaticText(containing: "Medium", in: app, timeout: 5))
 
         // Verify at least one play button exists
         try requireControl(named: "Play", in: app, timeout: 5)
@@ -79,7 +75,7 @@ final class VirgoUITests: XCTestCase {
         try openSongsView(in: app)
 
         // Wait for tracks to load
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].waitForExistence(timeout: 10))
+        try requireStaticText(containing: "Thunder Beat", in: app, timeout: 10)
 
         let searchField = app.textFields["searchField"]
         XCTAssertTrue(searchField.waitForExistence(timeout: 5))
@@ -89,8 +85,7 @@ final class VirgoUITests: XCTestCase {
         searchField.typeText("Thunder")
 
         // Wait for search results to update - Thunder Beat should still be visible
-        let thunderBeatAfterSearch = app.staticTexts["Thunder Beat"]
-        XCTAssertTrue(thunderBeatAfterSearch.waitForExistence(timeout: 5))
+        XCTAssertTrue(waitForStaticText(containing: "Thunder Beat", in: app, timeout: 5))
 
         // Clear search - try different approaches
         if app.buttons["Clear text"].exists {
@@ -106,8 +101,8 @@ final class VirgoUITests: XCTestCase {
         }
 
         // Wait for all tracks to be visible again after clearing search
-        let thunderBeatVisible = app.staticTexts["Thunder Beat"].waitForExistence(timeout: 5)
-        let jazzGrooveVisible = app.staticTexts["Jazz Groove"].waitForExistence(timeout: 5)
+        let thunderBeatVisible = waitForStaticText(containing: "Thunder Beat", in: app, timeout: 5)
+        let jazzGrooveVisible = waitForStaticText(containing: "Jazz Groove", in: app, timeout: 5)
         XCTAssertTrue(thunderBeatVisible && jazzGrooveVisible, "All tracks should be visible after clearing search")
 
         // Test search by artist - search for "Smooth" which exists in Jazz Groove
@@ -115,7 +110,7 @@ final class VirgoUITests: XCTestCase {
         searchField.typeText("Smooth")
 
         // Wait for search to filter results
-        XCTAssertTrue(app.staticTexts["Jazz Groove"].waitForExistence(timeout: 5))
+        XCTAssertTrue(waitForStaticText(containing: "Jazz Groove", in: app, timeout: 5))
     }
 
     @MainActor
@@ -124,8 +119,8 @@ final class VirgoUITests: XCTestCase {
         try openGameplay(in: app)
 
         // Verify we're in gameplay view - check for unique gameplay elements
-        XCTAssertTrue(app.staticTexts["Thunder Beat"].exists) // Track title in header
-        XCTAssertTrue(app.staticTexts["Rock Masters"].exists) // Artist name
+        try requireStaticText(containing: "Thunder Beat", in: app)
+        try requireStaticText(containing: "Rock Masters", in: app)
 
         // Verify playback controls exist
         try requireControl(named: "Play", in: app)

--- a/VirgoUITests/VirgoUITests.swift
+++ b/VirgoUITests/VirgoUITests.swift
@@ -16,6 +16,8 @@ final class VirgoUITests: XCTestCase {
 
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
+        installSystemDialogHandlers()
+        dismissSetupAssistantIfPresent()
 
         // Add custom launch argument to distinguish UI tests from unit tests
         // ContentView.isUITesting checks for this argument

--- a/VirgoUITests/VirgoUITests.swift
+++ b/VirgoUITests/VirgoUITests.swift
@@ -35,6 +35,7 @@ final class VirgoUITests: XCTestCase {
     @MainActor
     func testMainMenuNavigation() throws {
         app.launch()
+        dismissSetupAssistantIfPresent(returningTo: app)
 
         // Verify main menu elements are present
         XCTAssertTrue(app.staticTexts["VIRGO"].waitForExistence(timeout: 10))
@@ -52,6 +53,7 @@ final class VirgoUITests: XCTestCase {
     @MainActor
     func testDrumTracksListDisplay() throws {
         app.launch()
+        dismissSetupAssistantIfPresent(returningTo: app)
 
         // Navigate to songs
         try openSongsView(in: app)
@@ -72,6 +74,7 @@ final class VirgoUITests: XCTestCase {
     @MainActor
     func testSearchFunctionality() throws {
         app.launch()
+        dismissSetupAssistantIfPresent(returningTo: app)
         try openSongsView(in: app)
 
         // Wait for tracks to load
@@ -116,6 +119,7 @@ final class VirgoUITests: XCTestCase {
     @MainActor
     func testGameplayViewNavigation() throws {
         app.launch()
+        dismissSetupAssistantIfPresent(returningTo: app)
         try openGameplay(in: app)
 
         // Verify we're in gameplay view - check for unique gameplay elements
@@ -139,6 +143,7 @@ final class VirgoUITests: XCTestCase {
     @MainActor
     func testTabNavigation() throws {
         app.launch()
+        dismissSetupAssistantIfPresent(returningTo: app)
         try openSongsView(in: app)
 
         // Test tab navigation

--- a/VirgoUITests/VirgoUITests.swift
+++ b/VirgoUITests/VirgoUITests.swift
@@ -123,8 +123,8 @@ final class VirgoUITests: XCTestCase {
         try requireStaticText(containing: "Rock Masters", in: app)
 
         // Verify playback controls exist
-        try requireControl(named: "Play", in: app)
-        try requireControl(named: "Restart", in: app)
+        try requireGameplayPlayPauseControl(in: app)
+        try requireGameplayRestartControl(in: app)
 
         // Test back navigation
         try tapBackFromGameplay(in: app)

--- a/VirgoUITests/VirgoUITestsLaunchTests.swift
+++ b/VirgoUITests/VirgoUITestsLaunchTests.swift
@@ -29,7 +29,7 @@ final class VirgoUITestsLaunchTests: XCTestCase {
     @MainActor
     func testLaunch() throws {
         app.launch()
-        dismissSetupAssistantIfPresent()
+        dismissSetupAssistantIfPresent(returningTo: app)
 
         // Wait for app to fully launch
         XCTAssertTrue(app.staticTexts["VIRGO"].waitForExistence(timeout: 10))

--- a/VirgoUITests/VirgoUITestsLaunchTests.swift
+++ b/VirgoUITests/VirgoUITestsLaunchTests.swift
@@ -17,6 +17,8 @@ final class VirgoUITestsLaunchTests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
+        installSystemDialogHandlers()
+        dismissSetupAssistantIfPresent()
 
         // Add custom launch argument to distinguish UI tests from unit tests
         // ContentView.isUITesting checks for this argument
@@ -27,6 +29,7 @@ final class VirgoUITestsLaunchTests: XCTestCase {
     @MainActor
     func testLaunch() throws {
         app.launch()
+        dismissSetupAssistantIfPresent()
 
         // Wait for app to fully launch
         XCTAssertTrue(app.staticTexts["VIRGO"].waitForExistence(timeout: 10))


### PR DESCRIPTION
## Summary

Fix the macOS UI test failures from the GitHub Actions run by aligning the tests with the accessibility tree exposed by SwiftUI on macOS.

## Root cause

The failing tests were still using iOS-style expectations in several places:

- segmented controls and tabs are exposed as radio buttons on macOS, not normal buttons
- playback controls expose labels such as `Play`, `Pause`, and `Restart`, not SF Symbol identifiers like `play.circle.fill`
- the gameplay flow now requires expanding a song row and selecting a difficulty card before navigation
- the workflow wrote the result bundle directly to `./ui-test-results`, while later artifact handling expected a `.xcresult` child

## Changes

- Added shared UI-test helpers for role-tolerant control lookup and gameplay navigation.
- Updated gameplay, song tab, server song, and main navigation UI tests to follow the current macOS UI flow.
- Added stable accessibility labels/identifiers for chart difficulty cards and the server refresh control.
- Updated the UI test workflow result bundle path to `./ui-test-results/ui-tests.xcresult`.

## Validation

- `xcodebuild build-for-testing -project Virgo.xcodeproj -scheme Virgo -destination 'platform=macOS' -configuration Debug ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -derivedDataPath /private/tmp/virgo-deriveddata-20260523-2`
- `swiftlint lint --no-cache` completed with existing warnings only: 135 violations, 0 serious
- `git diff --check`

Full local UI execution could not complete because the local Mac was at the lock screen; the PR workflow is the remaining end-to-end UI-test validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved accessibility metadata across gameplay, song rows, difficulty badges, and bookmark controls for better assistive-tech support.

* **Tests**
  * Refactored and consolidated UI tests with shared helpers, robust setup/teardown, and more reliable element synchronization.

* **Chores**
  * CI UI-test workflow updated for more reliable simulator runs; added a gitignore rule to ignore a local tools directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cwchanap/Virgo/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->